### PR TITLE
Enable webpack minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Changes
 * [UI]: Fixed issue where issue where cart is not rendering to the full height of the page. (19.09.2)
 * [UI]: Updated and simplified associated project page.
 * [UI/Developer]: Removed old bootstrap customization files that are not used.
+* [Developer]: Added back minification config to production webpack config.
 
 19.05 to 19.09
 ---------------

--- a/src/main/webapp/wepack.config.prod.js
+++ b/src/main/webapp/wepack.config.prod.js
@@ -3,30 +3,42 @@ const webpack = require("webpack");
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const cssnano = require("cssnano");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 
 const BUILD_PATH = path.resolve(__dirname, "dist");
 exports.config = {
   mode: "production",
   devtool: "source-map",
   optimization: {
-    minimize: false,
+    minimizer: [
+      new TerserPlugin({
+        cache: true,
+        parallel: true,
+        sourceMap: true,
+        terserOptions: {
+          output: {
+            ascii_only: true
+          },
+        },
+      }),
+      new OptimizeCSSAssetsPlugin({
+        cssProcessor: cssnano,
+        cssProcessorOptions: {
+          discardComments: {
+            removeAll: true
+          },
+          // Run cssnano in safe mode to avoid
+          // potentially unsafe transformations.
+          safe: true,
+          canPrint: false
+        }
+      })
+    ]
   },
   plugins: [
     new webpack.DefinePlugin({
       "process.env.NODE_ENV": JSON.stringify("production")
     }),
     new CleanWebpackPlugin([BUILD_PATH]),
-    new OptimizeCSSAssetsPlugin({
-      cssProcessor: cssnano,
-      cssProcessorOptions: {
-        discardComments: {
-          removeAll: true
-        },
-        // Run cssnano in safe mode to avoid
-        // potentially unsafe transformations.
-        safe: true,
-        canPrint: false
-      }
-    })
   ]
 };


### PR DESCRIPTION
## Description of changes
Re-enabled minification in webpack config with options that don't encode unicode strings. terser-webpack-plugin options are the same that webpack uses in v4.41.2 with the addition of `ascii-only: true` which tells it to leave alone ascii strings. Default config was converting unicode strings. https://github.com/webpack/webpack/blob/v4.41.2/lib/WebpackOptionsDefaulter.js

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
