### PR TITLE
Added the calver info to the getting started guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes
 
 19.01 to 19.04
 ---------------
+* Added the CalVer updates to the documentation getting started guide.
 
 0.22.0 to 19.01
 ----------------

--- a/doc/developer/getting-started/index.md
+++ b/doc/developer/getting-started/index.md
@@ -429,10 +429,12 @@ IRIDA's branch structure is loosely based on the [GitFlow](http://nvie.com/posts
 #### Release tags & versioning scheme
 {:.no_toc}
 
+IRIDA uses a [CalVer](https://calver.org/) style versioning scheme.  This means the release version number is based on the year and month that it was released.  The scheme used is `YY.0M.minor`.  First segment is last 2 digits of the year, 2nd is 2 digit month, and 3rd is the number of bugfix release (optional).  For example a major release in January 2019 would be `19.01`.  If a bugfix release was performed for that version, it would be `19.01.1`.
+
 Whenever code is merged into *master*, a release should be created.  To mark the release the person merging the code should create a git tag at the point of the merge.
 
 ```bash
-git tag 0.version.subversion
+git tag YY.MM.minor
 ```
 
 Don't forget to push the tag when you're finished.


### PR DESCRIPTION
## Description of changes
Added the CalVer dates to the documentation contributing guide.

This should be tested by running jekyll to generate the documentation (https://irida.corefacility.ca/documentation/developer/getting-started/#building-irida-documentation) and verifying the new section renders properly (should be at http://localhost:4000/developer/getting-started/#release-tags--versioning-scheme).

## Related issue
Fixes #270 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
