### PR TITLE
Upgraded TravisCI mariadb version to 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ services:
 dist: xenial
 
 addons:
-  mariadb: '10.0'
+  mariadb: '10.1'
 
 jdk:
   - openjdk8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Changes
 * [UI]: New dedicated cart page.
 * [UI]: Exporting to Galaxy now runs through the new cart interface.  Export to Galaxy through the Project Samples page has been deprecated.
 * [Developer]: Updated Travis CI dist to `xenial`.
+* [Developer]: Upgraded MariaDB version in TravisCI to 10.1.  10.0 wasn't installing properly since upgrade to xenial.
 * [Developer]: Updated chromedriver in pom.xml and packages.json to newer versions to work better with newest chrome version.
 * [UI]: Removed `.xlsx` files from being previewed in the pipeline results page.
 * [UI/Developer]: Fixed issue with deleting a user group if it is linked to any projects.


### PR DESCRIPTION
## Description of changes
Upgraded the MariaDB version on the travis CI builds to 10.1.  Apparently it's been failing to install since we did the upgrade in #345, but was conveniently falling back to MySQL.  It stopped falling back today, so this is a version that properly installs.

To test, verify the CI tests are passing and that MariaDB is being installed:

Messages when MariaDB fails to install:
```
The following packages have unmet dependencies:
 mariadb-server-10.0 : Depends: mariadb-client-10.0 (>= 10.0.38+maria-1~xenial) but it is not going to be installed
                       Depends: mariadb-server-core-10.0 (>= 10.0.38+maria-1~xenial) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
...
Starting MariaDB v10.0
...
Job for mysql.service failed because the control process exited with error code. See "systemctl status mysql.service" and "journalctl -xe" for details.
```

Messages when things are good to go:
```
sudo systemctl start mysql
...
mysql --version
...
mysql  Ver 15.1 Distrib 10.1.38-MariaDB...
```

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
