### PR TITLE
Cart samples sidebar cleanup

### DIFF
--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -1404,6 +1404,8 @@ cart.excluded=Duplicate sample names not allowed in the cart; the following samp
 cart.in-cart={0} is already in the cart.	
 cart.in-cart-multiple={0} samples are already in the cart, and will not be re-added.
 cart.error.project-not-in-cart=Project '{0}' is not in the cart.
+cart.clear=Empty Cart
+cart.noneMatchingFilter=No samples match filter
 
 # ========================================================================================== #
 # PIPELINES                                                                                  #

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "build": "webpack --env.mode production",
-    "start": "webpack-dev-server --env.mode development",
+    "start": "webpack --env.mode development",
     "clean": "rm -r node* resources/dist/",
     "precommit": "lint-staged"
   },
@@ -66,6 +66,8 @@
     "react-dom-factories": "^1.0.2",
     "react-immutable-proptypes": "^2.1.0",
     "react-redux": "^6.0.0",
+    "react-virtualized-auto-sizer": "^1.0.2",
+    "react-window": "^1.7.1",
     "reactour": "^1.9.1",
     "redux": "4.0.1",
     "redux-saga": "^1.0.1",

--- a/src/main/webapp/pages/cart.html
+++ b/src/main/webapp/pages/cart.html
@@ -13,6 +13,8 @@
       window.PAGE = {
         user: /*[[${#authentication.getPrincipal().getEmail()}]]*/ "user@nowhere.org",
         i18n: {
+          "cart.clear": /*[[#{cart.clear}]]*/ "Clear",
+          "cart.noneMatchingFilter": /*[[#{cart.noneMatchingFilter}]]*/ "Cart filter error",
           "CartEmpty.heading": /*[[#{CartEmpty.heading}]]*/ "Your cart is empty",
           "CartEmpty.subheading": /*[[#{CartEmpty.subheading}]]*/ "Add some samples to it to make it happy :)",
           "CartEmpty.imageAlt": /*[[#{CartEmpty.imageAlt}]]*/ "Empty Cart",

--- a/src/main/webapp/resources/js/pages/cart/components/CartSamples.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartSamples.jsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import { AgGridReact } from "ag-grid-react";
-import "ag-grid-community/dist/styles/ag-grid.css";
-import "ag-grid-community/dist/styles/ag-theme-balham.css";
-import { Button, Input, Layout } from "antd";
+import { FixedSizeList as VList } from "react-window";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { Button, Icon, Input, List, Layout } from "antd";
 import styled from "styled-components";
 import { actions } from "../../../redux/reducers/cart";
 import { sampleDetailsActions } from "../../../components/SampleDetails/reducer";
@@ -19,52 +18,27 @@ import {
   grey5
 } from "../../../styles/colors";
 import { SPACE_MD, SPACE_SM } from "../../../styles/spacing";
+import { getI18N } from "../../../utilities/i18n-utilties";
 const { Sider } = Layout;
 
 const { Search } = Input;
 
 const CartSamplesWrapper = styled.div`
-  height: 100%;
-  width: 100%;
-  padding-top: 65px;
-
-  .ag-root {
-    border: none !important;
-  }
-
-  .ag-header {
-    border-bottom: none;
-  }
-
-  .ag-center-cols-container {
-    width: 100% !important;
-  }
-
-  .ag-row-odd {
-    background-color: ${grey2};
-  }
+  flex-grow: 1;
 `;
 
 const CartTools = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  padding: 0 ${SPACE_MD};
+  padding: 0 ${SPACE_SM};
   height: 65px;
   border-bottom: 1px solid ${COLOR_BORDER_LIGHT};
   display: flex;
   align-items: center;
 
-  .ant-input-search {
-    margin-right: ${SPACE_SM};
-  }
-
   .ant-input {
-    background-color: ${grey3};
+    background-color: ${grey1};
 
     &:hover {
-      background-color: ${grey5};
+      background-color: ${grey3};
     }
 
     &:focus {
@@ -82,46 +56,30 @@ class CartSamplesComponent extends React.Component {
     removeProject: PropTypes.func.isRequired
   };
 
-  columnDefs = [
-    {
-      headerName: "",
-      field: "label",
-      cellRenderer: "SampleRenderer",
-      cellStyle: {
-        padding: SPACE_MD,
-        width: "100%",
-        borderBottomWidth: 0
-      }
-    }
-  ];
+  samples = [];
+  state = { filter: "", samples: [], loaded: false };
 
-  state = { filter: "", samples: [] };
-
-  onGridReady = params => {
-    this.gridApi = params.api;
-    this.columnApi = params.columnApi;
-
-    // Add methods for handling the sample
-    this.gridApi.displaySample = this.props.displaySample;
-    this.gridApi.removeSample = this.removeSample;
-    this.gridApi.removeProject = this.removeProject;
-
+  componentDidMount() {
     // Fetch the samples, since no samples will be added we do not need redux for them.
     getCartIds().then(({ ids }) =>
       ids.forEach(id => {
-        getSamplesForProject(id).then(samples =>
-          this.setState(prevState => ({
-            samples: [...prevState.samples, ...samples]
-          }))
-        );
+        getSamplesForProject(id).then(result => {
+          const samples = [...this.state.samples, ...result];
+          this.setState({ samples, loaded: true }, () => {
+            this.samples = samples;
+          });
+        });
       })
     );
-  };
+  }
 
-  removeSample = (index, sample) => {
+  removeSample = sample => {
     this.props.removeSample(sample.project.id, sample.id);
-    const row = this.gridApi.getRowNode(sample.id);
-    this.gridApi.updateRowData({ remove: [row] });
+    const index = this.samples.findIndex(s => s.id === sample.id);
+    this.samples.splice(index, 1);
+    this.setState({
+      samples: this.samples.filter(s => s.label.includes(this.state.filter))
+    });
   };
 
   removeProject = id => {
@@ -137,12 +95,29 @@ class CartSamplesComponent extends React.Component {
     }
   };
 
-  onSearch = e => this.setState({ filter: e.target.value });
+  onSearch = e =>
+    this.setState({
+      samples: this.samples.filter(s => s.label.includes(e.target.value)),
+      filter: e.target.value
+    });
+
+  renderSample = ({ index, data, style }) => {
+    const sample = this.state.samples[index];
+    return (
+      <SampleRenderer
+        rowIndex={index}
+        data={sample}
+        style={style}
+        displaySample={this.props.displaySample}
+        removeSample={this.removeSample}
+        removeProject={this.removeProject}
+      />
+    );
+  };
 
   render() {
-    const samples = this.state.samples.filter(s =>
-      s.label.includes(this.state.filter)
-    );
+    const { samples, filter } = this.state;
+
     return (
       <Sider
         width={400}
@@ -150,39 +125,73 @@ class CartSamplesComponent extends React.Component {
         collapsible
         collapsed={this.props.collapsed}
         collapsedWidth={0}
+        style={{ backgroundColor: grey1 }}
       >
         <div
           style={{
+            display: "flex",
+            flexDirection: "column",
             height: "100%",
-            position: "relative",
             width: 400
           }}
         >
           <CartTools>
             <Search
+              allowClear
               style={{ width: "100%" }}
               onChange={this.onSearch}
-              value={this.state.filter}
+              value={filter}
             />
-            <Button onClick={this.props.emptyCart}>Empty</Button>
           </CartTools>
-          <CartSamplesWrapper className="ag-theme-balham">
-            <AgGridReact
-              getRowNodeId={data => data.id}
-              animateRows={true}
-              headerHeight={0}
-              columnDefs={this.columnDefs}
-              rowData={samples}
-              frameworkComponents={{ SampleRenderer }}
-              onGridReady={this.onGridReady}
-              rowHeight={80}
-              rowStyle={{ width: "100%", borderWidth: 0 }}
-              filter={true}
-              suppressRowClickSelection={true}
-              suppressCellSelection={true}
-              suppressRowHoverHighlight={true}
-            />
+          <CartSamplesWrapper>
+            {samples.length > 0 ? (
+              <AutoSizer>
+                {({ height, width }) => (
+                  <List itemLayout="vertical">
+                    <VList
+                      itemCount={samples.length}
+                      itemSize={95}
+                      height={height}
+                      width={width}
+                    >
+                      {this.renderSample}
+                    </VList>
+                  </List>
+                )}
+              </AutoSizer>
+            ) : this.state.loaded ? (
+              <div
+                style={{
+                  fontSize: 30,
+                  color: blue6,
+                  justifyContent: "center",
+                  alignItems: "center",
+                  flexDirection: "column",
+                  height: 300,
+                  display: "flex"
+                }}
+              >
+                <div>
+                  <Icon type="warning" style={{ fontSize: 60 }} />
+                </div>
+                <div>{getI18N("cart.noneMatchingFilter")}</div>
+              </div>
+            ) : null}
           </CartSamplesWrapper>
+          <div
+            style={{
+              height: 60,
+              padding: SPACE_SM,
+              display: "flex",
+              justifyContent: "center",
+              borderTop: `1px solid ${COLOR_BORDER_LIGHT}`,
+              alignItems: "center"
+            }}
+          >
+            <Button type="danger" block onClick={this.props.emptyCart}>
+              {getI18N("cart.clear")}
+            </Button>
+          </div>
         </div>
       </Sider>
     );

--- a/src/main/webapp/resources/js/pages/cart/components/CartSamples.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartSamples.jsx
@@ -1,10 +1,10 @@
 import React from "react";
+import styled from "styled-components";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { FixedSizeList as VList } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import { Button, Icon, Input, List, Layout } from "antd";
-import styled from "styled-components";
 import { actions } from "../../../redux/reducers/cart";
 import { sampleDetailsActions } from "../../../components/SampleDetails/reducer";
 import { SampleRenderer } from "./SampleRenderer";
@@ -15,16 +15,53 @@ import {
   grey1,
   grey2,
   grey3,
-  grey5
+  grey5,
+  red4,
+  red6
 } from "../../../styles/colors";
-import { SPACE_MD, SPACE_SM } from "../../../styles/spacing";
+import { SPACE_SM } from "../../../styles/spacing";
 import { getI18N } from "../../../utilities/i18n-utilties";
 const { Sider } = Layout;
 
 const { Search } = Input;
 
+const SiderInner = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 400px;
+`;
+
 const CartSamplesWrapper = styled.div`
   flex-grow: 1;
+`;
+
+const ButtonsPanelBotton = styled.div`
+  height: 60px;
+  padding: ${SPACE_SM};
+  border-top: 1px solid ${COLOR_BORDER_LIGHT};
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const EmptyCartButton = styled(Button)`
+  background-color: ${red4};
+  color: ${grey1};
+
+  &:hover {
+    background-color: ${red6};
+  }
+`;
+
+const FilterWarning = styled.div`
+  font-size: 30px;
+  color: ${blue6};
+  height: 300px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 `;
 
 const CartTools = styled.div`
@@ -84,15 +121,10 @@ class CartSamplesComponent extends React.Component {
 
   removeProject = id => {
     this.props.removeProject(id);
-    const rows = [];
-    this.gridApi.forEachNode((node, index) => {
-      if (node.data.project.id === id) {
-        rows.push(node);
-      }
+    this.samples = this.samples.filter(s => s.project.id !== id);
+    this.setState({
+      samples: this.samples.filter(s => s.label.includes(this.state.filter))
     });
-    if (rows.length) {
-      this.gridApi.updateRowData({ remove: rows });
-    }
   };
 
   onSearch = e =>
@@ -125,23 +157,11 @@ class CartSamplesComponent extends React.Component {
         collapsible
         collapsed={this.props.collapsed}
         collapsedWidth={0}
-        style={{ backgroundColor: grey1 }}
+        style={{ backgroundColor: grey2 }}
       >
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            height: "100%",
-            width: 400
-          }}
-        >
+        <SiderInner>
           <CartTools>
-            <Search
-              allowClear
-              style={{ width: "100%" }}
-              onChange={this.onSearch}
-              value={filter}
-            />
+            <Search allowClear onChange={this.onSearch} value={filter} />
           </CartTools>
           <CartSamplesWrapper>
             {samples.length > 0 ? (
@@ -160,39 +180,20 @@ class CartSamplesComponent extends React.Component {
                 )}
               </AutoSizer>
             ) : this.state.loaded ? (
-              <div
-                style={{
-                  fontSize: 30,
-                  color: blue6,
-                  justifyContent: "center",
-                  alignItems: "center",
-                  flexDirection: "column",
-                  height: 300,
-                  display: "flex"
-                }}
-              >
+              <FilterWarning>
                 <div>
-                  <Icon type="warning" style={{ fontSize: 60 }} />
+                  <Icon type="warning" style={{ fontSize: 120 }} />
                 </div>
                 <div>{getI18N("cart.noneMatchingFilter")}</div>
-              </div>
+              </FilterWarning>
             ) : null}
           </CartSamplesWrapper>
-          <div
-            style={{
-              height: 60,
-              padding: SPACE_SM,
-              display: "flex",
-              justifyContent: "center",
-              borderTop: `1px solid ${COLOR_BORDER_LIGHT}`,
-              alignItems: "center"
-            }}
-          >
-            <Button type="danger" block onClick={this.props.emptyCart}>
+          <ButtonsPanelBotton>
+            <EmptyCartButton type="danger" block onClick={this.props.emptyCart}>
               {getI18N("cart.clear")}
-            </Button>
-          </div>
-        </div>
+            </EmptyCartButton>
+          </ButtonsPanelBotton>
+        </SiderInner>
       </Sider>
     );
   }

--- a/src/main/webapp/resources/js/pages/cart/components/CartSamples.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartSamples.jsx
@@ -161,7 +161,7 @@ class CartSamplesComponent extends React.Component {
       >
         <SiderInner>
           <CartTools>
-            <Search allowClear onChange={this.onSearch} value={filter} />
+            <Search onChange={this.onSearch} value={filter} />
           </CartTools>
           <CartSamplesWrapper>
             {samples.length > 0 ? (

--- a/src/main/webapp/resources/js/pages/cart/components/CartTools.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartTools.jsx
@@ -3,7 +3,13 @@ import { Location, navigate, Router } from "@reach/router";
 import { Row } from "antd";
 import styled from "styled-components";
 import { CartToolsMenu } from "./CartToolsMenu";
-import { grey1, grey2, grey3, grey4 } from "../../../styles/colors";
+import {
+  grey1,
+  grey2,
+  grey3,
+  grey4,
+  COLOR_BORDER_LIGHT
+} from "../../../styles/colors";
 import { SPACE_MD } from "../../../styles/spacing";
 import { getI18N } from "../../../utilities/i18n-utilties";
 import { GalaxyExport } from "../../../components/galaxy/GalaxyExport";
@@ -12,7 +18,7 @@ import { Pipelines } from "../../../components/pipelines/Pipelines";
 const ToolsWrapper = styled(Row)`
   height: 100%;
   width: 100%;
-  border-right: 1px solid ${grey4};
+  border-right: 1px solid ${COLOR_BORDER_LIGHT};
   background-color: ${grey1};
   position: relative;
 `;

--- a/src/main/webapp/resources/js/pages/cart/components/CartTools.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartTools.jsx
@@ -3,7 +3,7 @@ import { Location, navigate, Router } from "@reach/router";
 import { Row } from "antd";
 import styled from "styled-components";
 import { CartToolsMenu } from "./CartToolsMenu";
-import { grey1, grey2, grey4 } from "../../../styles/colors";
+import { grey1, grey2, grey3, grey4 } from "../../../styles/colors";
 import { SPACE_MD } from "../../../styles/spacing";
 import { getI18N } from "../../../utilities/i18n-utilties";
 import { GalaxyExport } from "../../../components/galaxy/GalaxyExport";
@@ -12,9 +12,8 @@ import { Pipelines } from "../../../components/pipelines/Pipelines";
 const ToolsWrapper = styled(Row)`
   height: 100%;
   width: 100%;
-  background-color: ${grey1};
   border-right: 1px solid ${grey4};
-  background-color: ${grey2};
+  background-color: ${grey1};
   position: relative;
 `;
 

--- a/src/main/webapp/resources/js/pages/cart/components/SampleRenderer.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/SampleRenderer.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Button, Col, Dropdown, Icon, Menu, Row } from "antd";
+import { Button, Dropdown, Icon, Menu, List } from "antd";
 import styled from "styled-components";
 import { getI18N } from "../../../utilities/i18n-utilties";
 import {
@@ -8,6 +8,8 @@ import {
   FONT_COLOR_PRIMARY,
   FONT_SIZE_SMALL
 } from "../../../styles/fonts";
+import { grey1, grey2, grey3, grey4 } from "../../../styles/colors";
+import { SPACE_XS, SPACE_MD, SPACE_SM } from "../../../styles/spacing";
 
 const ProjectLink = styled.a`
   display: block;
@@ -17,7 +19,7 @@ const ProjectLink = styled.a`
 `;
 
 const DeleteMenu = ({ removeSample, removeProject }) => (
-  <Menu className="t-delete-menu">
+  <Menu className="t-delete-menu" style={{ border: `1px solid ${grey4}` }}>
     <Menu.Item>
       <div onClick={removeSample} className="t-delete-sample">
         {getI18N("SampleRenderer.remove.sample")}
@@ -29,6 +31,13 @@ const DeleteMenu = ({ removeSample, removeProject }) => (
       </div>
     </Menu.Item>
   </Menu>
+);
+
+const IconText = ({ type, text }) => (
+  <span>
+    <Icon type={type} style={{ marginRight: SPACE_XS }} />
+    {text}
+  </span>
 );
 
 /**
@@ -57,54 +66,65 @@ export class SampleRenderer extends React.Component {
     })
   };
 
-  displaySample = () => this.props.api.displaySample(this.props.data);
+  displaySample = () => this.props.displaySample(this.props.data);
 
-  removeSample = () =>
-    this.props.api.removeSample(this.props.rowIndex, this.props.data);
+  removeSample = () => this.props.removeSample(this.props.data);
 
-  removeProject = () =>
-    this.props.api.removeProject(this.props.data.project.id);
+  removeProject = () => this.props.removeProject(this.props.data.project.id);
 
   render() {
     const sample = this.props.data;
     return (
-      <Row
+      <div
+        style={{
+          ...this.props.style,
+          padding: `0 ${SPACE_SM}`,
+          backgroundColor: grey3,
+          borderBottom: `1px solid ${grey4}`
+        }}
         className="t-cart-sample"
-        type="flex"
-        align="top"
-        justify="space-between"
       >
-        <Col>
-          <Button
-            className="t-sample-name"
-            shape="round"
-            size="small"
-            onClick={this.displaySample}
-          >
-            {sample.label}
-          </Button>
-          <ProjectLink
-            href={`${window.TL.BASE_URL}projects/${sample.project.id}/linelist`}
-          >
-            {sample.project.label}
-          </ProjectLink>
-        </Col>
-        <Col>
-          <Dropdown
-            overlay={
-              <DeleteMenu
-                removeSample={this.removeSample}
-                removeProject={this.removeProject}
-              />
+        <List.Item
+          key={sample.id}
+          extra={
+            <Dropdown
+              overlay={
+                <DeleteMenu
+                  removeSample={this.removeSample}
+                  removeProject={this.removeProject}
+                />
+              }
+              trigger={["click"]}
+            >
+              <Button className="t-delete-menu-btn" shape="circle" size="small">
+                <Icon type="ellipsis" />
+              </Button>
+            </Dropdown>
+          }
+          actions={[
+            <IconText
+              type="folder"
+              text={
+                <a href={`${window.TL.BASE_URL}projects/${sample.project.id}`}>
+                  {sample.project.label}
+                </a>
+              }
+            />
+          ]}
+        >
+          <List.Item.Meta
+            title={
+              <Button
+                className="t-sample-name"
+                size="small"
+                onClick={this.displaySample}
+              >
+                {sample.label}
+              </Button>
             }
-            trigger={["click"]}
-          >
-            <Button className="t-delete-menu-btn" ghost shape="circle" size="small">
-              <Icon type="ellipsis" style={{ color: FONT_COLOR_PRIMARY }} />
-            </Button>
-          </Dropdown>
-        </Col>
-      </Row>
+          />
+        </List.Item>
+      </div>
     );
   }
 }

--- a/src/main/webapp/resources/js/styles/colors.js
+++ b/src/main/webapp/resources/js/styles/colors.js
@@ -72,4 +72,4 @@ export const gold1 = "hsl(51,100%,95%)";
 export const COLOR_BACKGROUND_LIGHTEST = grey1;
 export const COLOR_BACKGROUND_LIGHT = grey4;
 export const COLOR_BACKGROUND_DARK = grey8;
-export const COLOR_BORDER_LIGHT = grey3;
+export const COLOR_BORDER_LIGHT = grey4;

--- a/src/main/webapp/webpack.config.dev.js
+++ b/src/main/webapp/webpack.config.dev.js
@@ -1,19 +1,5 @@
-const webpack = require("webpack");
-
 exports.config = {
   mode: "none",
   devtool: "eval-source-map",
-  devServer: {
-    proxy: {
-      context: () => true,
-      target: "localhost:8080"
-    },
-    overlay: {
-      warnings: false,
-      errors: true
-    },
-    hot: true,
-    writeToDisk: true
-  },
-  plugins: [new webpack.HotModuleReplacementPlugin()]
+  watch: true
 };

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -4922,6 +4922,11 @@ mem@4.1.0, mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^2.0.0"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.2.tgz#6aba5276856d72fb44ead3efab86432f94ba203d"
+  integrity sha512-o7lldN4fs/axqctc03NF+PMhd2veRrWeJ2n2GjEzUPBD4F9rmNg4A+bQCACIzwjHJEXuYv4aFFMaH35KZfHUrw==
+
 memoize-one@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
@@ -6766,6 +6771,19 @@ react-slick@~0.23.2:
     lodash.debounce "^4.0.8"
     prettier "^1.14.3"
     resize-observer-polyfill "^1.5.0"
+
+react-virtualized-auto-sizer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
+  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
+
+react-window@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.7.1.tgz#c1db640415b97b85bc0a1c66eb82dadabca39b86"
+  integrity sha512-y4/Qc98agCtHulpeI5b6K2Hh8J7TeZIfvccBVesfqOFx4CS+TSUpnJl1/ipeXzhfvzPwvVEmaU/VosQ6O5VhTg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@16.8.2:
   version "16.8.2"


### PR DESCRIPTION
## Description of changes
* Removed using ag-grid as it was too much overkill and replaced with react-window.  This library was chosen because it allow for dynamic sliding DOM windows.
* Moved the clear cart button to the bottom of the page as it looked like it was a clear button for the form.

![Screen Shot 2019-04-02 at 10 05 16 AM](https://user-images.githubusercontent.com/11295750/55413626-4de22180-552f-11e9-8530-780bec916deb.png)

## Related issue
#192 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~~
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
