### PR TITLE
Remove unnecessary exists in update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes
 * [UI]: Removed `livestampjs` as a project dependency.
 * [REST]: Changed the URL suffix to analysis output files to be a numerical id instead of a hash key.  Files with a `.` in the name were having issues resolving.  No change in `rel`s so applications should work as usual.
 * [UI]: Removed `noty` as a `bower` dependency.
+* [Developer]: Removed unnecessary `exists` call in `updateFields` method which was causing some hibernate caching issues.
 
 19.01 to 19.05
 ---------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/CRUDServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/CRUDServiceImpl.java
@@ -191,14 +191,8 @@ public class CRUDServiceImpl<KeyType extends Serializable, ValueType extends Tim
 			throw new ConstraintViolationException(constraintViolations);
 		}
 
-		// check if the entity exists in the database
-		if (!exists(id)) {
-			throw new EntityNotFoundException("Entity not found.");
-		}
-
 		// at this point, everything is A-OK, so go through the act of updating
 		// the entity:
-		// return repository.update(id, updatedFields);
 		return repository.save(instance);
 	}
 	

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/user/UserServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/user/UserServiceImplTest.java
@@ -97,7 +97,6 @@ public class UserServiceImplTest {
 		verify(passwordEncoder).encode(password);
 		verify(userRepository).findOne(id);
 		verify(userRepository).save(persisted);
-		verify(userRepository).exists(id);
 	}
 
 	@Test


### PR DESCRIPTION
## Description of changes
Removed an unnecessary `exists` call in `CrudServiceImpl#updateFields`.  The call was there since the time we weren't using reflection or JPA to update the objects.  It was causing some weird Hibernate caching issues when running in a transaction.  It wasn't needed anyway since earlier in the method we were already reading the object so clearly it must exist.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~ Not needed