### PR TITLE
Fixes issue with creating linelist templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Changes
 * [UI]: Fixes issue where importing an excel file that contained "Created Date" and "Modified Date" created metadata fields with those labels.
 * [REST]: Updated http status code returned (400 Bad Request) when uploading files to the wrong type of run
 * [UI/Developer]: Updated to jquery v3.4.0 to fix security issue.
+* [UI]: Fixed bug causing issues with saving Line List templates.
 
 0.22.0 to 19.01
 ----------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/components/agGrid/AgGridColumn.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/components/agGrid/AgGridColumn.java
@@ -166,7 +166,7 @@ public class AgGridColumn {
 		this.headerCheckboxSelection = headerCheckboxSelection;
 	}
 
-	public String isFilter() {
+	public String getFilter() {
 		return filter;
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/components/agGrid/AgGridColumn.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/components/agGrid/AgGridColumn.java
@@ -58,9 +58,9 @@ public class AgGridColumn {
 	private boolean headerCheckboxSelection;
 
 	/**
-	 * Suppress the filter on this column
+	 * Type of column filter.
 	 */
-	private boolean filter;
+	private String filter;
 
 	/**
 	 * Suppress the ability to resize this column
@@ -166,11 +166,11 @@ public class AgGridColumn {
 		this.headerCheckboxSelection = headerCheckboxSelection;
 	}
 
-	public boolean isFilter() {
+	public String isFilter() {
 		return filter;
 	}
 
-	public void setFilter(boolean filter) {
+	public void setFilter(String filter) {
 		this.filter = filter;
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
@@ -351,7 +351,6 @@ public class LineListController {
 		iconField.setLockPosition(true);
 		iconField.setCheckboxSelection(true);
 		iconField.setHeaderCheckboxSelection(true);
-		iconField.setFilter(false);
 		iconField.setResizable(false);
 		fields.add(0, iconField);
 

--- a/src/main/webapp/resources/js/pages/projects/linelist/reducers/fields.js
+++ b/src/main/webapp/resources/js/pages/projects/linelist/reducers/fields.js
@@ -44,6 +44,7 @@ function getColumnDefinition(col) {
 
   if (field === FIELDS.icons) {
     Object.assign(col, {
+      filter: undefined,
       cellRenderer: "IconCellRenderer"
     });
   } else if (type === TYPES.date) {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectLineListPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectLineListPageIT.java
@@ -1,15 +1,16 @@
 package ca.corefacility.bioinformatics.irida.ria.integration.projects;
 
-import static org.junit.Assert.*;
-
 import org.junit.Test;
 import org.openqa.selenium.Dimension;
-
-import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectLineListPage;
+
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * <p>
@@ -82,6 +83,19 @@ public class ProjectLineListPageIT extends AbstractIridaUIITChromeDriver {
 		// Switch back to new template
 		page.selectTemplate(TEMPLATE_NAME);
 		assertEquals("Should have 3 columns visible", 3, page.getNumberOfTableColumnsVisible());
+
+		// Test creating a second template
+		page.toggleMetadataField(5);
+		assertEquals("Should have 4 columns visible", 4, page.getNumberOfTableColumnsVisible());
+		page.saveMetadataTemplate("ANOTHER TESTING TEMPLATE");
+
+		// Switch back to new template
+		page.selectTemplate(TEMPLATE_NAME);
+		assertEquals("Should have 3 columns visible", 3, page.getNumberOfTableColumnsVisible());
+
+		// Switch back to new template
+		page.selectTemplate("ANOTHER TESTING TEMPLATE");
+		assertEquals("Should have 4 columns visible", 4, page.getNumberOfTableColumnsVisible());
 
 		// Test inline editing
 		page.selectTemplate("All Fields");


### PR DESCRIPTION
## Description of changes
It appears the issue with saving linelist templates was the way that the filter variable is being parsed.  Changed this to a string for server parsing.  This lead to having to explicitly ignore the filter for the icon column in the table.

## Related issue
Fixes #369 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [X] Tests added (or description of how to test) for any new features.
~~* [ ] User documentation updated for UI or technical changes.~~
