### PR TITLE
Changed trim for tablerequests

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
@@ -44,7 +44,11 @@ public class TableRequest {
 	}
 
 	public void setSearch(String search) {
-		this.search = search.trim();
+		if (search != null) {
+			this.search = search.trim();
+		} else {
+			search = null;
+		}
 	}
 
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
@@ -40,6 +40,9 @@ public class TableRequest {
 	}
 
 	public String getSearch() {
+		if (search == null) {
+			return null;
+		}
 		return search.trim();
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
@@ -40,14 +40,11 @@ public class TableRequest {
 	}
 
 	public String getSearch() {
-		if (search == null) {
-			return null;
-		}
-		return search.trim();
+		return search;
 	}
 
 	public void setSearch(String search) {
-		this.search = search;
+		this.search = search.trim();
 	}
 
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/models/tables/TableRequest.java
@@ -43,6 +43,11 @@ public class TableRequest {
 		return search;
 	}
 
+	/**
+	 * Set the search term for the TableRequest.  This method will trim any leading and trailing whitespace.
+	 *
+	 * @param search The search term for the request
+	 */
 	public void setSearch(String search) {
 		if (search != null) {
 			this.search = search.trim();
@@ -52,10 +57,8 @@ public class TableRequest {
 	}
 
 	/**
-	 * Since we he need an actual {@link Sort} object and cannot pass this from
-	 * the client, we create one from the information fathered from the client
-	 * Direction of sort
-	 * Column (attribute) of sort
+	 * Since we he need an actual {@link Sort} object and cannot pass this from the client, we create one from the
+	 * information fathered from the client Direction of sort Column (attribute) of sort
 	 *
 	 * @return {@link Sort}
 	 */

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/analysis/AnalysesUserPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/analysis/AnalysesUserPage.java
@@ -58,6 +58,7 @@ public class AnalysesUserPage extends AbstractPage {
 		waitForElementToBeClickable(nameFilterSubmit);
 		nameFilterInput.sendKeys(name);
 		nameFilterSubmit.click();
+		waitForElementInvisible(By.className("t-name-filter"));
 	}
 
 	public void clearNameFilter() {


### PR DESCRIPTION
## Description of changes
Changed the search term to be trimmed when it's set for the `TableRequest` instead of when it's requested.  The issue was that if there's no search term and the getter is called, it's trying to trim it then which would throw a nullpointer.

## Related issue
Fixes #605 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~ Not bothering because we caused this error with the hotfix.  Not really a change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
