### PR TITLE
Correct MariaDB Client Package Name

### DIFF
--- a/packer/scripts/irida-web.sh
+++ b/packer/scripts/irida-web.sh
@@ -9,7 +9,7 @@ wait_for_tomcat() {
 
 # install java and apr
 yum -y install epel-release
-yum -y install apr tomcat java-1.8.0-openjdk-headless mariadb-server mariadb-client tomcat-native
+yum -y install apr tomcat java-1.8.0-openjdk-headless mariadb-server mariadb tomcat-native
 
 mkdir -p /home/irida/data/{sequencing,reference,analysis,snapshot}
 mkdir -p /etc/irida/analytics


### PR DESCRIPTION
The mariadb client package on EPEL is named 'mariadb'