### PR TITLE
WIP: Enable advanced vis for any AnalysisType containing "PHYLOGENOMICS"

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
@@ -298,7 +298,7 @@ public class AnalysisController {
 		try {
 			if (submission.getAnalysisState()
 					.equals(AnalysisState.COMPLETED)) {
-				if (analysisType.equals(BuiltInAnalysisTypes.PHYLOGENOMICS) || analysisType.equals(BuiltInAnalysisTypes.MLST_MENTALIST)) {
+				if (analysisType.toString().contains("PHYLOGENOMICS") || analysisType.equals(BuiltInAnalysisTypes.MLST_MENTALIST)) {
 					tree(submission, model);
 				} else if (analysisType.equals(BuiltInAnalysisTypes.SISTR_TYPING)) {
 					model.addAttribute("sistr", true);


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Allow any AnalysisType whose string representation contains `"PHYLOGENOMICS"` to use the advanced visualization system.

This allows pipeline plugins to use advanced visualization as long as they include `"PHYLOGENOMICS"` as part of their AnalysisType.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
