### PR TITLE
Fixed the title of the users list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Changes
 * [Documentation]: Fixed documentation link for developer authorization/oauth docs.
 * [Documentation]: Added info about upgrading to Tomcat 8.
 * [Documentation]: Added notice to upgrading guide about mysql 5.5 hibernate dialect.
+* [UI]: Fixed page title for users list page.
 
 19.05 to 19.09
 ---------------

--- a/src/main/webapp/pages/user/list.html
+++ b/src/main/webapp/pages/user/list.html
@@ -3,7 +3,7 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       data-layout-decorate="~{template/page}">
 <head>
-    <title th:text="#{projects.title}">_USER LIST TITLE_</title>
+    <title th:text="#{users.title}">_USER LIST TITLE_</title>
     <script th:inline="javascript">
         var PAGE = {
             urls: {


### PR DESCRIPTION
## Description of changes
The users list page was using the wrong i18n tag.  Fixed this to use the users title.

## Related issue
n/a

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
