### PR TITLE
Updated analysis duration to display correctly when not in completed or error state

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysesAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysesAjaxController.java
@@ -24,6 +24,7 @@ import ca.corefacility.bioinformatics.irida.model.workflow.analysis.AnalysisOutp
 import ca.corefacility.bioinformatics.irida.model.workflow.analysis.type.AnalysisType;
 import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
 import ca.corefacility.bioinformatics.irida.ria.utilities.FileUtilities;
+import ca.corefacility.bioinformatics.irida.ria.web.analysis.auditing.AnalysisAudit;
 import ca.corefacility.bioinformatics.irida.ria.web.analysis.dto.AnalysesListRequest;
 import ca.corefacility.bioinformatics.irida.ria.web.analysis.dto.AnalysisModel;
 import ca.corefacility.bioinformatics.irida.ria.web.analysis.dto.AnalysisStateModel;
@@ -50,18 +51,20 @@ public class AnalysesAjaxController {
 	private IridaWorkflowsService iridaWorkflowsService;
 	private MessageSource messageSource;
 	private UpdateAnalysisSubmissionPermission updateAnalysisSubmissionPermission;
+	private AnalysisAudit analysisAudit;
 
 	@Autowired
 	public AnalysesAjaxController(AnalysisSubmissionService analysisSubmissionService,
 			AnalysisTypesService analysisTypesService, ProjectService projectService,
 			IridaWorkflowsService iridaWorkflowsService, MessageSource messageSource,
-			UpdateAnalysisSubmissionPermission updateAnalysisSubmissionPermission) {
+			UpdateAnalysisSubmissionPermission updateAnalysisSubmissionPermission, AnalysisAudit analysisAudit) {
 		this.analysisSubmissionService = analysisSubmissionService;
 		this.analysisTypesService = analysisTypesService;
 		this.projectService = projectService;
 		this.iridaWorkflowsService = iridaWorkflowsService;
 		this.messageSource = messageSource;
 		this.updateAnalysisSubmissionPermission = updateAnalysisSubmissionPermission;
+		this.analysisAudit = analysisAudit;
 	}
 
 	/**
@@ -215,10 +218,12 @@ public class AnalysesAjaxController {
 		String stateString = messageSource.getMessage("analysis.state." + analysisState.toString(), null, locale);
 		AnalysisStateModel state = new AnalysisStateModel(stateString, analysisState.toString());
 		String workflow = messageSource.getMessage("workflow." + workflowType + ".title", null, workflowType, locale);
-		Long duration = 0L;
-		if (analysisState.equals(AnalysisState.COMPLETED)) {
-			duration = DateUtilities.getDurationInMilliseconds(submission.getCreatedDate(), submission.getAnalysis()
-					.getCreatedDate());
+		Long duration;
+		if(submission.getAnalysisState() != AnalysisState.COMPLETED && submission.getAnalysisState() != AnalysisState.ERROR) {
+			Date currentDate = new Date();
+			duration = DateUtilities.getDurationInMilliseconds(submission.getCreatedDate(), currentDate);
+		} else {
+			duration = analysisAudit.getAnalysisRunningTime(submission);
 		}
 
 		/*

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
@@ -1,6 +1,7 @@
 package ca.corefacility.bioinformatics.irida.ria.web.analysis;
 import java.io.*;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.security.Principal;
 import java.util.*;
@@ -711,6 +712,7 @@ public class AnalysisAjaxController {
 			Analysis analysis = submission.getAnalysis();
 			Path path = analysis.getAnalysisOutputFile(sistrFileKey)
 					.getFile();
+
 			try {
 				String json = new Scanner(new BufferedReader(new FileReader(path.toFile()))).useDelimiter("\\Z")
 						.next();
@@ -982,21 +984,26 @@ public class AnalysisAjaxController {
 			message= messageSource.getMessage("AnalysisPhylogeneticTree.noTreeFound",
 					new Object[] {}, locale);
 		} else {
-			List<String> lines = Files.readAllLines(file.getFile());
+			try {
+				List<String> lines = Files.readAllLines(file.getFile());
 
-			if (lines.size() > 0) {
-				tree = lines.get(0);
+				if (lines.size() > 0) {
+					tree = lines.get(0);
 
-				if (lines.size() > 1) {
-					logger.warn("Multiple lines in tree file, will only display first tree. For analysis: " + submission);
-					message = messageSource.getMessage("AnalysisPhylogeneticTree.multipleTrees", new Object[] {}, locale);
+					if (lines.size() > 1) {
+						logger.warn("Multiple lines in tree file, will only display first tree. For analysis: " + submission);
+						message = messageSource.getMessage("AnalysisPhylogeneticTree.multipleTrees", new Object[] {},
+								locale);
+					}
+
+					if (EMPTY_TREE.equals(tree)) {
+						logger.debug("Empty tree found, will hide tree preview. For analysis: " + submission);
+						tree = null;
+						message = messageSource.getMessage("AnalysisPhylogeneticTree.emptyTree", new Object[] {}, locale);
+					}
 				}
-
-				if (EMPTY_TREE.equals(tree)) {
-					logger.debug("Empty tree found, will hide tree preview. For analysis: " + submission);
-					tree = null;
-					message = messageSource.getMessage("AnalysisPhylogeneticTree.emptyTree", new Object[] {}, locale);
-				}
+			} catch (NoSuchFileException e) {
+				logger.debug("File was not found: " + e.toString());
 			}
 		}
 		return new AnalysisTreeResponse(tree, message);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
@@ -45,6 +45,7 @@ import ca.corefacility.bioinformatics.irida.ria.web.analysis.auditing.AnalysisAu
 import ca.corefacility.bioinformatics.irida.ria.web.analysis.dto.*;
 import ca.corefacility.bioinformatics.irida.ria.web.components.AnalysisOutputFileDownloadManager;
 import ca.corefacility.bioinformatics.irida.ria.web.dto.ResponseDetails;
+import ca.corefacility.bioinformatics.irida.ria.web.utilities.DateUtilities;
 import ca.corefacility.bioinformatics.irida.security.permissions.analysis.UpdateAnalysisSubmissionPermission;
 import ca.corefacility.bioinformatics.irida.service.AnalysisSubmissionService;
 import ca.corefacility.bioinformatics.irida.service.ProjectService;
@@ -223,7 +224,13 @@ public class AnalysisAjaxController {
 				.toString();
 
 		// Get the run time of the analysis runtime using the analysis
-		Long duration = analysisAudit.getAnalysisRunningTime(submission);
+		Long duration;
+		if(submission.getAnalysisState() != AnalysisState.COMPLETED && submission.getAnalysisState() != AnalysisState.ERROR) {
+			Date currentDate = new Date();
+			duration = DateUtilities.getDurationInMilliseconds(submission.getCreatedDate(), currentDate);
+		} else {
+			duration = analysisAudit.getAnalysisRunningTime(submission);
+		}
 
 		AnalysisSubmission.Priority[] priorities = AnalysisSubmission.Priority.values();
 		boolean emailPipelineResult = submission.getEmailPipelineResult();

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
@@ -1,6 +1,7 @@
 package ca.corefacility.bioinformatics.irida.ria.web.analysis;
 
 import java.security.Principal;
+import java.util.Date;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +22,7 @@ import ca.corefacility.bioinformatics.irida.model.workflow.analysis.type.Analysi
 import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
 
 import ca.corefacility.bioinformatics.irida.ria.web.analysis.auditing.AnalysisAudit;
+import ca.corefacility.bioinformatics.irida.ria.web.utilities.DateUtilities;
 import ca.corefacility.bioinformatics.irida.service.AnalysisSubmissionService;
 import ca.corefacility.bioinformatics.irida.service.EmailController;
 import ca.corefacility.bioinformatics.irida.service.user.UserService;
@@ -156,7 +158,13 @@ public class AnalysisController {
 		}
 
 		// Get the run time of the analysis runtime using the analysis
-		Long duration = analysisAudit.getAnalysisRunningTime(submission);
+		Long duration;
+		if(submission.getAnalysisState() != AnalysisState.COMPLETED && submission.getAnalysisState() != AnalysisState.ERROR) {
+			Date currentDate = new Date();
+			duration = DateUtilities.getDurationInMilliseconds(submission.getCreatedDate(), currentDate);
+		} else {
+			duration = analysisAudit.getAnalysisRunningTime(submission);
+		}
 		model.addAttribute("duration", duration);
 
 		return "analysis";

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisController.java
@@ -155,6 +155,10 @@ public class AnalysisController {
 			model.addAttribute("previousState", analysisAudit.getPreviousStateBeforeError(submissionId));
 		}
 
+		// Get the run time of the analysis runtime using the analysis
+		Long duration = analysisAudit.getAnalysisRunningTime(submission);
+		model.addAttribute("duration", duration);
+
 		return "analysis";
 	}
 

--- a/src/main/webapp/pages/analysis.html
+++ b/src/main/webapp/pages/analysis.html
@@ -16,7 +16,8 @@
         analysisType: [[${analysisType}]],
         isAdmin: [[${isAdmin}]],
         mailConfigured: [[${mailConfigured}]],
-        previousState: [[${previousState}]]
+        previousState: [[${previousState}]],
+        duration: [[${duration}]],
       };
 
       window.translations = [{

--- a/src/main/webapp/resources/js/contexts/AnalysisContext.js
+++ b/src/main/webapp/resources/js/contexts/AnalysisContext.js
@@ -34,7 +34,8 @@ const initialContext = {
   analysisType: window.PAGE.analysisType.type,
   isCompleted: window.PAGE.analysisState === "COMPLETED",
   isError: window.PAGE.analysisState.includes("ERROR"),
-  previousState: window.PAGE.previousState
+  previousState: window.PAGE.previousState,
+  duration: window.PAGE.duration
 };
 
 const AnalysisContext = React.createContext(initialContext);

--- a/src/main/webapp/resources/js/pages/analysis/components/AnalysisSteps.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/AnalysisSteps.jsx
@@ -15,50 +15,65 @@ import { AnalysisContext, stateMap } from "../../../contexts/AnalysisContext";
 import { SPACE_MD } from "../../../styles/spacing";
 import { Running } from "../../../components/icons/Running";
 
+import {
+  getHumanizedDuration
+} from "../../../utilities/date-utilities";
+
 const Step = Steps.Step;
 
 export function AnalysisSteps() {
   const { analysisContext } = useContext(AnalysisContext);
+
+  const analysisDuration = getHumanizedDuration({ date: analysisContext.duration });
+  const analysisError = analysisContext.isError;
+  const previousState = analysisContext.previousState;
+  const analysisState = analysisContext.analysisState;
+
   return (
     <Steps
       current={
-        analysisContext.isError
-          ? stateMap[analysisContext.previousState]
-          : stateMap[analysisContext.analysisState]
+        analysisError
+          ? stateMap[previousState]
+          : stateMap[analysisState]
       }
-      status={analysisContext.isError ? "error" : "finish"}
+      status={analysisError ? "error" : "finish"}
       style={{ paddingBottom: SPACE_MD, paddingTop: SPACE_MD }}
     >
       <Step
         title={i18n("AnalysisSteps.new")}
-        icon={analysisContext.analysisState === "NEW" ? <Running /> : null}
+        icon={analysisState === "NEW" ? <Running /> : null}
+        description={analysisState === "NEW" || (previousState === null || stateMap[previousState] === "NEW") && analysisError ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.preparing")}
         icon={
-          analysisContext.analysisState === "PREPARING" ? <Running /> : null
+          analysisState === "PREPARING" ? <Running /> : null
         }
+        description={analysisState === "PREPARING" || (stateMap[previousState] === "PREPARING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.submitting")}
         icon={
-          analysisContext.analysisState === "SUBMITTING" ? <Running /> : null
+          analysisState === "SUBMITTING" ? <Running /> : null
         }
+        description={analysisState === "SUBMITTING" || (stateMap[previousState] === "SUBMITTING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.running")}
-        icon={analysisContext.analysisState === "RUNNING" ? <Running /> : null}
+        icon={analysisState === "RUNNING" ? <Running /> : null}
+        description={analysisState === "RUNNING" || (stateMap[previousState] === "RUNNING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.completing")}
         icon={
-          analysisContext.analysisState === "COMPLETING" ? <Running /> : null
+          analysisState === "COMPLETING" ? <Running /> : null
         }
+        description={analysisState === "COMPLETING" || (stateMap[previousState] === "COMPLETING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.completed")}
         icon={
-          analysisContext.analysisState === "COMPLETED" ? <Success /> : null
+          analysisState === "COMPLETED" ? <Success /> : null
         }
       />
     </Steps>

--- a/src/main/webapp/resources/js/pages/analysis/components/AnalysisSteps.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/AnalysisSteps.jsx
@@ -42,33 +42,33 @@ export function AnalysisSteps() {
       <Step
         title={i18n("AnalysisSteps.new")}
         icon={analysisState === "NEW" ? <Running /> : null}
-        description={analysisState === "NEW" || (previousState === null || stateMap[previousState] === "NEW") && analysisError ? analysisDuration : null}
+        description={analysisState === "NEW" || (previousState === null || previousState === "NEW") && analysisError ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.preparing")}
         icon={
           analysisState === "PREPARING" ? <Running /> : null
         }
-        description={analysisState === "PREPARING" || (stateMap[previousState] === "PREPARING" && analysisError) ? analysisDuration : null}
+        description={analysisState === "PREPARING" || (previousState === "PREPARING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.submitting")}
         icon={
           analysisState === "SUBMITTING" ? <Running /> : null
         }
-        description={analysisState === "SUBMITTING" || (stateMap[previousState] === "SUBMITTING" && analysisError) ? analysisDuration : null}
+        description={analysisState === "SUBMITTING" || (previousState === "SUBMITTING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.running")}
         icon={analysisState === "RUNNING" ? <Running /> : null}
-        description={analysisState === "RUNNING" || (stateMap[previousState] === "RUNNING" && analysisError) ? analysisDuration : null}
+        description={analysisState === "RUNNING" || (previousState === "RUNNING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.completing")}
         icon={
           analysisState === "COMPLETING" ? <Running /> : null
         }
-        description={analysisState === "COMPLETING" || (stateMap[previousState] === "COMPLETING" && analysisError) ? analysisDuration : null}
+        description={analysisState === "COMPLETING" || (previousState === "COMPLETING" && analysisError) ? analysisDuration : null}
       />
       <Step
         title={i18n("AnalysisSteps.completed")}

--- a/src/main/webapp/resources/js/pages/analysis/components/outputs/OutputFilePreview.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/outputs/OutputFilePreview.jsx
@@ -130,7 +130,7 @@ export default function OutputFilePreview() {
   }
 
   return analysisOutputsContext.outputs !== null ? (
-    <TabPaneContent actionButton={createDownloadAllButton()} title={i18n("AnalysisOutputs.outputFilePreview")}>
+    <TabPaneContent actionButton={analysisOutputsContext.outputs.length > 0 ? createDownloadAllButton() : null} title={i18n("AnalysisOutputs.outputFilePreview")}>
       {analysisOutputsContext.outputs.length > 0 ? (
         <div>
 

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -2748,7 +2748,7 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   dependencies:
@@ -2778,10 +2778,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
@@ -2861,10 +2857,6 @@ destroy@~1.0.4:
 detect-file@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -3735,12 +3727,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-minipass@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
-  dependencies:
-    minipass "^2.6.0"
-
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -4166,7 +4152,7 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -4185,12 +4171,6 @@ ieee754@^1.1.4:
 iferr@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
-
-ignore-walk@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-3.0.3.tgz#017e2447184bfeade7c238e4aefdd1e8f95b1e37"
-  dependencies:
-    minimatch "^3.0.4"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4286,7 +4266,7 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
@@ -5200,24 +5180,11 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^2.6.0, minipass@^2.8.6, minipass@^2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
-  dependencies:
-    safe-buffer "^5.1.2"
-    yallist "^3.0.0"
-
 minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.1.tgz#7607ce778472a185ad6d89082aa2070f79cedcd5"
   dependencies:
     yallist "^4.0.0"
-
-minizlib@^1.2.1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.3.3.tgz#2290de96818a34c29551c8a8d301216bd65a861d"
-  dependencies:
-    minipass "^2.9.0"
 
 mississippi@^3.0.0:
   version "3.0.0"
@@ -5317,14 +5284,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-needle@^2.2.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.3.tgz#a041ad1d04a871b0ebb666f40baaf1fb47867117"
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -5401,21 +5360,6 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.50:
   version "1.1.52"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.52.tgz#bcffee3e0a758e92e44ecfaecd0a47554b0bcba9"
@@ -5449,13 +5393,6 @@ node-sass@^4.12.0:
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   dependencies:
     abbrev "1"
-
-nopt@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.3.tgz#a375cad9d02fd921278d954c2254d5aa57e15e48"
-  dependencies:
-    abbrev "1"
-    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.5.0"
@@ -5493,31 +5430,13 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
 
-npm-bundled@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  dependencies:
-    npm-normalize-package-bin "^1.0.1"
-
-npm-normalize-package-bin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
-
-npm-packlist@^1.1.6:
-  version "1.4.8"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
-  dependencies:
-    ignore-walk "^3.0.1"
-    npm-bundled "^1.0.1"
-    npm-normalize-package-bin "^1.0.1"
-
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
 
-"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0, npmlog@^4.0.2:
+"npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   dependencies:
@@ -5719,7 +5638,7 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@0, osenv@^0.1.4:
+osenv@0:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.5.tgz#85cdfafaeb28e8677f416e287592b5f3f49ea410"
   dependencies:
@@ -6889,15 +6808,6 @@ rc-util@^4.0.4, rc-util@^4.1.1, rc-util@^4.13.0, rc-util@^4.15.3, rc-util@^4.15.
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.1.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
@@ -7335,7 +7245,7 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
 
-rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   dependencies:
@@ -7416,7 +7326,7 @@ sass-loader@^8.0.0:
     schema-utils "^2.6.1"
     semver "^6.3.0"
 
-sax@^1.2.4, sax@~1.2.4:
+sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -7475,7 +7385,7 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "0.9.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
 
@@ -7989,10 +7899,6 @@ strip-json-comments@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
 style-loader@^1.0.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.1.3.tgz#9e826e69c683c4d9bf9db924f85e9abb30d5e200"
@@ -8098,18 +8004,6 @@ tar@^2.0.0:
     block-stream "*"
     fstream "^1.0.12"
     inherits "2"
-
-tar@^4.4.2:
-  version "4.4.13"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
-  dependencies:
-    chownr "^1.1.1"
-    fs-minipass "^1.2.5"
-    minipass "^2.8.6"
-    minizlib "^1.2.1"
-    mkdirp "^0.5.0"
-    safe-buffer "^5.1.2"
-    yallist "^3.0.3"
 
 tcp-port-used@^1.0.1:
   version "1.0.1"
@@ -8839,7 +8733,7 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
+yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
 


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed issue when a tree file was not found and an exception was thrown on the server side which caused the UI to crash when loading the phylogenetic tree page. Added duration to AnalysisSteps description which displays the analysis duration under the current step. Refactored some variables in AnalysisSteps component.

**To test properly start up irida with the production profile:**

1) Add samples to a project, add to cart, and run SNVPhyl
2) Wait a few minutes and view the analyses table. It should no longer say "a few seconds" but display the actual duration
3) Click on the analysis in the analyses table to view the Analysis. The analysis should still be running (not completed or errored) and you should see the duration under the current step the analysis is on (duration should be displaying correctly)
4) View the Settings > Details Tab. The analysis should still be running and you should see the correct duration for the analysis.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
