### PR TITLE
Remove DataTables from overrepresented sequences for sequencing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes
 * [Developer]: Updated maven `jetty` plugin to version 9.4.24.v20191120.
 * [UI]: Updated Remote API Listing page to use Ant Design.
 * [UI]: Updated Administrator Users page to use Ant Design.
+* [UI]: Removed DataTables from overrepresented sequence file page.
 
 19.09 to 20.01
 --------------

--- a/src/main/webapp/entries.js
+++ b/src/main/webapp/entries.js
@@ -79,6 +79,5 @@ module.exports = {
   "group-members": "./resources/js/pages/users/groups-members.js",
   "ncbi-exports": "./resources/js/pages/projects/ncbi-export.js",
   search: "./resources/js/pages/search/search.js",
-  overrepresented: "./resources/js/pages/sequence-files/overrepresented.js",
   "run-files": "./resources/js/pages/sequence-files/run-files.js"
 };

--- a/src/main/webapp/pages/sequenceFiles/file_overrepresented.html
+++ b/src/main/webapp/pages/sequenceFiles/file_overrepresented.html
@@ -4,7 +4,6 @@
       data-layout-decorate="~{sequenceFiles/_base}">
 <head>
     <title th:text="${file.getLabel()}">THIS IS SOMETHING WRONG</title>
-    <link rel="stylesheet" th:href="@{/dist/css/overrepresented.bundle.css}">
 </head>
 <body>
 <div layout:fragment="main">
@@ -31,9 +30,5 @@
     </table>
 </div>
 <aside th:replace="sequenceFiles/file_base :: sidebar"></aside>
-
-<th:block layout:fragment="pageScripts" th:inline="javascript">
-    <script th:src="@{/dist/js/overrepresented.bundle.js}"></script>
-</th:block>
 </body>
 </html>

--- a/src/main/webapp/resources/js/pages/sequence-files/overrepresented.js
+++ b/src/main/webapp/resources/js/pages/sequence-files/overrepresented.js
@@ -1,8 +1,0 @@
-import $ from "jquery";
-import "./../../vendor/datatables/datatables";
-
-$("#orTable").dataTable({
-  dom: "<'top'il>rt<'bottom'p><'clear'>",
-  bFilter: false,
-  bSort: false
-});


### PR DESCRIPTION
## Description of changes
Just remove DataTables and left as a regular table.  Looking through production data, these tables do not get that large.

## Related issue
#413 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
