### PR TITLE
Fix for datatables sort icons and missing icons on metadata import page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes
 * [Admin]: Made analysis task pool size configurable with `irida.workflow.analysis.threads`. (19.01.2)
 * [REST]: Fixes issue where the Sample collection date was synchronized incorrectly, leading to the synced date up to one day off from the original date. (19.01.2)
 * [UI]: Fixed bug where uploading a metadata file with a `.` in the header row would cause an error. (19.01.2)
+* [UI]: Updated icons on for Data Tables sorting and metadata importer.
 
 
 0.22.0 to 19.01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Changes
 * [Admin]: Made analysis task pool size configurable with `irida.workflow.analysis.threads`. (19.01.2)
 * [REST]: Fixes issue where the Sample collection date was synchronized incorrectly, leading to the synced date up to one day off from the original date. (19.01.2)
 * [UI]: Fixed bug where uploading a metadata file with a `.` in the header row would cause an error. (19.01.2)
-* [UI]: Updated icons on for Data Tables sorting and metadata importer.
+* [UI]: Updated icons for datatables sorting and metadata importer.
 
 
 0.22.0 to 19.01

--- a/src/main/webapp/pages/projects/project_samples_metadata_upload.html
+++ b/src/main/webapp/pages/projects/project_samples_metadata_upload.html
@@ -93,7 +93,7 @@
     <script type="text/ng-template" id="results.found.component.tmpl.html">
         <div class="alert alert-success" ng-show="$ctrl.rows.length &gt; 0">
             <strong>
-                <i class="fa fa-thumbs-o-up" aria-hidden="true"></i>&nbsp;
+                <i class="far fa-thumbs-up spaced-right__sm"></i>
                 <th:block th:text="#{metadata.results.found.component.title}"/>
             </strong>
             <save-metadata

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/saveMetadata.component.js
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/saveMetadata.component.js
@@ -8,13 +8,13 @@ const template = `
   <button ng-hide="$ctrl.saving" 
           class="btn btn-success" 
           ng-click="$ctrl.saveMetadata()">
-    <i class="fa fa-floppy-o" aria-hidden="true"></i>&nbsp;
+    <i class="far fa-save spaced-right__sm"></i>
     {{ $ctrl.label }}
   </button>
   <button ng-show="$ctrl.saving"
           disabled="disabled"
           class="btn btn-success">
-     <i class="fa fa-circle-o-notch fa-spin fa-fw" aria-hidden="true"></i>&nbsp;
+     <i class="fas fa-circle-notch fa-spin"></i>
 </button>
 </span>
 `;

--- a/src/main/webapp/resources/sass/components/datatables.scss
+++ b/src/main/webapp/resources/sass/components/datatables.scss
@@ -1,36 +1,9 @@
 /**
 This is a new files to replace datatables-custom.scss after all DataTables updated
  */
-/*
-Use FontAweseom as the sorting controllers.
- */
 table.dataTable thead th {
   position: relative;
   background-image: none !important;
-}
-
-table.dataTable thead th.sorting:after,
-table.dataTable thead th.sorting_asc:after,
-table.dataTable thead th.sorting_desc:after {
-  position: absolute;
-  display: block;
-  top: 50%;
-  transform: translateY(-50%);
-  content: "";
-  font-family: FontAwesome;
-}
-
-table.dataTable thead th.sorting:after {
-  content: "\f0dc";
-  color: #ddd;
-  font-size: 0.8em;
-  padding-top: 0.12em;
-}
-table.dataTable thead th.sorting_asc:after {
-  content: "\f0de";
-}
-table.dataTable thead th.sorting_desc:after {
-  content: "\f0dd";
 }
 
 table.dataTable {
@@ -202,15 +175,4 @@ table.dataTable {
   margin-left: 6px;
   cursor: pointer;
   display: inline-block;
-}
-
-// Datatables directional sorting arrows
-table.dataTable thead th.sorting_desc::after {
-  content: "\f175";
-  font-family: FontAwesome;
-}
-
-table.dataTable thead th.sorting_asc::after {
-  content: "\f176";
-  font-family: FontAwesome;
 }


### PR DESCRIPTION
Signed-off-by: Josh Adam <josh.adam@canada.ca>

## Description of changes
![Screen Shot 2019-03-20 at 10 12 11 AM](https://user-images.githubusercontent.com/11295750/54695933-e07acd80-4af8-11e9-9e79-20022b19cfe2.png)

![Screen Shot 2019-03-20 at 10 06 07 AM](https://user-images.githubusercontent.com/11295750/54695938-e40e5480-4af8-11e9-9e30-64ec7339da2d.png)


## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
