### PR TITLE
Fixes issue where selecting all samples after filtering selected all samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Changes
 * [Administration]: Updated method for automatically installing tools in Galaxy to use [Ephemeris](https://ephemeris.readthedocs.io/en/latest/readme.html).
 * [Developer]: Updated to version 20.0.0 of ag-grid UI component.
 * [UI]: Add link back to sample for analysis input files on the Analsysis Details Page.
+* [UI]: Fixes issue where attempting to select all samples with a filter applied selected all samples in project.
 
 0.21.0 to 0.22.0
 ----------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
@@ -31,6 +31,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
+
 import ca.corefacility.bioinformatics.irida.exceptions.EntityExistsException;
 import ca.corefacility.bioinformatics.irida.exceptions.EntityNotFoundException;
 import ca.corefacility.bioinformatics.irida.exceptions.SequenceFileAnalysisException;
@@ -54,9 +57,6 @@ import ca.corefacility.bioinformatics.irida.ria.web.models.datatables.DTProjectS
 import ca.corefacility.bioinformatics.irida.service.ProjectService;
 import ca.corefacility.bioinformatics.irida.service.SequencingObjectService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
-
-import com.google.common.base.Strings;
-import com.google.common.collect.Lists;
 
 /**
  * Controller for handling interactions with samples in a project
@@ -497,6 +497,7 @@ public class ProjectSamplesController {
 	 * Get a list of all {@link Sample} ids in a {@link Project}
 	 *
 	 * @param projectId            Identifier for the current project
+	 * @param params               {@link DataTablesParams}
 	 * @param sampleNames          {@link List} of sample names that the {@link Project} {@link Sample}s is currently filtered by.
 	 * @param associatedProjectIds {@link List} of associated {@link Project} identifiers
 	 * @param search               The global filter for the table
@@ -506,6 +507,7 @@ public class ProjectSamplesController {
 	@RequestMapping(value = "/projects/{projectId}/ajax/sampleIds", method = RequestMethod.POST)
 	@ResponseBody
 	public Map<String, List<String>> getAllProjectSampleIds(@PathVariable Long projectId,
+			@DataTablesRequest DataTablesParams params,
 			@RequestParam(required = false, defaultValue = "", value = "sampleNames[]") List<String> sampleNames,
 			@RequestParam(value = "associated[]", required = false, defaultValue = "") List<Long> associatedProjectIds,
 			@RequestParam(required = false, defaultValue = "") String search, UISampleFilter filter) {
@@ -518,8 +520,8 @@ public class ProjectSamplesController {
 
 		Sort sort = new Sort(Direction.ASC, "id");
 		final Page<ProjectSampleJoin> page = sampleService.getFilteredSamplesForProjects(projects, sampleNames,
-				filter.getName(), search, filter.getOrganism(), filter.getStartDate(), filter.getEndDate(), 0,
-				Integer.MAX_VALUE, sort);
+				filter.getName(), params.getSearchValue(), filter.getOrganism(), filter.getStartDate(),
+				filter.getEndDate(), 0, Integer.MAX_VALUE, params.getSort());
 
 		// Converting everything to a string for consumption by the UI.
 		Map<String, List<String>> result = new HashMap<>();

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -1,18 +1,18 @@
 package ca.corefacility.bioinformatics.irida.ria.integration.projects;
 
+import static org.junit.Assert.*;
+
 import java.util.List;
 
 import org.junit.Test;
-
-import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
-import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
-import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectSamplesPage;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import static org.junit.Assert.*;
+import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectSamplesPage;
 
 /**
  * <p>
@@ -315,7 +315,11 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 		page.filterByName("5");
 		assertEquals("Should have 17 projects displayed", "Showing 1 to 10 of 17 entries", page.getTableInfo());
 		page.filterByName("52");
-		assertEquals("Should have 17 projects displayed", "Showing 1 to 3 of 3 entries", page.getTableInfo());
+		assertEquals("Should have 3 projects displayed", "Showing 1 to 3 of 3 entries", page.getTableInfo());
+
+		// Make sure that when the filter is applied, only the correct number of samples are selected.
+		page.selectAllSamples();
+		assertEquals("Should only have 3 samples selected", "3 samples selected", page.getSelectedInfoText());
 
 		// Test clearing the filters
 		page.clearFilter();
@@ -336,6 +340,10 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 		ProjectSamplesPage page = ProjectSamplesPage.gotToPage(driver(), 1);
 		page.filterByDateRange("07/06/2015", "07/09/2015");
 		assertEquals("Should ignore case when filtering", "Showing 1 to 4 of 4 entries", page.getTableInfo());
+
+		// Make sure that when the filter is applied, only the correct number of samples are selected.
+		page.selectAllSamples();
+		assertEquals("Should only have 4 samples selected after filter", "4 samples selected", page.getSelectedInfoText());
 
 		// Test clearing the filters
 		page.clearFilter();
@@ -374,12 +382,16 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 		LoginPage.loginAsManager(driver());
 		ProjectSamplesPage page = ProjectSamplesPage.gotToPage(driver(), 1);
 
-		// Select some samples
-		page.selectSample(0);
-		page.selectSample(1);
+		page.filterByDateRange("07/06/2015", "07/09/2015");
+		assertEquals("Should ignore case when filtering", "Showing 1 to 4 of 4 entries", page.getTableInfo());
+
+		// Make sure that when the filter is applied, only the correct number of samples are selected.
+		page.selectAllSamples();
+		assertEquals("Should only have 4 samples selected after filter", "4 samples selected", page.getSelectedInfoText());
 
 		// Open the linker modal
-		assertEquals("Should display the correct linker command", "ngsArchiveLinker.pl -p 1 -s 21 -s 20",
+		assertEquals("Should display the correct linker command", "ngsArchiveLinker.pl -p 1 -s 9 -s 8 -s 7 -s 6",
 				page.getLinkerText());
+
 	}
 }


### PR DESCRIPTION
## Description of changes
Fixes issue where if a user applied a filter to the Project > Samples page and then attempted to select all filtered samples, all samples in the project were selected.  Now only the filtered ones are selected.

## Related issue
Fixes #30 
Fixes #100 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [X] Tests added (or description of how to test) for any new features.
* [X] ~~User documentation updated for UI or technical changes.~~ N/A
