### PR TITLE
Type single end analyses can now be shared with other projects

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/analysis/AnalysisAjaxController.java
@@ -582,10 +582,16 @@ public class AnalysisAjaxController {
 	@ResponseBody
 	public List<SharedProjectResponse> getSharedProjectsForAnalysis(@PathVariable Long submissionId) {
 		AnalysisSubmission submission = analysisSubmissionService.read(submissionId);
+
 		// Input files
+
 		// - Paired
 		Set<SequenceFilePair> inputFilePairs = sequencingObjectService.getSequencingObjectsOfTypeForAnalysisSubmission(
 				submission, SequenceFilePair.class);
+
+		// Single End
+		Set<SingleEndSequenceFile> inputFileSingleEnd = sequencingObjectService.getSequencingObjectsOfTypeForAnalysisSubmission(
+				submission, SingleEndSequenceFile.class);
 
 		// get projects already shared with submission
 		Set<Project> projectsShared = projectService.getProjectsForAnalysisSubmission(submission)
@@ -594,17 +600,24 @@ public class AnalysisAjaxController {
 				.collect(Collectors.toSet());
 
 		// get available projects
-		Set<Project> projectsInAnalysis = projectService.getProjectsForSequencingObjects(inputFilePairs);
+		Set<Project> projectsInAnalysisPaired = projectService.getProjectsForSequencingObjects(inputFilePairs);
+		Set<Project> projectsInAnalysisSingleEnd = projectService.getProjectsForSequencingObjects(inputFileSingleEnd);
 
+		// Create response for shared projects
 		List<SharedProjectResponse> projectResponses = projectsShared.stream()
 				.map(p -> new SharedProjectResponse(p, true))
 				.collect(Collectors.toList());
 
-		// Create response for shared projects
-		projectResponses.addAll(projectsInAnalysis.stream()
+		projectResponses.addAll(projectsInAnalysisPaired.stream()
 				.filter(p -> !projectsShared.contains(p))
 				.map(p -> new SharedProjectResponse(p, false))
 				.collect(Collectors.toList()));
+
+		projectResponses.addAll(projectsInAnalysisSingleEnd.stream()
+				.filter(p -> !projectsShared.contains(p))
+				.map(p -> new SharedProjectResponse(p, false))
+				.collect(Collectors.toList()));
+
 
 		projectResponses.sort(new Comparator<SharedProjectResponse>() {
 


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Updated AnalysisAjaxController so that a user can now share single end analyses with other projects.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
