### PR TITLE
Revert "Update chromedriver to fix Travis CI tests"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ Changes
 * [UI]: Fixed issue where issue where cart is not rendering to the full height of the page. (19.09.2)
 * [UI]: Updated and simplified associated project page.
 * [UI/Developer]: Removed old bootstrap customization files that are not used.
-* [Developer]: Updated chromedriver in packages.json to 78.0.1 to work better with chrome 78 on travis-ci.
 
 19.05 to 19.09
 ---------------

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -100,7 +100,7 @@
     "babel-plugin-import": "^1.12.2",
     "bootstrap-sass": "^3.3.7",
     "bower": "^1.7.7",
-    "chromedriver": "78.0.1",
+    "chromedriver": "76.0.0",
     "clean-webpack-plugin": "^1.0.1",
     "css-loader": "^3.2.0",
     "cssnano": "^4.1.10",

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -2268,10 +2268,10 @@ chrome-trace-event@^1.0.2:
   dependencies:
     tslib "^1.9.0"
 
-chromedriver@78.0.1:
-  version "78.0.1"
-  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-78.0.1.tgz#2db3425a2cba6fcaf1a41d9538b16c3d06fa74a8"
-  integrity sha512-eOsyFk4xb9EECs1VMrDbxO713qN+Bu1XUE8K9AuePc3839TPdAegg72kpXSzkeNqRNZiHbnJUItIVCLFkDqceA==
+chromedriver@76.0.0:
+  version "76.0.0"
+  resolved "https://registry.yarnpkg.com/chromedriver/-/chromedriver-76.0.0.tgz#cbf618c5b370799ff6e15b23de07e80f67f89025"
+  integrity sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==
   dependencies:
     del "^4.1.1"
     extract-zip "^1.6.7"


### PR DESCRIPTION
Reverts phac-nml/irida#531

Travis CI Xenial image appears to have downgraded chrome version back to 76