### PR TITLE
Seperate out vendor bundle to reduce individual bundle sizes.

### DIFF
--- a/src/main/webapp/pages/password/password_reset.html
+++ b/src/main/webapp/pages/password/password_reset.html
@@ -30,6 +30,7 @@
     </div>
 <th:block layout:fragment="scripts">
     <script th:src="@{/resources/dist/js/vendor.bundle.js}"></script>
+    <script th:src="@{/resources/dist/js/vendors.bundle.js}"></script>
     <script th:src="@{/resources/dist/js/users-password.bundle.js}"></script>
 </th:block>
 </main>

--- a/src/main/webapp/pages/template/page.html
+++ b/src/main/webapp/pages/template/page.html
@@ -4,6 +4,7 @@
 	  data-layout-decorate="~{template/base}">
 <head>
 	<link rel="stylesheet" th:href="@{/resources/dist/css/app.bundle.css}">
+	<link rel="stylesheet" th:href="@{/resources/dist/css/vendors.bundle.css}">
 	<style>
 		.ng-cloak {
 			display: none !important;
@@ -145,6 +146,7 @@
 	</script>
 
 	<script th:src="@{/resources/dist/js/vendor.bundle.js}"></script>
+	<script th:src="@{/resources/dist/js/vendors.bundle.js}"></script>
 	<script th:src="@{/resources/bower_components/bootstrap/dist/js/bootstrap.min.js}"></script>
 	<script th:src="@{/resources/bower_components/moment/moment.js}"></script>
 	<script th:src="@{/resources/bower_components/angular/angular.min.js}"></script>

--- a/src/main/webapp/webpack.config.js
+++ b/src/main/webapp/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const merge = require("webpack-merge");
+const webpack = require("webpack");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 const entries = require("./entries.js");
@@ -75,7 +76,19 @@ const config = {
       }
     ]
   },
+  optimization: {
+    splitChunks: {
+      cacheGroups: {
+        commons: {
+          test: /[\\/]node_modules[\\/]/,
+          name: "vendors",
+          chunks: "initial"
+        }
+      }
+    }
+  },
   plugins: [
+    new webpack.HashedModuleIdsPlugin(), // so that file hashes don't change unexpectedly
     new MiniCssExtractPlugin({
       filename: "css/[name].bundle.css"
     })


### PR DESCRIPTION
Signed-off-by: Josh Adam <josh.adam@canada.ca>

## Description of changes

Configured webpack to separate all `node_modules` into a single bundle called `vendors`.  This allows individual pages to load faster because this `vendors` bundle only needs to be downloaded once and then caches, then only pages specific code needs to be loaded.

`vendors` bundle size: 4.21 MiB

Bundle | Before (KiB) | After (KiB)
--------|-------|------
analysis | 948 | 19.2
analysis-output-table | 844 | 13.1
project-linelist | 375 | 65.2
samples-metadata-import | 252 | 7.81


## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
