### PR TITLE
Remove livestampjs as a project dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes
 * [UI]: Updated session expiration modal.
 * [UI]: Removed `momentjs` from being loaded on every page.
 * [UI]: Removed `livestampjs` as a project dependency.
+
 19.01 to 19.05
 ---------------
 * [Documentation]: Added the CalVer updates to the documentation getting started guide.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Changes
 * [UI/Developer]: Updated to latest `react-redux` to use new hooks API.
 * [UI]: Updated session expiration modal.
 * [UI]: Removed `momentjs` from being loaded on every page.
-
+* [UI]: Removed `livestampjs` as a project dependency.
 19.01 to 19.05
 ---------------
 * [Documentation]: Added the CalVer updates to the documentation getting started guide.

--- a/src/main/webapp/bower.json
+++ b/src/main/webapp/bower.json
@@ -7,7 +7,6 @@
     "**/*.txt"
   ],
   "dependencies": {
-    "livestampjs": "1.1.2",
     "select2": "3.5.0",
     "bower": "*",
     "angular-ui-router": "0.2.13",

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@babel/polyfill": "^7.2.5",
-    "@bassettsj/livestamp": "^2.0.0",
     "@fortawesome/fontawesome-free": "^5.5.0",
     "@reach/router": "^1.2.1",
     "ag-grid-community": "^20.0.0",

--- a/src/main/webapp/pages/announcements/announcements.html
+++ b/src/main/webapp/pages/announcements/announcements.html
@@ -5,10 +5,9 @@
                 <div class="announcement-content pull-left">
                     <marked th:inline="text">[[${ann.getMessage()}]]</marked>
                 </div>
-                <div class="pull-right announcement-info">
-                    <div class="announcement-date" th:with="dateFormat=#{locale.date.long}" uib-tooltip-placement="top"
-                         data:uib-tooltip="${#dates.format(ann.getCreatedDate(), dateFormat)}"
-                         data:livestamp="${ann.createdDate}">
+                <div class="announcement-info">
+                    <div class="announcement-date" th:with="dateFormat=#{locale.date.long}"
+                         th:text="${#dates.format(ann.getCreatedDate(), dateFormat)}">
                     </div>
                     <div class='btn-group pull-right announcement-markread'>
                     <button class="btn btn-default btn-xs"

--- a/src/main/webapp/pages/events/events.html
+++ b/src/main/webapp/pages/events/events.html
@@ -12,9 +12,8 @@
     <li class="list-group-item event-item" th:each="event : ${events}">
         <th:block th:replace="events/fragments/event :: ${event.name} (${event.event})"></th:block>
         <div class="event-date" data-toggle="tooltip"
-             th:title="${#dates.format(event.event.createdDate, dateFormat)}"
+             th:text="${#dates.format(event.event.createdDate, dateFormat)}"
              th:with="dateFormat=#{locale.date.long}">
-            <span th:with="dateFormat=#{locale.date.long}" th:text="${#dates.format(event.event.createdDate, dateFormat)}"></span>
         </div>
     </li>
     <li class="list-group-item" th:if="${#lists.isEmpty(events)}" th:text="#{event.no_activities}">

--- a/src/main/webapp/pages/events/events.html
+++ b/src/main/webapp/pages/events/events.html
@@ -14,7 +14,7 @@
         <div class="event-date" data-toggle="tooltip"
              th:title="${#dates.format(event.event.createdDate, dateFormat)}"
              th:with="dateFormat=#{locale.date.long}">
-            <span data:livestamp="${event.event.createdDate}"></span>
+            <span th:with="dateFormat=#{locale.date.long}" th:text="${#dates.format(event.event.createdDate, dateFormat)}"></span>
         </div>
     </li>
     <li class="list-group-item" th:if="${#lists.isEmpty(events)}" th:text="#{event.no_activities}">

--- a/src/main/webapp/pages/index.html
+++ b/src/main/webapp/pages/index.html
@@ -54,7 +54,6 @@
 </div>
 
 <th:block layout:fragment="scripts">
-  <script th:src="@{/resources/bower_components/livestampjs/livestamp.min.js}"></script>
   <script th:src="@{/resources/bower_components/marked/marked.min.js}"></script>
   <script th:src="@{/resources/bower_components/angular-marked/angular-marked.min.js}"></script>
   <script th:src="@{/dist/js/dashboard.bundle.js}"></script>

--- a/src/main/webapp/pages/samples/_base.html
+++ b/src/main/webapp/pages/samples/_base.html
@@ -66,8 +66,8 @@
                             <i class="fa fa-calendar fa-fw" aria-hidden="true"></i>
                         </div>
                         <div th:text="#{samples.details.modified}">Modified</div>
-                        <div class="sidebar__value" id="sb-modified" data:livestamp="${sample.getModifiedDate()}"
-                             th:title="${#calendars.format(sample.getModifiedDate(), 'dd MMM yyyy')}"></div>
+                        <div class="sidebar__value" id="sb-modified"
+                             th:text="${#calendars.format(sample.getModifiedDate(), 'dd MMM yyyy')}"></div>
                     </div>
                     <div th:if="${sample.isRemote()}" th:with="status=${sample.getRemoteStatus()}">
                         <div class="sidebar__item">
@@ -97,9 +97,6 @@
     </div>
 </div>
 <th:block layout:fragment="page-scripts">
-    <script th:src="@{/resources/bower_components/livestampjs/livestamp.min.js}"
-            src="/resources/bower_components/livestampjs/livestamp.min.js"></script>
-
     <th:block layout:fragment="scripts"></th:block>
 </th:block>
 </body>

--- a/src/main/webapp/pages/sequencingRuns/_details_base.html
+++ b/src/main/webapp/pages/sequencingRuns/_details_base.html
@@ -44,7 +44,7 @@
                         </div>
                     </div>
                     <div class="sidebar__item">
-                        <div class="sidebar__icon"><span class="fa fa-fw fa-calendar-o sidebar__icon"></span></div> <em
+                        <div class="sidebar__icon"><span class="far fa-calendar sidebar__icon"></span></div> <em
                             th:text="#{iridaThing.timestamp}">Created</em> <div id="sb-created"
                             class="sidebar__value" th:text="${#calendars.format(run.getCreatedDate(), 'dd MMM yyyy')}"></div>
                     </div>

--- a/src/main/webapp/resources/js/modules/events/events.js
+++ b/src/main/webapp/resources/js/modules/events/events.js
@@ -4,7 +4,6 @@
  */
 
 import angular from "angular";
-import "@bassettsj/livestamp";
 import "../../../sass/modules/events.scss";
 
 /**

--- a/src/main/webapp/resources/sass/modules/announcements.scss
+++ b/src/main/webapp/resources/sass/modules/announcements.scss
@@ -1,17 +1,12 @@
 .announcement-item {
   display: flex;
-  align-items: center;
 }
 
 .announcement-info {
   width: 120px;
   min-width: 120px;
-  display: flex;
 }
 
-.announcement-icon .fa {
-  font-size: 1.6em;
-}
 .announcement-date {
   display: inline-block;
   flex: 1;

--- a/src/main/webapp/resources/sass/modules/announcements.scss
+++ b/src/main/webapp/resources/sass/modules/announcements.scss
@@ -9,7 +9,7 @@
 
 .announcement-date {
   display: inline-block;
-  flex: 1;
+  flex: 0 0 150px;
   color: #666;
   line-height: 18px;
   font-size: 0.7em;

--- a/src/main/webapp/resources/sass/modules/events.scss
+++ b/src/main/webapp/resources/sass/modules/events.scss
@@ -19,7 +19,7 @@
 }
 .event-date {
   justify-content: flex-end;
-  flex: 0 0 90px;
+  flex: 0 0 150px;
   color: #666;
   font-size: 0.7em;
   text-align: right;

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -735,10 +735,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@bassettsj/livestamp@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@bassettsj/livestamp/-/livestamp-2.0.0.tgz#87640e82bb241b820407fb39275c77436e1bcf85"
-
 "@emotion/is-prop-valid@^0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"


### PR DESCRIPTION
## Description of changes
Removes `livestampjs` as a project dependency.  Anywhere that was using it (announcements and events) have been replaced with a standard date field.

## Related issue
N/A

Depends on PR #408 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
