### PR TITLE
Added database timeout recovery docs

### DIFF
--- a/doc/administrator/upgrades/index.md
+++ b/doc/administrator/upgrades/index.md
@@ -73,7 +73,7 @@ What's happened at this point is an error occurred while moving the temporary fi
 
 #### Database timeout error
 
-If you have lots of sequence files stored in IRIDA, this upgrade can take a while to write all the FastQC results to the filesystem. This could lead to database connection timeout issues. You should see a message in your log like below if this error were to occur:
+If you have lots of sequence files stored in IRIDA, this upgrade can take a while to write all the FastQC results to the filesystem. This could lead to database connection timeout issues (the default timeout is 8 hours for MySQL/MariaDB). You should see a message in your log like below if this error were to occur:
 
 ```
 Error: The last packet successfully received from the server was 38,881,098 milliseconds ago.  The last packet sent successfully to the server was 38,885,372 milliseconds ago. is longer than the server configured value of 'wait_timeout'. You should consider either expiring and/or testing connection validity before use in your application, increasing the server configured values for client timeouts, or using the Connector/J connection property 'autoReconnect=true' to avoid this problem. [Failed SQL: ALTER TABLE irida_prod_test.analysis_output_file MODIFY file_path VARCHAR(255) NOT NULL]
@@ -85,4 +85,4 @@ If you encounter this error, you can increase the database `wait_timeout` value 
 jdbc.url=jdbc:mysql://localhost:3306/irida_prod_test?sessionVariables=wait_timeout=57600
 ```
 
-Modify `57600` to some appropriate timeout value (in seconds). Once you've made this modification, you will have to go through the instructions above on recovering from an error before restarting the upgrade.
+Modify `57600` to some appropriate timeout value (in seconds). Once you've made this modification, you will have to go through the instructions above on recovering from an error before restarting the upgrade. Once the upgrade is complete, you can remove this variable from the connection string and restart IRIDA to reset to the default database timeout value.

--- a/doc/administrator/upgrades/index.md
+++ b/doc/administrator/upgrades/index.md
@@ -70,3 +70,19 @@ What's happened at this point is an error occurred while moving the temporary fi
 4. Remove all directories from your `output.file.base.directory` with an ID **GREATER THAN** the above noted ID.  These files were created as part of the upgrade process.
 5. Retry the upgrade by starting Tomcat again.
 6. Remove the temporary directory created during the failed upgrade.  It will be included in the error message. "... temporary file location (**YOUR TEMP DIRECTORY**)".
+
+#### Database timeout error
+
+If you have lots of sequence files stored in IRIDA, this upgrade can take a while to write all the FastQC results to the filesystem. This could lead to database connection timeout issues. You should see a message in your log like below if this error were to occur:
+
+```
+Error: The last packet successfully received from the server was 38,881,098 milliseconds ago.  The last packet sent successfully to the server was 38,885,372 milliseconds ago. is longer than the server configured value of 'wait_timeout'. You should consider either expiring and/or testing connection validity before use in your application, increasing the server configured values for client timeouts, or using the Connector/J connection property 'autoReconnect=true' to avoid this problem. [Failed SQL: ALTER TABLE irida_prod_test.analysis_output_file MODIFY file_path VARCHAR(255) NOT NULL]
+```
+
+If you encounter this error, you can increase the database `wait_timeout` value by modifying the database connection string in `/etc/irida/irida.conf` by appending `?sessionVariables=wait_timeout=57600` like below:
+
+```
+jdbc.url=jdbc:mysql://localhost:3306/irida_prod_test?sessionVariables=wait_timeout=57600
+```
+
+Modify `57600` to some appropriate timeout value (in seconds). Once you've made this modification, you will have to go through the instructions above on recovering from an error before restarting the upgrade.


### PR DESCRIPTION
## Description of changes

Added documentation on how to recover from a database timeout issue when upgrading to IRIDA `19.05`.

## Related issue
None.

## Checklist
* ~[ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* ~[ ] Tests added (or description of how to test) for any new features.~
* [x] User documentation updated for UI or technical changes.
