### PR TITLE
Analysis/ sample renderer undefined fix

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
@@ -296,7 +296,7 @@ public class AnalysisAjaxController {
 			SequenceFilePair fp = (SequenceFilePair)sso.getSequencingObject();
 			if(fp.getFiles().size() == 2) {
 				String sampleName = messageSource.getMessage("AnalysisSamples.sampleDeleted",
-									new Object[] {}, locale);
+						new Object[] {}, locale);
 				Long sampleId = 0L;
 				if(sso.getSample() != null) {
 					sampleName = sso.getSample().getSampleName();
@@ -310,7 +310,7 @@ public class AnalysisAjaxController {
 			SingleEndSequenceFile sesf = (SingleEndSequenceFile)sso.getSequencingObject();
 			if(sesf.getFiles().size() == 1) {
 				String sampleName = messageSource.getMessage("AnalysisSamples.sampleDeleted",
-									new Object[] {}, locale);
+						new Object[] {}, locale);
 				Long sampleId = 0L;
 				if(sso.getSample() != null) {
 					sampleName = sso.getSample().getSampleName();

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
@@ -250,10 +250,11 @@ public class AnalysisAjaxController {
 	 * Get analysis input files and their sizes
 	 *
 	 * @param submissionId analysis submission id to get data for
+	 * @param locale User's locale
 	 * @return dto of analysis input files data
 	 */
 	@RequestMapping(value = "/inputs/{submissionId}", method = RequestMethod.GET)
-	public AnalysisInputFiles ajaxGetAnalysisInputFiles(@PathVariable Long submissionId) {
+	public AnalysisInputFiles ajaxGetAnalysisInputFiles(@PathVariable Long submissionId, Locale locale) {
 		logger.trace("reading analysis submission " + submissionId);
 		AnalysisSubmission submission = analysisSubmissionService.read(submissionId);
 		ReferenceFile referenceFile = null;
@@ -294,18 +295,28 @@ public class AnalysisAjaxController {
 		for(SampleSequencingObject sso : sampleFiles) {
 			SequenceFilePair fp = (SequenceFilePair)sso.getSequencingObject();
 			if(fp.getFiles().size() == 2) {
-				pairedEnd.add(new AnalysisSamples(sso.getSample()
-						.getSampleName(), sso.getSample()
-						.getId(), fp.getId(), fp.getForwardSequenceFile(), fp.getReverseSequenceFile()));
+				String sampleName = messageSource.getMessage("AnalysisSamples.sampleDeleted",
+									new Object[] {}, locale);
+				Long sampleId = 0L;
+				if(sso.getSample() != null) {
+					sampleName = sso.getSample().getSampleName();
+					sampleId = sso.getSample().getId();
+				}
+				pairedEnd.add(new AnalysisSamples(sampleName, sampleId, fp.getId(), fp.getForwardSequenceFile(), fp.getReverseSequenceFile()));
 			}
 		}
 
 		for(SampleSequencingObject sso : singleFiles) {
 			SingleEndSequenceFile sesf = (SingleEndSequenceFile)sso.getSequencingObject();
 			if(sesf.getFiles().size() == 1) {
-				singleEnd.add(new AnalysisSingleEndSamples(sso.getSample()
-						.getSampleName(), sso.getSample()
-						.getId(), sesf.getId(), sesf.getSequenceFile()));
+				String sampleName = messageSource.getMessage("AnalysisSamples.sampleDeleted",
+									new Object[] {}, locale);
+				Long sampleId = 0L;
+				if(sso.getSample() != null) {
+					sampleName = sso.getSample().getSampleName();
+					sampleId = sso.getSample().getId();
+				}
+				singleEnd.add(new AnalysisSingleEndSamples(sampleName, sampleId, sesf.getId(), sesf.getSequenceFile()));
 			}
 		}
 
@@ -1110,7 +1121,9 @@ public class AnalysisAjaxController {
 			try {
 				SampleSequencingObjectJoin sampleSequencingObjectJoin = sampleService.getSampleForSequencingObject(
 						sequencingObject);
-				this.sample = sampleSequencingObjectJoin.getSubject();
+				if(sampleSequencingObjectJoin != null) {
+					this.sample = sampleSequencingObjectJoin.getSubject();
+				}
 			} catch (Exception e) {
 				logger.debug("Sequence file [" + sequencingObject.getIdentifier() + "] does not have a parent sample",
 						e);

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1925,6 +1925,7 @@ AnalysisSamples.downloadReferenceFile=Download Reference File
 AnalysisSamples.searchSamples=Search Samples
 AnalysisSamples.checkingForSamples=Checking for samples
 AnalysisSamples.samplesDeleted=Samples used for this analysis were removed.
+AnalysisSamples.sampleDeleted=Sample Deleted
 # ========================================================================================== #
 # ANALYSIS SHARE COMPONENT                                                                   #
 # ========================================================================================== #

--- a/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
@@ -186,7 +186,7 @@ export function AnalysisSampleRenderer() {
             message={i18n("AnalysisSamples.checkingForSamples")}
           />
         </div>
-      ) : analysisSamplesContext.samples.length > 0 || analysisSamplesContext.singleEndSamples.length > 0 ? (
+      ) : (typeof analysisSamplesContext.samples !== 'undefined' && analysisSamplesContext.samples.length > 0) || (typeof analysisSamplesContext.singleEndSamples !== 'undefined' && analysisSamplesContext.singleEndSamples.length > 0) ? (
         <div>
           <Search
             placeholder={i18n("AnalysisSamples.searchSamples")}

--- a/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
@@ -59,12 +59,15 @@ export function AnalysisSampleRenderer() {
                   </Avatar>
                 }
                 title={
-                  <a
-                    href={`${SAMPLES_BASE_URL}/${item.sampleId}/details`}
-                    target="_blank"
-                    className="t-paired-end-sample-name"
-                  >
-                    {item.sampleName}
+                  item.sampleId == 0 ?
+				  item.sampleName
+				  :
+				  <a
+					href={`${SAMPLES_BASE_URL}/${item.sampleId}/details`}
+					target="_blank"
+					className="t-paired-end-sample-name"
+				  >
+					{item.sampleName}
                   </a>
                 }
                 description={
@@ -117,7 +120,10 @@ export function AnalysisSampleRenderer() {
                   </Avatar>
                 }
                 title={
-                  <a
+                  item.sampleId == 0 ?
+				  item.sampleName
+				  :
+				  <a
                     href={`${SAMPLES_BASE_URL}/${item.sampleId}/details`}
                     target="_blank"
                     className="t-single-end-sample-name"
@@ -186,7 +192,8 @@ export function AnalysisSampleRenderer() {
             message={i18n("AnalysisSamples.checkingForSamples")}
           />
         </div>
-      ) : (typeof analysisSamplesContext.samples !== 'undefined' && analysisSamplesContext.samples.length > 0) || (typeof analysisSamplesContext.singleEndSamples !== 'undefined' && analysisSamplesContext.singleEndSamples.length > 0) ? (
+      ) : analysisSamplesContext.samples.length > 0) ||
+		  analysisSamplesContext.singleEndSamples.length > 0) ? (
         <div>
           <Search
             placeholder={i18n("AnalysisSamples.searchSamples")}

--- a/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
@@ -192,8 +192,8 @@ export function AnalysisSampleRenderer() {
             message={i18n("AnalysisSamples.checkingForSamples")}
           />
         </div>
-      ) : analysisSamplesContext.samples.length > 0) ||
-		  analysisSamplesContext.singleEndSamples.length > 0) ? (
+      ) : analysisSamplesContext.samples.length > 0 ||
+		  analysisSamplesContext.singleEndSamples.length > 0 ? (
         <div>
           <Search
             placeholder={i18n("AnalysisSamples.searchSamples")}

--- a/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/settings/AnalysisSampleRenderer.jsx
@@ -60,14 +60,14 @@ export function AnalysisSampleRenderer() {
                 }
                 title={
                   item.sampleId == 0 ?
-				  item.sampleName
-				  :
-				  <a
-					href={`${SAMPLES_BASE_URL}/${item.sampleId}/details`}
-					target="_blank"
-					className="t-paired-end-sample-name"
-				  >
-					{item.sampleName}
+		  item.sampleName
+		  :
+		  <a
+			href={`${SAMPLES_BASE_URL}/${item.sampleId}/details`}
+			target="_blank"
+			className="t-paired-end-sample-name"
+		  >
+			{item.sampleName}
                   </a>
                 }
                 description={
@@ -121,9 +121,9 @@ export function AnalysisSampleRenderer() {
                 }
                 title={
                   item.sampleId == 0 ?
-				  item.sampleName
-				  :
-				  <a
+		  item.sampleName
+		  :
+		  <a
                     href={`${SAMPLES_BASE_URL}/${item.sampleId}/details`}
                     target="_blank"
                     className="t-single-end-sample-name"

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/analysis/AnalysisAjaxControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/analysis/AnalysisAjaxControllerTest.java
@@ -357,7 +357,7 @@ public class AnalysisAjaxControllerTest {
 	public void testGetAnalysisInputFiles() {
 		AnalysisSubmission submission = TestDataFactory.constructAnalysisSubmission();
 		when(analysisSubmissionServiceMock.read(submission.getId())).thenReturn(submission);
-		analysisAjaxController.ajaxGetAnalysisInputFiles(submission.getId());
+		analysisAjaxController.ajaxGetAnalysisInputFiles(submission.getId(), Locale.getDefault());
 		assertNotNull("Submission exists", submission);
 		verify(sequencingObjectService, times(1)).getSequencingObjectsOfTypeForAnalysisSubmission(submission,
 				SequenceFilePair.class);


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed 500 error being thrown in console when visiting an analysis samples page from which a sample had been deleted. Updated samples page to display samples which have been deleted and made styling changes to the sample name.

To test:

1. Add sample to a project and run an analysis
2. Once the analysis is completed visit the analysis > settings > samples tab and see which samples the analysis was run with. The sample name should be clickable and there should be no 500 error thrown in the console for the browser
3. Go to the project you used the sample from and delete it.
4. Visit the analysis > settings > sample tab
5. The sample name should display as `Sample Deleted` and should not be clickable. Also, there should be no 500 error in the browser console

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
