### PR TITLE
adding wait to service test to ensure seq file is settled before reading

### DIFF
--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/SequencingObjectServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/SequencingObjectServiceImplIT.java
@@ -362,6 +362,10 @@ public class SequencingObjectServiceImplIT {
 				Thread.sleep(1000);
 			}
 		} while (sf.getFileRevisionNumber() < expectedRevisionNumber);
+
+		//one more sleep to make sure everything's settled
+		Thread.sleep(1000);
+
 		assertEquals("Wrong version number after processing.", expectedRevisionNumber, sf.getFileRevisionNumber());
 		assertFalse("File name is still gzipped.", sf.getFile().getFileName().toString().endsWith(".gz"));
 		AnalysisFastQC analysis = asRole(Role.ROLE_ADMIN, "admin").analysisService


### PR DESCRIPTION
## Description of changes
Added a wait to SequencingObjectServiceImplIT to help ensure the seq file in the test is settled before reading

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
