### PR TITLE
Added mysql5.5 dialect change to upgrading guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Changes
 * [UI/Developer]: Update version of `babel` and `eslint`.
 * [Documentation]: Fixed documentation link for developer authorization/oauth docs.
 * [Documentation]: Added info about upgrading to Tomcat 8.
+* [Documentation]: Added notice to upgrading guide about mysql 5.5 hibernate dialect.
 
 19.05 to 19.09
 ---------------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,7 @@ upgrading IRIDA that cannot be automated.
 * This upgrade changes the Java version to Java 11.  To upgrade, follow the install instructions for your system in <https://irida.corefacility.ca/documentation/administrator/web/#prerequisite-install-instructions>.
 * Tomcat 8 (or another Servlet 3.1 compatible servlet container) is required for this IRIDA version.  Systems using Tomcat 7 must be upgraded before deploying this update.
 * This upgrade adds a required field to OAuth2 clients using the `authorization_code` grant (that is external applications connecting to IRIDA via the web application).  This includes other IRIDA installations synchronizing data via the Remote API system, and Galaxy importer clients.  In order for these systems to continue working properly, administrators must register a redirect URI for all `authorization_code` clients.  For more on this process, see <https://irida.corefacility.ca/documentation/administrator/upgrades/#2001>.
+* The configuration key `hibernate.dialect=org.hibernate.dialect.MySQL55Dialect` should be set in your `/etc/irida/irida.conf` file for this release.  Note the change from `MySQL5Dialect` to `MySQL55Dialect`.
 
 19.05 to 19.09
 --------------


### PR DESCRIPTION
## Description of changes
Added a change to the hibernate.dialect to mysql 5.5.  This is already set in the default server conf files, but if someone added it to their `/etc/irida/irida.conf` file it could cause issues in the future if they don't update it.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
* [x] User documentation updated for UI or technical changes. (checked and it's in the default conf file in the docs)
