### PR TITLE
Add version to description in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes
 * [UI]: Fixes issue where importing an excel file that contained "Created Date" and "Modified Date" created metadata fields with those labels.
 * [REST]: Updated http status code returned (400 Bad Request) when uploading files to the wrong type of run
 * [UI/Developer]: Updated to jquery v3.4.0 to fix security issue.
+* [Database]: Fixed issue where FastQC description was being stored with an invalidly formatted version in the database.
 
 0.22.0 to 19.01
 ----------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
@@ -87,7 +87,7 @@ public class FastqcFileProcessor implements FileProcessor {
 		AnalysisFastQC.AnalysisFastQCBuilder analysis = AnalysisFastQC.builder()
 				.fastqcVersion(FastQCApplication.VERSION)
 				.executionManagerAnalysisId(EXECUTION_MANAGER_ANALYSIS_ID)
-				.description(messageSource.getMessage("fastqc.file.processor.analysis.description", null,
+				.description(messageSource.getMessage("fastqc.file.processor.analysis.description", new Object[] {FastQCApplication.VERSION},
 						LocaleContextHolder.getLocale()));
 		try {
 			uk.ac.babraham.FastQC.Sequence.SequenceFile fastQCSequenceFile = SequenceFactory.getSequenceFile(


### PR DESCRIPTION
## Description of changes
Updated the **description** in the **fastqc** analysis results so it contains the version (instead of `{0}`).

```
+----+---------------------+----------------------------------------------+----------------------------+---------------+
| id | createdDate         | description                                  | executionManagerAnalysisId | analysis_type |
+----+---------------------+----------------------------------------------+----------------------------+---------------+
|  9 | 2019-04-25 16:06:16 | Analysis produced by FastQC (Version {0})    | internal-fastqc            | FASTQC        |
| 10 | 2019-04-25 16:06:30 | Analysis produced by FastQC (Version {0})    | internal-fastqc            | FASTQC        |
| 11 | 2019-04-25 16:17:59 | Analysis produced by FastQC (Version 0.11.7) | internal-fastqc            | FASTQC        |
| 12 | 2019-04-25 16:18:13 | Analysis produced by FastQC (Version 0.11.7) | internal-fastqc            | FASTQC        |
+----+---------------------+----------------------------------------------+----------------------------+---------------+
```

Database entries 9 and 10 are before the fix, 11 and 12 are after this fix.

## Related issue

Fix #366 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* ~[ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* ~[ ] Tests added (or description of how to test) for any new features.~
* ~[ ] User documentation updated for UI or technical changes.~
