### PR TITLE
Remove noty from bower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes
 * [UI]: Updated session expiration modal.
 * [UI]: Removed `momentjs` from being loaded on every page.
 * [UI]: Removed `livestampjs` as a project dependency.
+* [UI]: Removed `noty` as a `bower` dependency.
 
 19.01 to 19.05
 ---------------

--- a/src/main/webapp/bower.json
+++ b/src/main/webapp/bower.json
@@ -18,7 +18,6 @@
     "animate.css": "3.4.0",
     "angular-bootstrap": "0.14.3",
     "select2-bootstrap-css": "select2-bootstrap3-css#1.4.6",
-    "noty": "2.3.7",
     "angular-datatables": "~0.5.2",
     "angular-daterangepicker-enhanced": "^0.1.24",
     "lodash": "4.6.1",
@@ -30,7 +29,6 @@
   "devDependencies": {},
   "resolutions": {
     "angular": ">=1.4.0",
-    "moment": "2.15.0",
     "datatables": "^1.10.15",
     "angular-bootstrap": "0.14.3"
   }

--- a/src/main/webapp/pages/sequencingRuns/run_files.html
+++ b/src/main/webapp/pages/sequencingRuns/run_files.html
@@ -49,8 +49,6 @@
 <th:block layout:fragment="scripts" th:inline="javascript">
 	<script th:src="@{/resources/bower_components/datatables/media/js/jquery.dataTables.min.js}"
 	        src="/resources/bower_components/datatables/media/js/jquery.dataTables.min.js"></script>
-	<script th:src="@{/resources/bower_components/noty/js/noty/packaged/jquery.noty.packaged.min.js}"
-	        src="/resources/bower_components/noty/js/noty/packaged/jquery.noty.packaged.min.js"></script>
 	<script>
 		/*<![CDATA[*/
 		$(document).ready(function () {


### PR DESCRIPTION
## Description of changes
Remove noty from bower.  The only page it was loaded on was `run_files.html`.  There is nothing for noty on that page.

## Related issue
N/A

Depends on PR #409 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
