### PR TITLE
Fix extra / in projects link from projects table

### DIFF
--- a/src/main/webapp/resources/js/pages/projects/list/ProjectsTable.jsx
+++ b/src/main/webapp/resources/js/pages/projects/list/ProjectsTable.jsx
@@ -125,7 +125,7 @@ export function ProjectsTable() {
         ) : null
     },
     {
-      ...nameColumnFormat(`${window.TL.BASE_URL}projects/`),
+      ...nameColumnFormat(`${window.TL.BASE_URL}projects`),
       title: getI18N("ProjectsTable_th_name")
     },
     {


### PR DESCRIPTION
## Description of changes
Removed extra / character in projects link in projects table

Note: Changelog is not updated as this is not currently present in a release.