### PR TITLE
Updated to latest bootstrap (3.4.1) to fix security vulnerability

### DIFF
--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -31,7 +31,7 @@
     "angular-ui-router": "1.0.0-alpha.4",
     "antd": "^3.16.3",
     "axios": "^0.18.0",
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "bootstrap-daterangepicker": "^3.0.3",
     "bootstrap-switch": "^3.3.4",
     "chroma-js": "^1.3.4",

--- a/src/main/webapp/resources/js/pages/analyses/analyses-table.js
+++ b/src/main/webapp/resources/js/pages/analyses/analyses-table.js
@@ -47,6 +47,7 @@ const POPOVER_OPTIONS = {
   trigger: "click",
   placement: "auto right",
   html: true,
+  sanitize: false,
   template: $("#popover-template").clone()
 };
 

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import angular from "angular";
 import chroma from "chroma-js";
 import {
   createItemLink,
@@ -36,6 +35,7 @@ const POPOVER_OPTIONS = {
   container: "body",
   trigger: "hover",
   placement: "right",
+  sanitize: false,
   html: true,
   template: $("#popover-template").clone()
 };

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -1789,10 +1789,10 @@ bootstrap-switch@^3.3.4:
   resolved "https://registry.yarnpkg.com/bootstrap-switch/-/bootstrap-switch-3.4.0.tgz#6bbb0445ad8b4264883d06366d48aad3c06988f4"
   integrity sha512-P4Qdx7mLjqgilKQeeuDCf8AHWeO7992+NFfh0doAA/ExaJqr02QFHhq18GL8EYd2XRviJ16pUUyMRsfOVaPEVg==
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 bootstrap@>=2.3.2:
   version "4.3.1"


### PR DESCRIPTION
## Description of changes
Updated Bootstrap to 3.4.1 to fix security vulnerability.  Needed to fix a bug the htm in popovers.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

**CHANGELOG updated in a previous merge request**
~~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~~
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
