### PR TITLE
Fixed default server language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+19.09 to 20.01
+--------------
+* [UI]: Fixed default server language.  It was accidentally set to 'fr' for release.  (19.09.1)
+
 19.05 to 19.09
 ---------------
 * [UI/Developer]: Removed `datatables-bootstrap3-plugin` to remove dependency on outdated `jquery`.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>19.09</version>
+	<version>19.09.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -32,5 +32,5 @@ irida.administrative.notifications.email=ADMIN_EMAIL
 
 irida.scheduled.threads=2
 
-locales.default=fr
+locales.default=en
 locales.enabled=en


### PR DESCRIPTION
## Description of changes
Hotfix to fix the default server language.  It was accidentally released with `fr`.  This wouldn't have seen any user issues since there was no `fr` translation file, except some people may have seen a google translate popup.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
