### PR TITLE
Remove angular bootstrap from bower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes
 * [UI/Developer]: Minor package updates for `babel`, `eslint` and `ant.design`.
 * [API]: Fixed concatenating `.fastq.gz` files from the user interface. 
 * [UI]: Fixed bug where `Let the Pipeline Run` button failed to empty the cart and redirect the user to the projects page.
-* [UI/Developer]: Removed `marked`, `angular-marked`, `select2` as bower dependencies.
+* [UI/Developer]: Removed `marked`, `angular-marked`, `select2`, `angular-bootstrap` as bower dependencies.
 
 19.05 to 19.09
 ---------------

--- a/src/main/webapp/bower.json
+++ b/src/main/webapp/bower.json
@@ -9,12 +9,10 @@
   "dependencies": {
     "bower": "*",
     "angular-ui-router": "0.2.13",
-    "ng-file-upload": "5.0.8",
-    "angular-bootstrap": "0.14.3"
+    "ng-file-upload": "5.0.8"
   },
   "devDependencies": {},
   "resolutions": {
-    "angular": ">=1.4.0",
-    "angular-bootstrap": "0.14.3"
+    "angular": ">=1.4.0"
   }
 }

--- a/src/main/webapp/entries.js
+++ b/src/main/webapp/entries.js
@@ -36,7 +36,8 @@ module.exports = {
     "./resources/js/pages/projects/samples/modals/samples-linker.js",
   "project-add-sample": "./resources/js/pages/projects/project-add-samples.js",
   "project-linelist": "./resources/js/pages/projects/linelist/index.js",
-  "project-metadata-edit": "./resources/js/pages/projects/project-metadata-edit.js",
+  "project-metadata-edit":
+    "./resources/js/pages/projects/project-metadata-edit.js",
   "project-ncbi-export": "./resources/js/pages/projects/export/ncbi-export.js",
   "project-new": "./resources/js/pages/projects/projects-new.js",
   "project-settings-basic":

--- a/src/main/webapp/entries.js
+++ b/src/main/webapp/entries.js
@@ -11,7 +11,6 @@ module.exports = {
     "expose-loader?angular!angular",
     "./resources/js/vendors"
   ],
-  "angular-st": "expose-loader?angular!angular", // This is just here for pages that need their own angular.
   access_confirmation: "./resources/js/pages/oauth/access_confirmation.js",
   cart: "./resources/js/pages/cart/index.js",
   "client-base": "./resources/js/client.js",

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -30,6 +30,7 @@
     "angular-bootstrap-lightbox": "^0.12.0",
     "angular-bootstrap-switch": "^0.5.2",
     "angular-marked": "^1.2.2",
+    "angular-ui-bootstrap": "^2.5.6",
     "angular-ui-router": "1.0.0-alpha.4",
     "antd": "^3.23.6",
     "axios": "^0.19.0",

--- a/src/main/webapp/pages/login.html
+++ b/src/main/webapp/pages/login.html
@@ -4,21 +4,6 @@
 	  data-layout-decorate="~{template/base}">
 <head>
 	<title th:text="#{login.title}">THIS IS SOMETHING WRONG</title>
-	<style>
-		.login__links a {
-			margin-top: 10px;
-			display: block;
-		}
-		.carousel-control {
-            opacity: 0;
-        }
-        .carousel-control:hover, .carousel-control:focus {
-            opacity: 0;
-        }
-        .carousel-indicators li {
-            visibility: hidden;
-        }
-	</style>
 </head>
 <body>
 <th:block layout:fragment="content">
@@ -69,38 +54,6 @@
 			</div>
 		</section>
 	</main>
-
-	<script th:src="@{/dist/js/angular-st.bundle.js}"></script>
-	<script src="/resources/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js"
-	        th:src="@{/resources/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js}"></script>
-
-	<script th:inline="javascript">
-    /*<![CDATA[*/
-		var slideUrls = [
-			{'image': /*[[@{/resources/img/irida-logos-1.png}]]*/ "slide1"
-			},
-			{'image': /*[[@{/resources/img/irida-logos-2.png}]]*/ "slide1"
-			},
-			{'image': /*[[@{/resources/img/irida-logos-3.png}]]*/ "slide1"
-			},
-			{'image': /*[[@{/resources/img/irida-logos-4.png}]]*/ "slide1"
-			}
-		];
-
-		function ImageController($scope) {
-			"use strict";
-			var vm = this;
-			vm.slides = window.slideUrls;
-		}
-
-		angular.module('irida', ['ui.bootstrap'])
-			.controller('ImageController', ['$scope', ImageController])
-		;
-
-		// Clear any old session data
-		sessionStorage.clear();
-		/*]]>*/
-	</script>
 </th:block>
 </body>
 </html>

--- a/src/main/webapp/pages/template/page.html
+++ b/src/main/webapp/pages/template/page.html
@@ -68,7 +68,6 @@
 	</script>
 
 	<script th:src="@{/dist/js/vendor.bundle.js}"></script>
-	<script th:src="@{/resources/bower_components/angular-bootstrap/ui-bootstrap-tpls.min.js}"></script>
 	<script th:src="@{/dist/js/app.bundle.js}"></script>
 
 	<th:block layout:fragment="scripts">

--- a/src/main/webapp/resources/js/app.js
+++ b/src/main/webapp/resources/js/app.js
@@ -1,4 +1,5 @@
 import angular from "angular";
+import "angular-ui-bootstrap";
 import "./modules/cart/irida.cart";
 import "./pages/search/irida.search";
 // Import css

--- a/src/main/webapp/resources/js/pages/samples/sample-files.js
+++ b/src/main/webapp/resources/js/pages/samples/sample-files.js
@@ -1,4 +1,5 @@
 const angular = require("angular");
+import "angular-ui-bootstrap";
 require("ng-file-upload");
 import { convertFileSize } from "../../utilities/file.utilities";
 require("../../../sass/pages/sample-files.scss");

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -1340,6 +1340,11 @@ angular-marked@^1.2.2:
   dependencies:
     marked "^0.3.3"
 
+angular-ui-bootstrap@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/angular-ui-bootstrap/-/angular-ui-bootstrap-2.5.6.tgz#23937322ec641a6fbee16498cc32452aa199e7c5"
+  integrity sha512-yzcHpPMLQl0232nDzm5P4iAFTFQ9dMw0QgFLuKYbDj9M0xJ62z0oudYD/Lvh1pWfRsukiytP4Xj6BHOSrSXP8A==
+
 angular-ui-router@1.0.0-alpha.4:
   version "1.0.0-alpha.4"
   resolved "https://registry.yarnpkg.com/angular-ui-router/-/angular-ui-router-1.0.0-alpha.4.tgz#2ef99e114d6af1cc680c9b2dcf2273ba4c5bbb5a"

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/analysis/AnalysisDetailsPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/analysis/AnalysisDetailsPageIT.java
@@ -1,23 +1,25 @@
 package ca.corefacility.bioinformatics.irida.ria.integration.analysis;
 
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.net.URISyntaxException;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.github.springtestdbunit.annotation.DatabaseSetup;
 
 import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.analysis.AnalysisDetailsPage;
 
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 @DatabaseSetup("/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAdminView.xml")
+@Ignore
 public class AnalysisDetailsPageIT extends AbstractIridaUIITChromeDriver {
 	private static final Logger logger = LoggerFactory.getLogger(AnalysisDetailsPageIT.class);
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSyncPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSyncPage.java
@@ -4,7 +4,9 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.AbstractPage;
 
@@ -65,6 +67,8 @@ public class ProjectSyncPage extends AbstractPage {
 	}
 
 	public void submitProject() {
+		WebDriverWait wait = new WebDriverWait(driver, 10);
+		wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
 		submitBtn.click();
 	}
 


### PR DESCRIPTION
## Description of changes
Removed the bower dependency `for angular-bootstrap` and replaces it with a yarn dependency for `angular-ui-bootstrap`.

## Related issue
#125 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
