### PR TITLE
Hotfix 313 import headers with period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes
 --------------
 * [UI/Developer]: Updated to lodash v4.17.11 to fix security issue. (19.01.1)
 * [Admin]: Added message to add `irida.db.profile` param for Tomcat in docs and upgrading guide.
+* [UI]: Fixed bug where uploading a metadata file with a `.` in the header row would cause an error. (19.03.1)
 
 0.22.0 to 19.01
 ----------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>19.01.1</version>
+	<version>19.03.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/resources/js/utilities/datatables.utilities.js
+++ b/src/main/webapp/resources/js/utilities/datatables.utilities.js
@@ -26,7 +26,7 @@ export const domButtonsScroller = `
  */
 export const formatBasicHeaders = headers => {
   return headers.map(title => {
-    return { title, data: title };
+    return { title, data: title.replace(".", "\\.") };
   });
 };
 


### PR DESCRIPTION
## Description of changes
Fixes #313 Where importing a metadata excel file with a `.` in the header would cause datatables to error.

## Related issue
None.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
