### PR TITLE
Ngs linker description update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+19.04 to 19.06
+---------------
+* Added note with link to NGS Linker installation documentation to Command-line Linker modal
+
 19.01 to 19.04
 ---------------
 * Added the CalVer updates to the documentation getting started guide.

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -776,6 +776,7 @@ project.export.warning.nofiles=Warning: Sample {0} has no files.  It cannot be s
 # ========================================================================================== #
 ngs.linker.title=Command-line Linker
 ngs.linker.details=In your terminal, go to the folder you want to contain the sample links.  Copy and paste the following command.
+ngs.linker.note=<b>Note:</b> If the Command-line Linker is not installed on your system, see the installation documentation on the <a href="https://github.com/phac-nml/irida-linker" target="_blank">NGS Linker GitHub Page</a>
 
 # ========================================================================================== #
 # Project Samples - Table                                                                    #

--- a/src/main/webapp/pages/projects/templates/linker-modal.tmpl.html
+++ b/src/main/webapp/pages/projects/templates/linker-modal.tmpl.html
@@ -9,6 +9,7 @@
         </div>
         <div class="modal-body">
             <p th:text="#{ngs.linker.details}"></p>
+            <p th:utext="#{ngs.linker.note}"></p>
             <div class="form-group linker-form js-linker-form">
                 <div class="input-group">
                     <input class="form-control js-cmd-text t-cmd-text" type="text" th:value="${command}"/>


### PR DESCRIPTION
## Description of changes
Added a note with link to NGS Linker installation on the Command-line Linker modal.

To test this, visit a Project page then click the Export drop-down, and select Command-line Linker. Verify that the Note appears in the modal. If the Command-line Linker is not installed on your system then you will need to follow the instructions at [https://github.com/phac-nml/irida-linker](https://github.com/phac-nml/irida-linker) to install

## Related issue
Fixes #83 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
