### PR TITLE
Hotfix 337 metadata template creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+19.05 to 19.09
+--------------
+* [UI]: Fixed bug where a new metadata template could not be created. (19.05.1)
+
 19.01 to 19.05
 ---------------
 * [Documentation]: Added the CalVer updates to the documentation getting started guide.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>19.05</version>
+	<version>19.05.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/metadata/ProjectSamplesMetadataTemplateController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/metadata/ProjectSamplesMetadataTemplateController.java
@@ -101,7 +101,9 @@ public class ProjectSamplesMetadataTemplateController {
 		for (String field : fields) {
 			MetadataTemplateField f = metadataTemplateService.readMetadataFieldByLabel(field);
 			if (f == null) {
-				templateFields.add(new MetadataTemplateField(field, "text"));
+				MetadataTemplateField templateField = metadataTemplateService.saveMetadataField(
+						new MetadataTemplateField(field, "text"));
+				templateFields.add(templateField);
 			} else {
 				templateFields.add(f);
 			}


### PR DESCRIPTION
## Description of changes
Appears to be an issue that new MetadataTemplateFields are not automatically saved for a new template.  This PR saves the field when it is created and before adding it to the new template.

## Related issue
Fixes #337 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
