### PR TITLE
Apetkau/doc tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ cache:
   directories:
     - $HOME/.m2
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install jekyll
+
 install:
   - mysql -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD'; GRANT ALL ON $MYSQL_DATABASE.* to '$MYSQL_USER'@'localhost';"
   - mvn -version

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,17 @@ addons:
 jdk:
   - openjdk8
 
+rvm:
+  - 2.4.1
+
 cache:
   directories:
     - $HOME/.m2
-
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install jekyll
 
 install:
   - mysql -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD'; GRANT ALL ON $MYSQL_DATABASE.* to '$MYSQL_USER'@'localhost';"
   - mvn -version
   - pushd lib; ./install-libs.sh; popd
+  - gem install jekyll
 
 script: ./run-tests.sh $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - mysql -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD'; GRANT ALL ON $MYSQL_DATABASE.* to '$MYSQL_USER'@'localhost';"
   - mvn -version
   - pushd lib; ./install-libs.sh; popd
-  - gem install jekyll pygments
+  - gem install jekyll
+  - gem install pygments
 
 script: ./run-tests.sh $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - "TEST_SUITE=rest_testing"
     - "TEST_SUITE=galaxy_testing"
     - "TEST_SUITE=ui_testing"
+    - "TEST_SUITE=doc_testing"
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,6 @@ install:
   - mvn -version
   - pushd lib; ./install-libs.sh; popd
   - gem install jekyll
-  - gem install pygments
+  - gem install pygments.rb
 
 script: ./run-tests.sh $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,6 @@ install:
   - mysql -e "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD'; GRANT ALL ON $MYSQL_DATABASE.* to '$MYSQL_USER'@'localhost';"
   - mvn -version
   - pushd lib; ./install-libs.sh; popd
-  - gem install jekyll
+  - gem install jekyll pygments
 
 script: ./run-tests.sh $TEST_SUITE

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
     - "MYSQL_USER=test"
     - "MYSQL_PASSWORD=test"
   matrix:
-    - "TEST_SUITE=service_testing"
-    - "TEST_SUITE=rest_testing"
     - "TEST_SUITE=galaxy_testing"
     - "TEST_SUITE=ui_testing"
     - "TEST_SUITE=doc_testing"
+    - "TEST_SUITE=service_testing"
+    - "TEST_SUITE=rest_testing"
 
 services:
   - docker

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -118,7 +118,7 @@ test_galaxy() {
 }
 
 test_doc() {
-	mvn clean site
+	mvn clean site $@
 	exit_code=$?
 	return $exit_code
 }

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -117,8 +117,14 @@ test_galaxy() {
 	return $exit_code
 }
 
+test_doc() {
+	mvn clean site
+	exit_code=$?
+	return $exit_code
+}
+
 test_all() {
-	for test_profile in test_rest test_service test_galaxy test_ui;
+	for test_profile in test_rest test_service test_galaxy test_ui test_doc;
 	do
 		tmp_dir_cleanup
 		eval $test_profile
@@ -144,7 +150,7 @@ then
 	echo -e "\t-c|--no-cleanup: Do not cleanup previous test database before execution."
 	echo -e "\t--no-kill-docker: Do not kill Galaxy Docker after Galaxy tests have run."
 	echo -e "\t--no-headless: Do not run chrome in headless mode (for viewing results of UI tests)."
-	echo -e "\ttest_type:     One of the IRIDA test types {service_testing, ui_testing, rest_testing, galaxy_testing, all}."
+	echo -e "\ttest_type:     One of the IRIDA test types {service_testing, ui_testing, rest_testing, galaxy_testing, doc_testing, all}."
 	echo -e "\t[Maven options]: Additional options to pass to 'mvn'.  In particular, can pass '-Dit.test=ca.corefacility.bioinformatics.irida.fully.qualified.name' to run tests from a particular class.\n"
 	echo -e "Examples:\n"
 	echo -e "$0 service_testing\n"
@@ -219,6 +225,13 @@ case "$1" in
 		exit_code=$?
 		posttest_cleanup
 	;;
+	doc_testing)
+		shift
+		#pretest_cleanup
+		test_doc $@
+		exit_code=$?
+		posttest_cleanup
+	;;
 	all)
 		shift
 		pretest_cleanup
@@ -227,7 +240,7 @@ case "$1" in
 		posttest_cleanup
 	;;
 	*)
-		exit_error "Unrecogized test [$1]"
+		exit_error "Unrecogized command [$1]"
 	;;
 esac
 


### PR DESCRIPTION
Adds strict Javadoc documentation enforcement as part of the travis tests.  Specifically documentation will be required for all classes/methods in `/src/main/java` with the following caveats:

* Only required for `public` and `protected` methods.
* Not required for basic "getter" and "setter" methods.
* Not required for `@Override` methods as it assumes the parent is documented.  Overridden methods should still be commented if they do something different than the parent method.
* Not required (but highly encouraged) for constructors.

Related to https://irida.corefacility.ca/irida/irida/merge_requests/1218

@dfornika this may affect some of your code.  After this is merged in please merge into your branch and verify that the doc tests run successfully.