### PR TITLE
Blank out processing state after project sync

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -343,6 +343,9 @@ public class ProjectSynchronizationService {
 		try {
 			file = singleEndRemoteService.mirrorSequencingObject(file);
 
+			file.setProcessingState(SequencingObject.ProcessingState.UNPROCESSED);
+			file.setFileProcessor(null);
+
 			file.getSequenceFile().setId(null);
 			file.getSequenceFile().getRemoteStatus().setSyncStatus(SyncStatus.SYNCHRONIZED);
 
@@ -371,6 +374,9 @@ public class ProjectSynchronizationService {
 		pair.getRemoteStatus().setSyncStatus(SyncStatus.UPDATING);
 		try {
 			pair = pairRemoteService.mirrorSequencingObject(pair);
+
+			pair.setProcessingState(SequencingObject.ProcessingState.UNPROCESSED);
+			pair.setFileProcessor(null);
 
 			pair.getFiles().forEach(s -> {
 				s.setId(null);


### PR DESCRIPTION
I encountered an issue when synchronizing remote projects where FastQC analysis was not being run.  The issue is that when synchronizing the sequencing object, the `processing_state` value of `FINISHED` is also copied over, so file processing is not run.

That is, if file processing was run on **irida-web-development**, and then I sychronize to my local machine, I get the following in the database:

```
+----+---------------------+---------------+------------------+---------------------------------------------+
| id | created_date        | remote_status | processing_state | file_processor                              |
+----+---------------------+---------------+------------------+---------------------------------------------+
|  3 | 2018-06-29 13:36:05 |            14 | FINISHED         | 11815@irida-web-development.corefacility.ca |
+----+---------------------+---------------+------------------+---------------------------------------------+
```

Since the state is `FINISHED`, nothing gets run on my local machine (so no FastQC results).

This merge fixes this issue by blanking both the `processing_state` and `file_processor` before saving the sequencing object.  So, in our database it will start from the state `UNPROCESSED` and then get picked up, as seen from our audit tables:

```
+----+---------------------+---------------+------------------+----------------+
| id | created_date        | remote_status | processing_state | file_processor |
+----+---------------------+---------------+------------------+----------------+
|  5 | 2018-06-29 13:48:16 |            23 | UNPROCESSED      | NULL           |
|  5 | 2018-06-29 13:48:16 |            23 | PROCESSING       | 20723@jupiter  |
|  5 | 2018-06-29 13:48:16 |            23 | FINISHED         | 20723@jupiter  |
+----+---------------------+---------------+------------------+----------------+
```

I'm sending over GitHub as this is the final issue before release and I wanted your opinion @tom114 (or possibly @peterk87).