### PR TITLE
Updated lodash to version 4.17.11 to fix security issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 Changes
 =======
 
-19.04 to 19.06
----------------
-* Added note with link to NGS Linker installation documentation to Command-line Linker modal
-
 19.01 to 19.04
 ---------------
-* Added the CalVer updates to the documentation getting started guide.
+* [Documentation]: Added the CalVer updates to the documentation getting started guide.
+* [Documentation]: Added note with link to NGS Linker installation documentation to Command-line Linker modal
+* [UI/Developer]: Updated to lodash v4.17.11 to fix security issue.
 
 0.22.0 to 19.01
 ----------------

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -50,7 +50,7 @@
     "jquery": "^3.2.1",
     "jquery-validation": "^1.17.0",
     "jszip": "^3.1.3",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "moment": "^2.18.1",
     "ng-file-upload": "^12.2.12",
     "noty": "^3.2.0-beta",

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -5139,12 +5139,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
-lodash@^4.0.0, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
+lodash@4.17.11, lodash@^4.0.0, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
## Description of changes
Updated package.json to use lodash version 4.17.11 to fix security vulnerability.

## Related issue
Fixes #275 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
