### PR TITLE
Updated to latest lodash to 4.17.11 fix security issue caused by 4.17.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+19.01 to 19.04
+--------------
+* [UI/Developer]: Updated to lodash v4.17.11 to fix security issue. (19.01.1)
+
 0.22.0 to 19.01
 ----------------
 * [Admin]: Updated versioning to a [CalVer](https://calver.org/) scheme of YY.0M.MICRO.  New feature releases will have the appropriate the year and month fields, where bugfixes will increment the MICRO field.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>19.01</version>
+	<version>19.01.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -50,7 +50,7 @@
     "jquery": "^3.2.1",
     "jquery-validation": "^1.17.0",
     "jszip": "^3.1.3",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "moment": "^2.18.1",
     "ng-file-upload": "^12.2.12",
     "noty": "^3.2.0-beta",

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -5139,12 +5139,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.10:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
-  integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
-
-lodash@^4.0.0, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
+lodash@4.17.11, lodash@^4.0.0, lodash@^4.16.5, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
Signed-off-by: Josh Adam <josh.adam@canada.ca>

## Description of changes
This fixes security issue cause by lodash 4.17.10.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
