### PR TITLE
Move all updates to one entry in XML

### DIFF
--- a/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/0.23.0/fastqc-version.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/0.23.0/fastqc-version.xml
@@ -6,12 +6,9 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
     <changeSet id="file-processing-state" author="tom">
         <addColumn tableName="analysis_fastqc">
-            <column name="fastqcVersion" type="varchar(255)"/>
+            <column name="fastqcVersion" type="varchar(255)" value="0.10.1">
+                <constraints nullable="false" />
+            </column>
         </addColumn>
-
-        <sql>UPDATE analysis_fastqc SET fastqcVersion="0.10.1"</sql>
-
-        <addNotNullConstraint tableName="analysis_fastqc" columnName="fastqcVersion" columnDataType="varchar(255)"/>
-
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
An attempt to fix #207 by condensing some of the sql commands to one entry.

I think the only improvement that gets made is by moving the **not null** constraint to the code to add the column.

Before, the SQL that gets generated is:

```sql
ALTER TABLE irida_prod_test.analysis_fastqc ADD fastqcVersion VARCHAR(255) NULL;

UPDATE analysis_fastqc SET fastqcVersion="0.10.1";

ALTER TABLE irida_prod_test.analysis_fastqc MODIFY fastqcVersion VARCHAR(255) NOT NULL;
```

This was taking me up to **1.5 hours** to run on our main IRIDA database.

After applying these changes, the SQL that gets generated is:

```sql
ALTER TABLE irida_prod_test.analysis_fastqc ADD fastqcVersion VARCHAR(255) NOT NULL;

UPDATE irida_prod_test.analysis_fastqc SET fastqcVersion = '0.10.1';
```

This takes about **40 mins** for me to run, since we only run one `ALTER TABLE` command.

I don't think this can be improved any further. The problem is that, running `ALTER TABLE` must re-write the entire table to make the changes. Since this is the fastqc table, in contains something like 170,000 entries, each of which store large images. So, re-writing all this data takes a while. See https://stackoverflow.com/questions/7599519/alter-table-add-column-takes-a-long-time