### PR TITLE
Fixed checking to see if table sorted by modified date

### DIFF
--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/AdminUsersPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/AdminUsersPage.java
@@ -26,11 +26,11 @@ public class AdminUsersPage extends AbstractPage {
 	}
 
 	public boolean isTableSortedByUsername() {
-		return table.isColumnSorted("t-username");
+		return table.isColumnSorted("t-username", null);
 	}
 
 	public boolean isTableSortedByModifiedDate() {
-		return table.isColumnSorted("t-modified");
+		return table.isColumnSorted("t-modified", AntTable.LONG_DATE_FORMAT);
 	}
 
 	public void sortTableByUsername() {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/users/AdminUsersPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/users/AdminUsersPageIT.java
@@ -31,7 +31,7 @@ public class AdminUsersPageIT extends AbstractIridaUIITChromeDriver {
 
 		// Test sorting
 		assertTrue("Table should be sorted by the modified date initially", adminUsersPage.isTableSortedByModifiedDate());
-		assertFalse("Table should not be sorted by username initially", adminUsersPage.isTableSortedByUsername());
+		assertFalse("Table should not be sorted by username", adminUsersPage.isTableSortedByUsername());
 		adminUsersPage.sortTableByUsername();
 		assertTrue("Table should be sorted by username", adminUsersPage.isTableSortedByUsername());
 		adminUsersPage.sortTableByModifiedDate();


### PR DESCRIPTION
## Description of changes
When designing the tests for this table, I forgot to take into account that I was checking a column of dates was sorted.  This fixes the test by first ensuring the date is formatted properly, and then converting it to milliseconds before checking to see if the column is sorted properly.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~~
* [X] Tests added (or description of how to test) for any new features.
~~* [ ] User documentation updated for UI or technical changes.~~
