### PR TITLE
Fixed issue where cart page does not display at full height.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes
 19.09 to 20.01
 --------------
 * [UI]: Fixed default server language.  It was accidentally set to 'fr' for release.  (19.09.1)
+* [UI]: Fixed issue where issue where cart is not rendering to the full height of the page. (19.09.2 )
 
 19.05 to 19.09
 ---------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>19.09.1</version>
+	<version>19.09.2</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/pages/cart.html
+++ b/src/main/webapp/pages/cart.html
@@ -43,7 +43,7 @@
     </script>
   </head>
   <body>
-    <div id="root" style="height: 100%;" layout:fragment="page">
+    <div id="root" style="align-items: stretch; flex-grow: 1; display: flex;" layout:fragment="page">
     <!--
        This is a DOM element for React to render the full cart experience into.
        See  src/main/webapp/resources/js/pages/cart/components/Cart.jsx

--- a/src/main/webapp/pages/template/page.html
+++ b/src/main/webapp/pages/template/page.html
@@ -23,7 +23,7 @@
 			</ol>
 		</div>
 	</div>
-	<div class="container-fluid body-content">
+	<div class="container-fluid body-content" style="display: flex; flex-direction: column;">
 		<div class="row" layout:fragment="page"></div>
 	</div>
 

--- a/src/main/webapp/resources/js/pages/cart/components/Cart.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/Cart.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useState, useEffect } from "react";
+import React, { lazy, Suspense, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { Layout } from "antd";
@@ -23,7 +23,7 @@ function CartComponent({ count = 0, loadCart }) {
   const toggleSidebar = () => setCollapsed(!collapsed);
 
   return (
-    <Content style={{ display: "flex", height: "100%" }}>
+    <Content style={{ display: "flex", alignItems: "stretch" }}>
       <Content style={{ flexGrow: 1 }}>
         <Suspense fallback={<div />}>
           <CartTools


### PR DESCRIPTION
## Description of changes
Issue report by Nabil on Gitter, where the cart page does not render at full height.

Before:
 
![Screen Shot 2019-10-22 at 11 11 26 AM](https://user-images.githubusercontent.com/11295750/67306529-bccb9b80-f4bc-11e9-8c94-62392266a6d6.png)

After:

![Screen Shot 2019-10-22 at 11 09 32 AM](https://user-images.githubusercontent.com/11295750/67306541-c2c17c80-f4bc-11e9-93b9-e561ec36283a.png)

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
