### PR TITLE
Concatenate zipped fastq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes
 * [UI]: Updated project and global analyses listing pages to use Ant Design tables.
 * [UI]: Updated sequencing runs table to use Ant Design tables.
 * [UI/Developer]: Minor package updates for `babel`, `eslint` and `ant.design`.
+* [API]: Fixed concatenating `.fastq.gz` files from the user interface. 
 
 19.05 to 19.09
 ---------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/ConcatenateException.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/ConcatenateException.java
@@ -3,11 +3,14 @@ package ca.corefacility.bioinformatics.irida.exceptions;
 import ca.corefacility.bioinformatics.irida.processing.concatenate.SequencingObjectConcatenator;
 
 /**
- * Exception thrown when there's an issue with a
- * {@link SequencingObjectConcatenator}
+ * Exception thrown when there's an issue with a {@link SequencingObjectConcatenator}
  */
 public class ConcatenateException extends Exception {
 	public ConcatenateException(String message, Throwable cause) {
 		super(message, cause);
+	}
+
+	public ConcatenateException(String message) {
+		super(message);
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenator.java
@@ -19,6 +19,7 @@ import java.util.Optional;
  * @param <Type> the {@link SequencingObject} class to concatenate
  */
 public abstract class SequencingObjectConcatenator<Type extends SequencingObject> {
+	//Valid extensions to try to concatenate with this tool
 	private static final List<String> VALID_EXTENSIONS = Lists.newArrayList("fastq", "fastq.gz");
 
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenator.java
@@ -1,21 +1,16 @@
 package ca.corefacility.bioinformatics.irida.processing.concatenate;
 
-import java.io.BufferedWriter;
-import java.io.FileReader;
-import java.io.FileWriter;
+import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
+import com.google.common.collect.Lists;
+
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Optional;
-
-import com.google.common.collect.Lists;
-import org.apache.commons.io.IOUtils;
-
-import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 
 /**
  * Class to concatenate multiple {@link SequencingObject}s and return a single new {@link SequencingObject}. This class

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenator.java
@@ -4,9 +4,13 @@ import java.io.BufferedWriter;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Optional;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
 
 import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
@@ -14,50 +18,85 @@ import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 
 /**
- * Class to concatenate multiple {@link SequencingObject}s and return a single
- * new {@link SequencingObject}. This class should be extended by
- * implementations for specific {@link SequencingObject}s
- * 
- * @param <Type>
- *            the {@link SequencingObject} class to concatenate
+ * Class to concatenate multiple {@link SequencingObject}s and return a single new {@link SequencingObject}. This class
+ * should be extended by implementations for specific {@link SequencingObject}s
+ *
+ * @param <Type> the {@link SequencingObject} class to concatenate
  */
 public abstract class SequencingObjectConcatenator<Type extends SequencingObject> {
+	private static final List<String> VALID_EXTENSIONS = Lists.newArrayList("fastq", "fastq.gz");
 
 	/**
 	 * Concatenate a set of {@link SequencingObject}s of a given type
-	 * 
-	 * @param toConcatenate
-	 *            the set of {@link SequencingObject}s to concatenate
-	 * @param filename
-	 *            base name of the new file to create
+	 *
+	 * @param toConcatenate the set of {@link SequencingObject}s to concatenate
+	 * @param filename      base name of the new file to create
 	 * @return the newly created {@link SequencingObject} class
-	 * @throws ConcatenateException
-	 *             if there is an error during concatenation
+	 * @throws ConcatenateException if there is an error during concatenation
 	 */
 	public abstract Type concatenateFiles(List<? extends SequencingObject> toConcatenate, String filename)
 			throws ConcatenateException;
 
 	/**
 	 * Append a {@link SequenceFile} to a {@link Path} on the filesystem
-	 * 
-	 * @param target
-	 *            the {@link Path} to append to
-	 * @param file
-	 *            the {@link SequenceFile} to append to the path
-	 * @throws ConcatenateException
-	 *             if there is an error appending the file
+	 *
+	 * @param target the {@link Path} to append to
+	 * @param file   the {@link SequenceFile} to append to the path
+	 * @throws ConcatenateException if there is an error appending the file
 	 */
 	protected void appendToFile(Path target, SequenceFile file) throws ConcatenateException {
 
-		try (FileWriter fw = new FileWriter(target.toFile(), true);
-				BufferedWriter writer = new BufferedWriter(fw);
-				FileReader reader = new FileReader(file.getFile().toFile())) {
-
-			IOUtils.copy(reader, writer);
+		try (FileChannel out = FileChannel.open(target, StandardOpenOption.CREATE, StandardOpenOption.APPEND,
+				StandardOpenOption.WRITE)) {
+			try (FileChannel in = FileChannel.open(file.getFile(), StandardOpenOption.READ)) {
+				for (long p = 0, l = in.size(); p < l; ) {
+					p += in.transferTo(p, l - p, out);
+				}
+			} catch (IOException e) {
+				throw new ConcatenateException("Could not open input file for reading", e);
+			}
 
 		} catch (IOException e) {
 			throw new ConcatenateException("Could not open target file for writing", e);
 		}
+	}
 
+	/**
+	 * Get the extension of the files to concatenate
+	 *
+	 * @param toConcatenate The list of {@link SequencingObject} to concatenate
+	 * @return The common extension of the files
+	 * @throws ConcatenateException if the files have different or invalid extensions
+	 */
+	protected String getFileExtension(List<? extends SequencingObject> toConcatenate) throws ConcatenateException {
+		String selectedExtension = null;
+		for (SequencingObject object : toConcatenate) {
+
+			for (SequenceFile file : object.getFiles()) {
+				String fileName = file.getFile()
+						.toFile()
+						.getName();
+
+				Optional<String> currentExtensionOpt = VALID_EXTENSIONS.stream()
+						.filter(e -> fileName.endsWith(e))
+						.findFirst();
+
+				if (!currentExtensionOpt.isPresent()) {
+					throw new ConcatenateException("File extension is not valid " + fileName);
+				}
+
+				String currentExtension = currentExtensionOpt.get();
+
+				if (selectedExtension == null) {
+					selectedExtension = currentExtensionOpt.get();
+				} else if (selectedExtension != currentExtensionOpt.get()) {
+					throw new ConcatenateException(
+							"Extensions of files to concatenate do not match " + currentExtension + " vs "
+									+ selectedExtension);
+				}
+			}
+		}
+
+		return selectedExtension;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SequenceFilePairConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SequenceFilePairConcatenator.java
@@ -4,18 +4,21 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 import ca.corefacility.bioinformatics.irida.processing.concatenate.SequencingObjectConcatenator;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.FilenameUtils;
 
 /**
  * {@link SequencingObjectConcatenator} for {@link SequenceFilePair}s
  */
 public class SequenceFilePairConcatenator extends SequencingObjectConcatenator<SequenceFilePair> {
-
+	
 	public SequenceFilePairConcatenator() {
 	}
 
@@ -26,9 +29,11 @@ public class SequenceFilePairConcatenator extends SequencingObjectConcatenator<S
 	public SequenceFilePair concatenateFiles(List<? extends SequencingObject> toConcatenate, String filename)
 			throws ConcatenateException {
 
+		String extension = getFileExtension(toConcatenate);
+
 		// create the filenames with F/R for the forward and reverse files
-		String forwardName = filename + "_R1.fastq";
-		String reverseName = filename + "_R2.fastq";
+		String forwardName = filename + "_R1." + extension;
+		String reverseName = filename + "_R2." + extension;
 
 		Path forwardFile;
 		Path reverseFile;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SequenceFilePairConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SequenceFilePairConcatenator.java
@@ -1,18 +1,15 @@
 package ca.corefacility.bioinformatics.irida.processing.concatenate.impl;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
-
 import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 import ca.corefacility.bioinformatics.irida.processing.concatenate.SequencingObjectConcatenator;
-import com.google.common.collect.Lists;
-import org.apache.commons.io.FilenameUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 /**
  * {@link SequencingObjectConcatenator} for {@link SequenceFilePair}s

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenator.java
@@ -27,8 +27,10 @@ public class SingleEndSequenceFileConcatenator extends SequencingObjectConcatena
 			throws ConcatenateException {
 		Path tempFile;
 
+		String extension = getFileExtension(toConcatenate);
+
 		// create the filename with extension
-		filename = filename + ".fastq";
+		filename = filename + "." + extension;
 		try {
 			// create a temp directory and temp file
 			Path tempDirectory = Files.createTempDirectory(null);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenator.java
@@ -1,15 +1,15 @@
 package ca.corefacility.bioinformatics.irida.processing.concatenate.impl;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
 import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
 import ca.corefacility.bioinformatics.irida.processing.concatenate.SequencingObjectConcatenator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 
 /**
  * {@link SequenceFilePairConcatenator} for {@link SingleEndSequenceFile}s

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenatorFactoryTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/SequencingObjectConcatenatorFactoryTest.java
@@ -1,18 +1,16 @@
 package ca.corefacility.bioinformatics.irida.processing.concatenate;
 
-import static org.junit.Assert.assertTrue;
-
-import java.util.Set;
-
-import org.junit.Test;
-
-import com.google.common.collect.Sets;
-
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
 import ca.corefacility.bioinformatics.irida.processing.concatenate.impl.SequenceFilePairConcatenator;
 import ca.corefacility.bioinformatics.irida.processing.concatenate.impl.SingleEndSequenceFileConcatenator;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit test for {@link SequencingObjectConcatenatorFactory}
@@ -20,15 +18,15 @@ import ca.corefacility.bioinformatics.irida.processing.concatenate.impl.SingleEn
 public class SequencingObjectConcatenatorFactoryTest {
 	@Test
 	public void testGetConcatenatorSingle() {
-		SequencingObjectConcatenator<SingleEndSequenceFile> concatenator = SequencingObjectConcatenatorFactory
-				.getConcatenator(SingleEndSequenceFile.class);
+		SequencingObjectConcatenator<SingleEndSequenceFile> concatenator = SequencingObjectConcatenatorFactory.getConcatenator(
+				SingleEndSequenceFile.class);
 		assertTrue(concatenator instanceof SingleEndSequenceFileConcatenator);
 	}
 
 	@Test
 	public void testGetConcatenatorPair() {
-		SequencingObjectConcatenator<SequenceFilePair> concatenator = SequencingObjectConcatenatorFactory
-				.getConcatenator(SequenceFilePair.class);
+		SequencingObjectConcatenator<SequenceFilePair> concatenator = SequencingObjectConcatenatorFactory.getConcatenator(
+				SequenceFilePair.class);
 		assertTrue(concatenator instanceof SequenceFilePairConcatenator);
 	}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SequenceFilePairConcatenatorTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SequenceFilePairConcatenatorTest.java
@@ -1,20 +1,18 @@
 package ca.corefacility.bioinformatics.irida.processing.concatenate.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import com.google.common.collect.Lists;
-
-import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SequenceFilePairConcatenatorTest {
 	private static final String SEQUENCE = "ACGTACGTN";
@@ -38,7 +36,9 @@ public class SequenceFilePairConcatenatorTest {
 		SequenceFile original3 = createSequenceFile("testFile2_F");
 		SequenceFile original4 = createSequenceFile("testFile2_R");
 
-		long originalLength = original1.getFile().toFile().length();
+		long originalLength = original1.getFile()
+				.toFile()
+				.length();
 
 		SequenceFilePair f1 = new SequenceFilePair(original1, original2);
 		SequenceFilePair f2 = new SequenceFilePair(original3, original4);
@@ -51,7 +51,9 @@ public class SequenceFilePairConcatenatorTest {
 		assertTrue("file exists", Files.exists(forward.getFile()));
 		assertTrue("file exists", Files.exists(reverse.getFile()));
 
-		long newFileSize = forward.getFile().toFile().length();
+		long newFileSize = forward.getFile()
+				.toFile()
+				.length();
 
 		assertEquals("new file should be 2x size of originals", originalLength * 2, newFileSize);
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenatorTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenatorTest.java
@@ -1,20 +1,18 @@
 package ca.corefacility.bioinformatics.irida.processing.concatenate.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
+import com.google.common.collect.Lists;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import com.google.common.collect.Lists;
-
-import ca.corefacility.bioinformatics.irida.exceptions.ConcatenateException;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SingleEndSequenceFileConcatenatorTest {
 	private static final String SEQUENCE = "ACGTACGTN";

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenatorTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/concatenate/impl/SingleEndSequenceFileConcatenatorTest.java
@@ -32,10 +32,12 @@ public class SingleEndSequenceFileConcatenatorTest {
 	public void testConcatenateFiles() throws IOException, ConcatenateException {
 		String newFileName = "newFile";
 
-		SequenceFile original1 = createSequenceFile("testFile");
-		SequenceFile original2 = createSequenceFile("testFile2");
+		SequenceFile original1 = createSequenceFile("testFile", ".fastq");
+		SequenceFile original2 = createSequenceFile("testFile2", ".fastq");
 
-		long originalLength = original1.getFile().toFile().length();
+		long originalLength = original1.getFile()
+				.toFile()
+				.length();
 
 		SingleEndSequenceFile f1 = new SingleEndSequenceFile(original1);
 		SingleEndSequenceFile f2 = new SingleEndSequenceFile(original2);
@@ -46,14 +48,68 @@ public class SingleEndSequenceFileConcatenatorTest {
 
 		assertTrue("file exists", Files.exists(newSeqFile.getFile()));
 
-		long newFileSize = newSeqFile.getFile().toFile().length();
+		long newFileSize = newSeqFile.getFile()
+				.toFile()
+				.length();
 
 		assertEquals("new file should be 2x size of originals", originalLength * 2, newFileSize);
-
 	}
 
-	private SequenceFile createSequenceFile(String name) throws IOException {
-		Path sequenceFile = Files.createTempFile(name, ".fastq");
+	@Test
+	public void testConcatenateFilesZipped() throws IOException, ConcatenateException {
+		String newFileName = "newFile";
+
+		SequenceFile original1 = createSequenceFile("testFile", ".fastq.gz");
+		SequenceFile original2 = createSequenceFile("testFile2", ".fastq.gz");
+
+		long originalLength = original1.getFile()
+				.toFile()
+				.length();
+
+		SingleEndSequenceFile f1 = new SingleEndSequenceFile(original1);
+		SingleEndSequenceFile f2 = new SingleEndSequenceFile(original2);
+
+		SingleEndSequenceFile concatenateFiles = concat.concatenateFiles(Lists.newArrayList(f1, f2), newFileName);
+
+		SequenceFile newSeqFile = concatenateFiles.getSequenceFile();
+
+		assertTrue("file exists", Files.exists(newSeqFile.getFile()));
+
+		long newFileSize = newSeqFile.getFile()
+				.toFile()
+				.length();
+
+		assertEquals("new file should be 2x size of originals", originalLength * 2, newFileSize);
+	}
+
+	@Test(expected = ConcatenateException.class)
+	public void testConcatenateDifferentFileTypes() throws IOException, ConcatenateException {
+		String newFileName = "newFile";
+
+		SequenceFile original1 = createSequenceFile("testFile", ".fastq");
+		SequenceFile original2 = createSequenceFile("testFile2", ".fastq.gz");
+
+		SingleEndSequenceFile f1 = new SingleEndSequenceFile(original1);
+		SingleEndSequenceFile f2 = new SingleEndSequenceFile(original2);
+
+		SingleEndSequenceFile concatenateFiles = concat.concatenateFiles(Lists.newArrayList(f1, f2), newFileName);
+	}
+
+	@Test(expected = ConcatenateException.class)
+	public void testConcatenateBadExtension() throws IOException, ConcatenateException {
+		String newFileName = "newFile";
+
+		SequenceFile original1 = createSequenceFile("testFile", ".something");
+		SequenceFile original2 = createSequenceFile("testFile2", ".something");
+
+		SingleEndSequenceFile f1 = new SingleEndSequenceFile(original1);
+		SingleEndSequenceFile f2 = new SingleEndSequenceFile(original2);
+
+		SingleEndSequenceFile concatenateFiles = concat.concatenateFiles(Lists.newArrayList(f1, f2), newFileName);
+	}
+
+	private SequenceFile createSequenceFile(String name, String extension) throws IOException {
+		Path sequenceFile = Files.createTempFile(name, extension);
 		Files.write(sequenceFile, FASTQ_FILE_CONTENTS);
 
 		return new SequenceFile(sequenceFile);


### PR DESCRIPTION
## Description of changes
Fixed the file concatenation methods to work with `.fastq.gz` data.  Previously the file extension was hardcoded as `.fastq` so the file processing would fail.  Also the method we were using to concatenate the files didn't work with gzipped data.

To test, upload multiple files to a sample, wait for them to file process, then concatenate from the sample/files page.  Then change the `file.processing.decompress=` value in your `/etc/irida/irida.conf` file and try the same again.

## Related issue
Fixes #481 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
