### PR TITLE
HOTFIX: Fixed jquery issue preventing associated projects from loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes
 * [REST]: Fixes issue where the Sample collection date was synchronized incorrectly, leading to the synced date up to one day off from the original date. (19.01.2)
 * [UI]: Fixed bug where uploading a metadata file with a `.` in the header row would cause an error. (19.01.2)
 * [UI]: Fixed bug where users could not update their email subscriptions to projects. (19.01.2)
+* [UI]: Fixed bug preventing associated projects from being loaded into the project samples table. (19.01.3)
 
 0.22.0 to 19.01
 ----------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>19.01.2</version>
+	<version>19.01.3</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -388,7 +388,7 @@ $(".associated-dd .dropdown-menu a").on("click", function(event) {
     // Update the select all checkbox
     $("#select-all-cb").prop(
       "checked",
-      ASSOCIATED_PROJECTS.size === ASSOCIATED_INPUTS.size()
+      ASSOCIATED_PROJECTS.size === ASSOCIATED_INPUTS.length
     );
     // Update the DataTable
     $dt.ajax.reload(null, false);


### PR DESCRIPTION
## Description of changes
When we updated jQuery there was a breaking change when calling for the number of elements found after DOM selection.  Previously is was `.size()` now it is just `.length`.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
