### PR TITLE
Fix galaxy create collection checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes
 * [UI]: Fixed issue where grant types, and refresh token validity would not populate correctly on client edit form.
 * [UI]: Fixed issue where hidden portions of client edit and creation form would not toggle correctly.
 * [UI/Developer]: Removed `marked`, `angular-marked`, `select2` as bower dependencies.
+* [UI]: Fixed bug where the "Automatically  create collection" could not be unchecked when exporting to Galaxy.
 
 19.05 to 19.09
 ---------------

--- a/src/main/webapp/resources/js/components/galaxy/GalaxyApp.jsx
+++ b/src/main/webapp/resources/js/components/galaxy/GalaxyApp.jsx
@@ -1,12 +1,7 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { GalaxyStateProvider } from "./GalaxyState";
 import { initialState, reducer } from "./reducer";
-import {
-  Card,
-  Col,
-  Row
-} from "antd";
+import { Card, Col, Row } from "antd";
 import { GalaxyDetailsForm } from "./GalaxyDetailsForm";
 import { GalaxySamples } from "./GalaxySamples";
 import { GalaxySubmitError } from "./GalaxySubmitError";

--- a/src/main/webapp/resources/js/components/galaxy/GalaxyDetailsForm.jsx
+++ b/src/main/webapp/resources/js/components/galaxy/GalaxyDetailsForm.jsx
@@ -7,10 +7,6 @@ import { FONT_WEIGHT_HEAVY } from "../../styles/fonts";
 
 /**
  * Component to display a form containing all required and user modifiable fields.
- * @param {string} email - email for galaxy
- * @param  {boolean} makepairedcollection - whether to organize data into a library
- * @param {function} updateEmail - handles updates to the email address
- * @param {function} updateMakePairedCollection - handles update to makepairedcollection
  * @returns {*}
  */
 export function GalaxyDetailsForm() {
@@ -19,7 +15,8 @@ export function GalaxyDetailsForm() {
   const emailModified = e => dispatch(actions.setEmail(e.target.value));
 
   const makePairedCollectionModified = e =>
-    updateMakePairedCollection(e.target.checked);
+    dispatch(actions.setMakePairedCollection(e.target.checked));
+
 
 
   const galaxyUrl = window


### PR DESCRIPTION
## Description of changes
Fixed issue from Matt Walker where the checkbox to "Automatically create collection" could not be unchecked.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
