### PR TITLE
fixed the email subscription toggle on the user details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changes
 * [Admin]: Made analysis task pool size configurable with `irida.workflow.analysis.threads`. (19.01.2)
 * [REST]: Fixes issue where the Sample collection date was synchronized incorrectly, leading to the synced date up to one day off from the original date. (19.01.2)
 * [UI]: Fixed bug where uploading a metadata file with a `.` in the header row would cause an error. (19.01.2)
+* [UI]: Fixed bug where users could not update their email subscriptions to projects. (19.01.2)
 
 0.22.0 to 19.01
 ----------------

--- a/src/main/webapp/pages/user/user_details.html
+++ b/src/main/webapp/pages/user/user_details.html
@@ -234,17 +234,22 @@
 			}
 		}]);
 
-        pwd.service('SubscriptionService', ['$http', function($http){
-          var svc = this;
+				pwd.service('SubscriptionService', ['$http', function ($http) {
+					var svc = this;
 
-          svc.updateSubscription = function(userId, projectId, subscribe){
-            var urlBase = /*[[@{/events/projects/}]]*/ '/events/projects/';
-            urlBase += projectId + '/subscribe/' + userId;
-            var params = {subscribe:subscribe};
+					svc.updateSubscription = function (userId, projectId, subscribe) {
+						var urlBase = /*[[@{/events/projects/}]]*/ '/events/projects/';
+						urlBase += projectId + '/subscribe/' + userId;
+						var params = $.param({ subscribe: subscribe });
 
-            return $http.post(urlBase, params);
-          };
-        }]);
+						return $http({
+							method: "POST",
+							url: urlBase,
+							data: $.param({ subscribe: subscribe }),
+							headers: { "Content-Type": "application/x-www-form-urlencoded" }
+						});
+					};
+				}]);
 
         pwd.controller('SubscriptionController', ['SubscriptionService', function (SubscriptionService) {
           var sub = this;

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/user/UserDetailsPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/user/UserDetailsPage.java
@@ -67,6 +67,14 @@ public class UserDetailsPage extends AbstractPage {
 		confirmButton.click();
 	}
 
+	public void subscribeToFirstProject() {
+		WebElement firstCheckbox = driver.findElements(By.className("subcription-checkbox"))
+				.iterator()
+				.next();
+
+		firstCheckbox.click();
+	}
+
 	public boolean checkSuccessNotification() {
 		return pageUtilities.checkSuccessNotification();
 	}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/users/UserDetailsPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/users/UserDetailsPageIT.java
@@ -57,4 +57,11 @@ public class UserDetailsPageIT extends AbstractIridaUIITChromeDriver {
 		assertTrue(usersPage.checkSuccessNotification());
 	}
 
+	@Test
+	public void testSubscribeToProject() {
+		usersPage.getCurrentUser();
+		usersPage.subscribeToFirstProject();
+		assertTrue("Should be a success notification that you subscribed", usersPage.checkSuccessNotification());
+	}
+
 }


### PR DESCRIPTION
## Description of changes
Fixed the email subscription toggle on the user details page.  It was throwing error messages and wasn't allowing users to change their subscriptions.

Note this is a hotfix and should be merged to both master and development.

## Related issue
Fixes #323 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
