### PR TITLE
Hotfix - Missing upgrading message

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,7 @@ upgrading IRIDA that cannot be automated.
 
 19.05 to 19.09
 --------------
+* This upgrade makes schema changes to the databases and cannot be parallel deployed.  Servlet container must be stopped before deploying the new `war` file.
 
 19.01 to 19.05
 --------------


### PR DESCRIPTION
## Description of changes
There was no upgrading message in the 19.09 release.  This adds the message about database changes.  Note this needs to be merged into both `development` and `master`.

No tag updates or official releases needed since it's just for display in the repo.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
