### PR TITLE
Make carousel controls transparent on login page

### DIFF
--- a/src/main/webapp/pages/login.html
+++ b/src/main/webapp/pages/login.html
@@ -9,6 +9,15 @@
 			margin-top: 10px;
 			display: block;
 		}
+		.carousel-control {
+            opacity: 0;
+        }
+        .carousel-control:hover, .carousel-control:focus {
+            opacity: 0;
+        }
+        .carousel-indicators li {
+            visibility: hidden;
+        }
 	</style>
 </head>
 <body>


### PR DESCRIPTION
Minor aesthetic change, makes the sides of the logo banner carousel on the login page transparent instead of a grey gradient. Also hides the white dots that overlap some logos.