### PR TITLE
Fixed issue with "Let the pipeline run" button not working.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes
 * [UI]: Updated project and global analyses listing pages to use Ant Design tables.
 * [UI]: Updated sequencing runs table to use Ant Design tables.
 * [UI/Developer]: Minor package updates for `babel`, `eslint` and `ant.design`.
+* [UI]: Fixed bug where `Let the Pipeline Run` button failed to empty the cart and redirect the user to the projects page.
 
 19.05 to 19.09
 ---------------

--- a/src/main/webapp/resources/js/modules/cart/irida.cart.js
+++ b/src/main/webapp/resources/js/modules/cart/irida.cart.js
@@ -1,6 +1,6 @@
 import angular from "angular";
 import { CART } from "../../utilities/events-utilities";
-import { removeSample } from "../../apis/cart/cart";
+import { emptyCart, removeSample } from "../../apis/cart/cart";
 
 function CartService(scope, $http) {
   const svc = this;
@@ -9,8 +9,7 @@ function CartService(scope, $http) {
   };
 
   svc.clear = function() {
-    //fire a DELETE to the server on the cart then broadcast the cart update event
-    return $http.delete(urls.all).then(function() {
+    return emptyCart().then(() => {
       const event = new Event(CART.UPDATED);
       document.dispatchEvent(event);
     });

--- a/src/main/webapp/resources/js/pages/pipelines/pipeline.launch.js
+++ b/src/main/webapp/resources/js/pages/pipelines/pipeline.launch.js
@@ -311,10 +311,7 @@
      * Clear the cart and redirect to the projects page
      */
     vm.clearAndRedirect = function() {
-      var clearPromise = CartService.clear();
-
-      // after the cart is cleared, redirect the browser
-      clearPromise.then(function() {
+      CartService.clear().then(function() {
         window.location = page.urls.projectsPage;
       });
     };


### PR DESCRIPTION
## Description of changes
Fixes issue where once a pipeline was kicked off, the "Let the pipeline run" button was not working.  It was supposed to empty the cart and redirect the browser to the projects listing page.  This broke during the cart refactor.

## Related issue
Fixes #411 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
