### PR TITLE
Excluding xlsx files from being previewed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Changes
 * [UI]: Exporting to Galaxy now runs through the new cart interface.  Export to Galaxy through the Project Samples page has been deprecated.
 * [Developer]: Updated Travis CI dist to `xenial`.
 * [Developer]: Updated chromedriver in pom.xml and packages.json to newer versions to work better with newest chrome version.
+* [UI]: Removed `.xlsx` files from being previewed in the pipeline results page.
 
 0.22.0 to 19.01
 ----------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
@@ -392,7 +392,7 @@ public class AnalysisController {
 	 */
 	private AnalysisOutputFileInfo getAnalysisOutputFileInfo(AnalysisSubmission submission, Analysis analysis,
 			String outputName) {
-		final ImmutableSet<String> BLACKLIST_FILE_EXT = ImmutableSet.of("zip", "pdf", "html");
+		final ImmutableSet<String> BLACKLIST_FILE_EXT = ImmutableSet.of("zip", "pdf", "html", "xlsx");
 		// set of file extensions for indicating whether the first line of the file should be read
 		final ImmutableSet<String> FILE_EXT_READ_FIRST_LINE = ImmutableSet.of("tsv", "txt", "tabular", "csv", "tab", TREE_EXT);
 		final AnalysisOutputFile aof = analysis.getAnalysisOutputFile(outputName);


### PR DESCRIPTION
## Description of changes

Excludes `.xlsx` files from being displayed in the analysis pipelines output preview.

## Related issue

Fix issue #347 

## Checklist

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* ~[ ] Tests added (or description of how to test) for any new features.~
* ~[ ] User documentation updated for UI or technical changes.~
