### PR TITLE
Added missing translations for project samples date range filter

### DIFF
--- a/src/main/webapp/pages/projects/project_samples.html
+++ b/src/main/webapp/pages/projects/project_samples.html
@@ -41,6 +41,14 @@
             /*[[@{/projects/{id}/ajax/samples/missing(id=${project.getId()})}]]*/ "/projects/{projectId}/ajax/samples/missing"
         }
       };
+
+      // Translations for the date range filter modal
+      window.translations = [{
+        "project.sample.filter.date.format": /*[[#{project.sample.filter.date.format}]]*/ "",
+        "project.sample.filter.date.month": /*[[#{project.sample.filter.date.month}]]*/ "",
+        "project.sample.filter.date.months3": /*[[#{project.sample.filter.date.months3}]]*/ "",
+        "project.sample.filter.date.months6": /*[[#{project.sample.filter.date.months6}]]*/ "",
+        "project.sample.filter.date.year": /*[[#{project.sample.filter.date.year}]]*/ ""}];
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Description of changes
Because the project samples filter is loaded into a modal separate from webpack builds (it is loaded using bootstrap itself), they are not added to the `window.translations` array.  This manually adds them.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] ~~CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~~
* [ ] ~~Tests added (or description of how to test) for any new features.~~
* [ ] ~~User documentation updated for UI or technical changes.~~
