### PR TITLE
Changed NCBI export collections to sets

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/export/NcbiBioSampleFiles.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/export/NcbiBioSampleFiles.java
@@ -1,24 +1,17 @@
 package ca.corefacility.bioinformatics.irida.model.export;
 
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
-import javax.persistence.*;
-
-import com.google.common.collect.Sets;
-import org.hibernate.annotations.LazyCollection;
-import org.hibernate.annotations.LazyCollectionOption;
-import org.hibernate.envers.Audited;
-
 import ca.corefacility.bioinformatics.irida.model.NcbiExportSubmission;
 import ca.corefacility.bioinformatics.irida.model.enums.ExportUploadState;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.hibernate.envers.Audited;
+
+import javax.persistence.*;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * {@link SequenceFile}s and {@link SequenceFilePair}s associated with a
@@ -37,15 +30,13 @@ public class NcbiBioSampleFiles {
 	private String bioSample;
 
 	@JsonIgnore
-	@ManyToMany()
+	@ManyToMany(fetch = FetchType.EAGER)
 	@JoinTable(joinColumns = @JoinColumn(name = "ncbi_export_biosample_id"))
-	@LazyCollection(LazyCollectionOption.FALSE)
 	private Set<SingleEndSequenceFile> files;
 
 	@JsonIgnore
-	@ManyToMany()
+	@ManyToMany(fetch = FetchType.EAGER)
 	@JoinTable(joinColumns = @JoinColumn(name = "ncbi_export_biosample_id"))
-	@LazyCollection(LazyCollectionOption.FALSE)
 	private Set<SequenceFilePair> pairs;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/export/NcbiBioSampleFiles.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/export/NcbiBioSampleFiles.java
@@ -1,10 +1,12 @@
 package ca.corefacility.bioinformatics.irida.model.export;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.persistence.*;
 
+import com.google.common.collect.Sets;
 import org.hibernate.annotations.LazyCollection;
 import org.hibernate.annotations.LazyCollectionOption;
 import org.hibernate.envers.Audited;
@@ -38,13 +40,13 @@ public class NcbiBioSampleFiles {
 	@ManyToMany()
 	@JoinTable(joinColumns = @JoinColumn(name = "ncbi_export_biosample_id"))
 	@LazyCollection(LazyCollectionOption.FALSE)
-	private List<SingleEndSequenceFile> files;
+	private Set<SingleEndSequenceFile> files;
 
 	@JsonIgnore
 	@ManyToMany()
 	@JoinTable(joinColumns = @JoinColumn(name = "ncbi_export_biosample_id"))
 	@LazyCollection(LazyCollectionOption.FALSE)
-	private List<SequenceFilePair> pairs;
+	private Set<SequenceFilePair> pairs;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "instrument_model")
@@ -76,8 +78,8 @@ public class NcbiBioSampleFiles {
 	private String accession;
 
 	public NcbiBioSampleFiles() {
-		files = Lists.newArrayList();
-		pairs = Lists.newArrayList();
+		files = Sets.newHashSet();
+		pairs = Sets.newHashSet();
 		submissionStatus = ExportUploadState.NEW;
 	}
 
@@ -90,7 +92,7 @@ public class NcbiBioSampleFiles {
 
 	}
 
-	public NcbiBioSampleFiles(String bioSample, List<SingleEndSequenceFile> files, List<SequenceFilePair> pairs,
+	public NcbiBioSampleFiles(String bioSample, Set<SingleEndSequenceFile> files, Set<SequenceFilePair> pairs,
 			NcbiInstrumentModel instrument_model, String library_name, NcbiLibrarySelection library_selection,
 			NcbiLibrarySource library_source, NcbiLibraryStrategy library_strategy,
 			String library_construction_protocol, String namespace) {
@@ -112,8 +114,8 @@ public class NcbiBioSampleFiles {
 	public static class Builder {
 		private String bioSample;
 
-		private List<SingleEndSequenceFile> files;
-		private List<SequenceFilePair> pairs;
+		private Set<SingleEndSequenceFile> files;
+		private Set<SequenceFilePair> pairs;
 		private NcbiInstrumentModel instrumentModel;
 		private String libraryName;
 		private NcbiLibrarySelection librarySelection;
@@ -128,7 +130,7 @@ public class NcbiBioSampleFiles {
 		 * @param files the single end files
 		 * @return the builder
 		 */
-		public Builder files(List<SingleEndSequenceFile> files) {
+		public Builder files(Set<SingleEndSequenceFile> files) {
 			this.files = files;
 			return this;
 		}
@@ -138,7 +140,7 @@ public class NcbiBioSampleFiles {
 		 * @param pairs the file pairs
 		 * @return the builder
 		 */
-		public Builder pairs(List<SequenceFilePair> pairs) {
+		public Builder pairs(Set<SequenceFilePair> pairs) {
 			this.pairs = pairs;
 			return this;
 		}
@@ -253,7 +255,7 @@ public class NcbiBioSampleFiles {
 		return bioSample;
 	}
 
-	public List<SingleEndSequenceFile> getFiles() {
+	public Set<SingleEndSequenceFile> getFiles() {
 		return files;
 	}
 
@@ -265,15 +267,15 @@ public class NcbiBioSampleFiles {
 		this.id = id;
 	}
 
-	public List<SequenceFilePair> getPairs() {
+	public Set<SequenceFilePair> getPairs() {
 		return pairs;
 	}
 
-	public void setFiles(List<SingleEndSequenceFile> files) {
+	public void setFiles(Set<SingleEndSequenceFile> files) {
 		this.files = files;
 	}
 
-	public void setPairs(List<SequenceFilePair> pairs) {
+	public void setPairs(Set<SequenceFilePair> pairs) {
 		this.pairs = pairs;
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectExportController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectExportController.java
@@ -192,11 +192,11 @@ public class ProjectExportController {
 		List<NcbiBioSampleFiles> bioSampleFiles = new ArrayList<>();
 
 		for (BioSampleBody sample : submission.getSamples()) {
-			List<SingleEndSequenceFile> singleFiles = new ArrayList<>();
+			Set<SingleEndSequenceFile> singleFiles = new HashSet<>();
 			sequencingObjectService.readMultiple(sample.getSingle()).forEach(
 					f -> singleFiles.add((SingleEndSequenceFile) f));
 
-			List<SequenceFilePair> paired = new ArrayList<>();
+			HashSet<SequenceFilePair> paired = new HashSet<>();
 			sequencingObjectService.readMultiple(sample.getPaired()).forEach(f -> paired.add((SequenceFilePair) f));
 
 			Builder sampleBuilder = new NcbiBioSampleFiles.Builder();

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/AnnouncementServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/AnnouncementServiceImpl.java
@@ -100,8 +100,6 @@ public class AnnouncementServiceImpl extends CRUDServiceImpl<Long, Announcement>
 
     /**
      * {@inheritDoc}
-	 * @param specification
-	 * @param request
 	 */
     @Override
     @Transactional

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/CRUDServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/CRUDServiceImpl.java
@@ -254,8 +254,6 @@ public class CRUDServiceImpl<KeyType extends Serializable, ValueType extends Tim
 
 	/**
 	 * {@inheritDoc}
-	 * @param specification
-	 * @param pageRequest
 	 */
 	@Override
 	@Transactional(readOnly = true)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/IridaClientDetailsServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/IridaClientDetailsServiceImpl.java
@@ -48,8 +48,6 @@ public class IridaClientDetailsServiceImpl extends CRUDServiceImpl<Long, IridaCl
 
 	/**
 	 * {@inheritDoc}
-	 * @param specification
-	 * @param pageRequest
 	 */
 	@Override
 	@PreAuthorize("permitAll()")

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/user/UserGroupServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/user/UserGroupServiceImpl.java
@@ -333,8 +333,6 @@ public class UserGroupServiceImpl extends CRUDServiceImpl<Long, UserGroup> imple
 
 	/**
 	 * {@inheritDoc}
-	 * @param specification
-	 * @param pageRequest
 	 */
 	@Override
 	@PreAuthorize("hasRole('ROLE_USER')")

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/export/ExportUploadServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/export/ExportUploadServiceTest.java
@@ -15,6 +15,7 @@ import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateServi
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.junit.Test;
 import org.mockftpserver.fake.FakeFtpServer;
 import org.mockftpserver.fake.UserAccount;
@@ -236,7 +237,7 @@ public class ExportUploadServiceTest {
 		Sample iridaSample = new Sample("sample1");
 		NcbiBioSampleFiles sample2 = new NcbiBioSampleFiles();
 		sample2.setId("NMLTEST2");
-		sample2.setFiles(Lists.newArrayList(seqObject));
+		sample2.setFiles(Sets.newHashSet(seqObject));
 		NcbiExportSubmission submission = new NcbiExportSubmission();
 		submission.setBioSampleFiles(Lists.newArrayList(sample2));
 		submission.setDirectoryPath("submit/Test/example");
@@ -321,7 +322,7 @@ public class ExportUploadServiceTest {
 		sequenceFile.setId(1L);
 		SingleEndSequenceFile singleFile = new SingleEndSequenceFile(sequenceFile);
 		singleFile.setId(1L);
-		ncbiBioSampleFiles.setFiles(Lists.newArrayList(singleFile));
+		ncbiBioSampleFiles.setFiles(Sets.newHashSet(singleFile));
 
 		submission.setBioSampleFiles(Lists.newArrayList(ncbiBioSampleFiles));
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/export/NcbiExportSubmissionServceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/export/NcbiExportSubmissionServceTest.java
@@ -7,6 +7,7 @@ import java.util.Date;
 
 import javax.validation.Validator;
 
+import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,8 +42,8 @@ public class NcbiExportSubmissionServceTest {
 	public void testCreate() {
 		SingleEndSequenceFile sequenceFile = new SingleEndSequenceFile(new SequenceFile());
 
-		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Lists.newArrayList(sequenceFile),
-				Lists.newArrayList(), null, "library_name", null, null, null, "library_construction_protocol",
+		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Sets.newHashSet(sequenceFile),
+				Sets.newHashSet(), null, "library_name", null, null, null, "library_construction_protocol",
 				"namespace");
 		NcbiExportSubmission submission = new NcbiExportSubmission(null, null, "bioProjectId", "organization",
 				"ncbiNamespace", new Date(), Lists.newArrayList(ncbiBioSampleFiles));
@@ -56,8 +57,8 @@ public class NcbiExportSubmissionServceTest {
 	public void testCreatePairs() {
 		SequenceFile sequenceFile = new SequenceFile();
 
-		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Lists.newArrayList(),
-				Lists.newArrayList(new SequenceFilePair(sequenceFile, sequenceFile)), null, "library_name", null, null,
+		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Sets.newHashSet(),
+				Sets.newHashSet(new SequenceFilePair(sequenceFile, sequenceFile)), null, "library_name", null, null,
 				null, "library_construction_protocol", "namespace");
 		NcbiExportSubmission submission = new NcbiExportSubmission(null, null, "bioProjectId", "organization",
 				"ncbiNamespace", new Date(), Lists.newArrayList(ncbiBioSampleFiles));
@@ -70,8 +71,8 @@ public class NcbiExportSubmissionServceTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreateNoFiles() {
 
-		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Lists.newArrayList(),
-				Lists.newArrayList(), null, "library_name", null, null, null, "library_construction_protocol",
+		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Sets.newHashSet(),
+				Sets.newHashSet(), null, "library_name", null, null, null, "library_construction_protocol",
 				"namespace");
 		NcbiExportSubmission submission = new NcbiExportSubmission(null, null, "bioProjectId", "organization",
 				"ncbiNamespace", new Date(), Lists.newArrayList(ncbiBioSampleFiles));

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/export/NcbiExportSubmissionServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/export/NcbiExportSubmissionServiceTest.java
@@ -1,18 +1,5 @@
 package ca.corefacility.bioinformatics.irida.service.export;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import java.util.Date;
-
-import javax.validation.Validator;
-
-import com.google.common.collect.Sets;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.google.common.collect.Lists;
-
 import ca.corefacility.bioinformatics.irida.model.NcbiExportSubmission;
 import ca.corefacility.bioinformatics.irida.model.export.NcbiBioSampleFiles;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
@@ -20,11 +7,21 @@ import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
 import ca.corefacility.bioinformatics.irida.repositories.NcbiExportSubmissionRepository;
 import ca.corefacility.bioinformatics.irida.service.impl.export.NcbiExportSubmissionServiceImpl;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.Validator;
+import java.util.Date;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test for {@link NcbiExportSubmissionService}
  */
-public class NcbiExportSubmissionServceTest {
+public class NcbiExportSubmissionServiceTest {
 
 	NcbiExportSubmissionService service;
 	NcbiExportSubmissionRepository repository;
@@ -71,9 +68,8 @@ public class NcbiExportSubmissionServceTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testCreateNoFiles() {
 
-		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Sets.newHashSet(),
-				Sets.newHashSet(), null, "library_name", null, null, null, "library_construction_protocol",
-				"namespace");
+		NcbiBioSampleFiles ncbiBioSampleFiles = new NcbiBioSampleFiles("sample", Sets.newHashSet(), Sets.newHashSet(),
+				null, "library_name", null, null, null, "library_construction_protocol", "namespace");
 		NcbiExportSubmission submission = new NcbiExportSubmission(null, null, "bioProjectId", "organization",
 				"ncbiNamespace", new Date(), Lists.newArrayList(ncbiBioSampleFiles));
 


### PR DESCRIPTION
## Description of changes
Changed file collections in NCBI export object to Sets to keep to JPA standard.  This removes the hibernate imports for the collection types.  Better for these files to be sets anyway.

I've tested running this code against NCBI's test FTP server and confirmed the uploads are working as expected.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
