### PR TITLE
Fixed console warnings from upgrade to ag-grid v20

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/components/agGrid/AgGridColumn.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/components/agGrid/AgGridColumn.java
@@ -60,12 +60,12 @@ public class AgGridColumn {
 	/**
 	 * Suppress the filter on this column
 	 */
-	private boolean suppressFilter;
+	private boolean filter;
 
 	/**
 	 * Suppress the ability to resize this column
 	 */
-	private boolean suppressResize;
+	private boolean resizable;
 
 	/**
 	 * Set to 'asc' or 'desc' to sort by this column by default.
@@ -90,6 +90,8 @@ public class AgGridColumn {
 		this.type = type;
 		this.hide = hide;
 		this.editable = editable;
+		// Default to be resizable unless explicitly set.
+		this.resizable = true;
 	}
 
 	public String getField() {
@@ -164,19 +166,19 @@ public class AgGridColumn {
 		this.headerCheckboxSelection = headerCheckboxSelection;
 	}
 
-	public boolean isSuppressFilter() {
-		return suppressFilter;
+	public boolean isFilter() {
+		return filter;
 	}
 
-	public void setSuppressFilter(boolean suppressFilter) {
-		this.suppressFilter = suppressFilter;
+	public void setFilter(boolean filter) {
+		this.filter = filter;
 	}
 
-	public boolean isSuppressResize() {
-		return suppressResize;
+	public boolean isResizable() {
+		return resizable;
 	}
 
-	public void setSuppressResize(boolean suppressResize) {
-		this.suppressResize = suppressResize;
+	public void setResizable(boolean resizable) {
+		this.resizable = resizable;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
@@ -351,8 +351,8 @@ public class LineListController {
 		iconField.setLockPosition(true);
 		iconField.setCheckboxSelection(true);
 		iconField.setHeaderCheckboxSelection(true);
-		iconField.setSuppressFilter(true);
-		iconField.setSuppressResize(true);
+		iconField.setFilter(false);
+		iconField.setResizable(false);
 		fields.add(0, iconField);
 
 		return fields;

--- a/src/main/webapp/resources/js/pages/projects/linelist/components/Table/Table.jsx
+++ b/src/main/webapp/resources/js/pages/projects/linelist/components/Table/Table.jsx
@@ -431,23 +431,21 @@ export class Table extends React.Component {
         <AgGridReact
           id="linelist-grid"
           rowSelection="multiple"
-          enableFilter={true}
           onFilterChanged={this.setFilterCount}
-          enableSorting={true}
-          enableColResize={true}
           localeText={i18n.linelist.agGrid}
           columnDefs={this.props.fields.toJS()}
           rowData={rowData}
           frameworkComponents={this.frameworkComponents}
           loadingOverlayComponent="LoadingOverlay"
-          animateRows={true}
           onGridReady={this.onGridReady}
           onDragStopped={this.onColumnDropped}
           rowDeselection={true}
           suppressRowClickSelection={true}
           onSelectionChanged={this.onSelectionChange}
           defaultColDef={{
-            headerCheckboxSelectionFilteredOnly: true
+            headerCheckboxSelectionFilteredOnly: true,
+            sortable: true,
+            filter: true
           }}
           enableCellChangeFlash={true}
           onCellEditingStarted={this.onCellEditingStarted}


### PR DESCRIPTION
## Description of changes
Fixed changes is column definition properties changed in v20 of ag-grid.  These were just warning and were not actually breaking anything.  This is just cleanup.

## Related issue
N/A

## Checklist
N/A
