### PR TITLE
🔨️ Fixed missing icon on GalaxyAlert

### DIFF
--- a/src/main/webapp/resources/js/components/Header/GalaxyAlert.jsx
+++ b/src/main/webapp/resources/js/components/Header/GalaxyAlert.jsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { Alert, Icon } from "antd";
+import { Alert } from "antd";
 import { removeGalaxySession } from "../../apis/galaxy/galaxy";
 import { FONT_WEIGHT_HEAVY } from "../../styles/fonts";
 import { SPACE_XS } from "../../styles/spacing";
+import { IconLinkOut } from "../icons/Icons";
 
 export default function GalaxyAlert() {
   const galaxyUrl = window
@@ -25,7 +26,7 @@ export default function GalaxyAlert() {
         rel="noopener noreferrer"
         href="https://irida.corefacility.ca/documentation/user/user/samples/#galaxy-export"
       >
-        {window.GALAXY.DOCUMENTATION} <Icon type="link" />
+        {window.GALAXY.DOCUMENTATION} <IconLinkOut />
       </a>
     </span>
   );


### PR DESCRIPTION
## Description of changes
The link icon on the Galaxy Alert was missed during the last upgrade.  This fixes it.

## Related issue
N/A

## Checklist
N/A
