### PR TITLE
Added link to Galaxy export tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changes
 * [Admin/Documentation]: Added a [Troubleshooting](https://irida.corefacility.ca/documentation/administrator/troubleshooting/pipelines/) guide for troubleshooting common problems with IRIDA Pipelines/Galaxy.
 * [Developer]: Split `ProjectSettingsController` into smaller functional controllers and moved them to a `.settings` subpackage.
 * [UI/Developer]: Allowing any analysis pipeline to be run automatically on data upload.  See <https://irida.corefacility.ca/documentation/user/user/project/#automated-pipelines> for more details.
+* [Documentation]: Added link to Galaxy Export (Import) tool documentation.
 
 19.01 to 19.05
 ---------------

--- a/doc/_includes/tutorials/common/samples/galaxy-export.md
+++ b/doc/_includes/tutorials/common/samples/galaxy-export.md
@@ -1,5 +1,7 @@
 Samples can also be exported directly to Galaxy. Samples exported from IRIDA into Galaxy are loaded into a [Galaxy data library](https://galaxyproject.org/data-libraries/) that can be easily shared with multiple Galaxy users.
 
+*Note: The Galaxy tool being used by this tutorial is located on GitHub <https://github.com/phac-nml/irida-galaxy-importer>. Please see the GitHub page for installation instructions (if the tool is not already installed in your Galaxy instance).*
+
 To export data from IRIDA to Galaxy, start in Galaxy and find the "IRIDA server" tool in the "Get Data" section:
 
 ![IRIDA server import tool.]({{ site.baseurl }}/images/tutorials/common/samples/galaxy-export-inside-galaxy.png)


### PR DESCRIPTION
## Description of changes
Added a link to installation instructions for the Galaxy export (import) tool.

The majority of the documentation is in the tool's github repo (part of PR https://github.com/phac-nml/irida-galaxy-importer/pull/10, direct link to documentation [here](https://github.com/phac-nml/irida-galaxy-importer/blob/b692f8e0c69a2a457fc7198a400a5594595df360/README.md). This just adds a link to the github repo.)

## Related issue
Fixes issue #276 

## Checklist

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* ~[ ] Tests added (or description of how to test) for any new features.~
* [x] User documentation updated for UI or technical changes.
