### PR TITLE
Cart: tell webpack where the resources are located.

### DIFF
--- a/src/main/webapp/pages/oauth/access_confirmation.html
+++ b/src/main/webapp/pages/oauth/access_confirmation.html
@@ -4,7 +4,7 @@
     <title th:text="#{auth.title}">IRIDA OAuth2 Approval Page</title>
     <link
       rel="stylesheet"
-      href="/resources/dist/css/access_confirmation.bundle.css"
+      th:href="@{/resources/dist/css/access_confirmation.bundle.css}"
     />
     <style>
       body {

--- a/src/main/webapp/resources/js/apis/oauth/oauth.js
+++ b/src/main/webapp/resources/js/apis/oauth/oauth.js
@@ -15,11 +15,11 @@ const getWindowFeatures = () => {
 
   // Fixes dual-screen position Most browsers Firefox
   const dualScreenLeft =
-    typeof window.screenLeft != "undefined"
+    typeof window.screenLeft !== "undefined"
       ? window.screenLeft
       : window.screenX;
   const dualScreenTop =
-    typeof window.screenTop != "undefined" ? window.screenTop : window.screenY;
+    typeof window.screenTop !== "undefined" ? window.screenTop : window.screenY;
 
   const width = window.innerWidth
     ? window.innerWidth

--- a/src/main/webapp/resources/js/components/Header/PageHeader.jsx
+++ b/src/main/webapp/resources/js/components/Header/PageHeader.jsx
@@ -2,6 +2,14 @@ import React, { Suspense } from "react";
 import { render } from "react-dom";
 import { blue1 } from "../../styles/colors";
 
+/*
+WEBPACK PUBLIC PATH:
+Webpack does not know what the servlet context path is.  To fix this, webpack exposed
+the variable `__webpack_public_path__`
+See: https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+__webpack_public_path__ = `${window.TL.BASE_URL}resources/dist/`;
+
 const GalaxyAlert = React.lazy(() => import("./GalaxyAlert"));
 
 export class PageHeader extends React.Component {

--- a/src/main/webapp/resources/js/pages/cart/components/CartTools.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartTools.jsx
@@ -3,13 +3,7 @@ import { Location, navigate, Router } from "@reach/router";
 import { Row } from "antd";
 import styled from "styled-components";
 import { CartToolsMenu } from "./CartToolsMenu";
-import {
-  grey1,
-  grey2,
-  grey3,
-  grey4,
-  COLOR_BORDER_LIGHT
-} from "../../../styles/colors";
+import { COLOR_BORDER_LIGHT, grey1 } from "../../../styles/colors";
 import { SPACE_MD } from "../../../styles/spacing";
 import { getI18N } from "../../../utilities/i18n-utilties";
 import { Pipelines } from "../../../components/pipelines/Pipelines";
@@ -80,10 +74,10 @@ export default class CartTools extends Component {
     if (this.state.fromGalaxy) {
       this.setState(
         prevState => ({
-          fromGalaxy: false,
+          fromGalaxy: false
         }),
         () => {
-          navigate("/cart/pipelines");
+          navigate(`${window.TL.BASE_URL}cart/pipelines`);
           this.removeGalaxyListener();
         }
       );
@@ -97,20 +91,23 @@ export default class CartTools extends Component {
     const paths = [
       this.state.fromGalaxy
         ? {
-            key: "/cart/galaxy",
-            link: "cart/galaxy",
+            link: `${window.TL.BASE_URL}cart/galaxy`,
             text: getI18N("CartTools.menu.galaxy"),
-            component: <GalaxyComponent key="cart/galaxy" path="cart/galaxy" />
+            component: (
+              <GalaxyComponent
+                key="galaxy"
+                path={`${window.TL.BASE_URL}cart/galaxy`}
+              />
+            )
           }
         : null,
       {
-        key: "/cart/pipelines",
-        link: "cart/pipelines",
+        link: `${window.TL.BASE_URL}cart/pipelines`,
         text: getI18N("CartTools.menu.pipelines"),
         component: (
           <Pipelines
-            key="/cart/pipelines"
-            path="cart/pipelines"
+            key="pipelines"
+            path={`${window.TL.BASE_URL}cart/pipelines`}
             displaySelect={this.props.count > 0}
             default={!this.state.fromGalaxy}
           />

--- a/src/main/webapp/resources/js/pages/cart/components/CartToolsMenu.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/CartToolsMenu.jsx
@@ -34,7 +34,7 @@ export function CartToolsMenu({ pathname, paths, toggleSidebar, collapsed }) {
         style={{ borderBottom: `1px solid ${COLOR_BORDER_LIGHT}` }}
       >
         {paths.map(path => (
-          <Menu.Item key={path.key}>
+          <Menu.Item key={path.link}>
             <Link to={path.link}>{path.text}</Link>
           </Menu.Item>
         ))}

--- a/src/main/webapp/resources/js/pages/cart/index.js
+++ b/src/main/webapp/resources/js/pages/cart/index.js
@@ -17,7 +17,7 @@ import { Cart } from "./components/Cart";
 
 /*
 WEBPACK PUBLIC PATH:
-Webpack does not now what the servlet context path is.  To fix this, webpack exposed
+Webpack does not know what the servlet context path is.  To fix this, webpack exposed
 the variable `__webpack_public_path__`
 See: https://webpack.js.org/guides/public-path/#on-the-fly
  */

--- a/src/main/webapp/resources/js/pages/cart/index.js
+++ b/src/main/webapp/resources/js/pages/cart/index.js
@@ -21,7 +21,7 @@ Webpack does not now what the servlet context path is.  To fix this, webpack exp
 the variable `__webpack_public_path__`
 See: https://webpack.js.org/guides/public-path/#on-the-fly
  */
-window.__webpack_public_path__ = `${window.TL.BASE_URL}resources/dist/`;
+__webpack_public_path__ = `${window.TL.BASE_URL}resources/dist/`;
 
 const store = getStore(
   { sampleDetailsReducer },

--- a/src/main/webapp/resources/js/pages/cart/index.js
+++ b/src/main/webapp/resources/js/pages/cart/index.js
@@ -7,14 +7,21 @@ import {
   sampleDetailsReducer
 } from "../../components/SampleDetails";
 import { actions } from "../../redux/reducers/app";
-import { reducer as galaxyReducer } from "../../components/galaxy/reducer";
 import {
   empty,
+  loadFullCart,
   removeProjectFromCart,
-  removeSampleFromCart,
-  loadFullCart
+  removeSampleFromCart
 } from "../../redux/sagas/cart";
 import { Cart } from "./components/Cart";
+
+/*
+WEBPACK PUBLIC PATH:
+Webpack does not now what the servlet context path is.  To fix this, webpack exposed
+the variable `__webpack_public_path__`
+See: https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+window.__webpack_public_path__ = `${window.TL.BASE_URL}resources/dist/`;
 
 const store = getStore(
   { sampleDetailsReducer },


### PR DESCRIPTION
Signed-off-by: Josh Adam <josh.adam@canada.ca>

## Description of changes
What issue where webpack did not know where to look for code split resources.

## Related issue

## Checklist

