### PR TITLE
Disbale fastqc zipped

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/sequenceFile/Fast5Object.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/sequenceFile/Fast5Object.java
@@ -115,7 +115,7 @@ public class Fast5Object extends SequencingObject {
 			} else if (extension.equals("fast5")) {
 				type = Fast5Object.Fast5Type.SINGLE;
 			}
-		} catch (IOException e) {
+		} catch (Exception e) {
 			logger.warn("Problem checking for zipped file.  Setting as UNKNOWN type", e);
 		}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/sequenceFile/Fast5Object.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/sequenceFile/Fast5Object.java
@@ -1,6 +1,5 @@
 package ca.corefacility.bioinformatics.irida.model.sequenceFile;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.Set;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/FileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/FileProcessor.java
@@ -40,12 +40,12 @@ public interface FileProcessor {
 	/**
 	 * This method asks the file processor whether it should act on this file.
 	 * The processor may have some settings that would not run on certain files.
-	 * 
-	 * @param sequencingObjectId
-	 *            the {@link SequencingObject} id to check
+	 *
+	 * @param sequencingObject
+	 *            the {@link SequencingObject} to check
 	 * @return true if the processor should act on the file
 	 */
-	public default boolean shouldProcessFile(Long sequencingObjectId) {
+	public default boolean shouldProcessFile(SequencingObject sequencingObject) {
 		return true;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/AutomatedAnalysisFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/AutomatedAnalysisFileProcessor.java
@@ -6,6 +6,7 @@ import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectSampleJoin;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.SampleSequencingObjectJoin;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.Fast5Object;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 import ca.corefacility.bioinformatics.irida.model.workflow.IridaWorkflow;
 import ca.corefacility.bioinformatics.irida.model.workflow.analysis.type.AnalysisType;
@@ -288,5 +289,13 @@ public class AutomatedAnalysisFileProcessor implements FileProcessor {
 				logger.error("Could not associate automated workflow with analysis " + submission.getIdentifier(), e);
 			}
 		}
+	}
+
+	@Override
+	public boolean shouldProcessFile(SequencingObject sequencingObject) {
+		if (sequencingObject instanceof Fast5Object) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/AutomatedAnalysisFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/AutomatedAnalysisFileProcessor.java
@@ -297,6 +297,7 @@ public class AutomatedAnalysisFileProcessor implements FileProcessor {
 
 	@Override
 	public boolean shouldProcessFile(SequencingObject sequencingObject) {
+		//don't want to run for fast5 data because no pipelines support it yet.
 		if (sequencingObject instanceof Fast5Object) {
 			return false;
 		}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/DefaultFileProcessingChain.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/DefaultFileProcessingChain.java
@@ -77,9 +77,9 @@ public class DefaultFileProcessingChain implements FileProcessingChain {
 
 		for (FileProcessor fileProcessor : fileProcessors) {
 			try {
-				if (fileProcessor.shouldProcessFile(sequencingObjectId)) {
-					SequencingObject settledSequencingObject = getSettledSequencingObject(sequencingObjectId);
+				SequencingObject settledSequencingObject = getSettledSequencingObject(sequencingObjectId);
 
+				if (fileProcessor.shouldProcessFile(settledSequencingObject)) {
 					fileProcessor.process(settledSequencingObject);
 				}
 			} catch (FileProcessorException e) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
@@ -1,5 +1,6 @@
 package ca.corefacility.bioinformatics.irida.processing.impl;
 
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.Fast5Object;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.OverrepresentedSequence;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFile;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
@@ -71,8 +72,20 @@ public class FastqcFileProcessor implements FileProcessor {
 	@Override
 	@Transactional
 	public void process(SequencingObject sequencingObject) {
-		for (SequenceFile file : sequencingObject.getFiles()) {
-			processSingleFile(file);
+		boolean processFile = true;
+		if (sequencingObject instanceof Fast5Object) {
+			if (((Fast5Object) sequencingObject).getFast5Type()
+					.equals(Fast5Object.Fast5Type.ZIPPED)) {
+				processFile = false;
+			}
+		}
+
+		if (processFile) {
+			for (SequenceFile file : sequencingObject.getFiles()) {
+				processSingleFile(file);
+			}
+		} else {
+			logger.debug("Not running file processor for file. Object id: " + sequencingObject.getId());
 		}
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
@@ -73,6 +73,8 @@ public class FastqcFileProcessor implements FileProcessor {
 	@Transactional
 	public void process(SequencingObject sequencingObject) {
 		boolean processFile = true;
+
+		//we don't want to run the processor for zipped fast5 files.  It will just fail and create a qc entry even though it did what it was supposed to
 		if (sequencingObject instanceof Fast5Object) {
 			if (((Fast5Object) sequencingObject).getFast5Type()
 					.equals(Fast5Object.Fast5Type.ZIPPED)) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/FastqcFileProcessor.java
@@ -72,22 +72,8 @@ public class FastqcFileProcessor implements FileProcessor {
 	@Override
 	@Transactional
 	public void process(SequencingObject sequencingObject) {
-		boolean processFile = true;
-
-		//we don't want to run the processor for zipped fast5 files.  It will just fail and create a qc entry even though it did what it was supposed to
-		if (sequencingObject instanceof Fast5Object) {
-			if (((Fast5Object) sequencingObject).getFast5Type()
-					.equals(Fast5Object.Fast5Type.ZIPPED)) {
-				processFile = false;
-			}
-		}
-
-		if (processFile) {
-			for (SequenceFile file : sequencingObject.getFiles()) {
-				processSingleFile(file);
-			}
-		} else {
-			logger.debug("Not running file processor for file. Object id: " + sequencingObject.getId());
+		for (SequenceFile file : sequencingObject.getFiles()) {
+			processSingleFile(file);
 		}
 	}
 
@@ -259,5 +245,19 @@ public class FastqcFileProcessor implements FileProcessor {
 	@Override
 	public Boolean modifiesFile() {
 		return false;
+	}
+
+	@Override
+	public boolean shouldProcessFile(SequencingObject sequencingObject) {
+		//we don't want to run the processor for zipped or unknown fast5 files.  It will just fail and create a qc entry even though it did what it was supposed to
+		if (sequencingObject instanceof Fast5Object) {
+			Fast5Object fast5 = (Fast5Object) sequencingObject;
+			if (!fast5.getFast5Type()
+					.equals(Fast5Object.Fast5Type.SINGLE)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/GzipFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/GzipFileProcessor.java
@@ -74,16 +74,15 @@ public class GzipFileProcessor implements FileProcessor {
 
 	/**
 	 * {@inheritDoc}
-     */
-    @Transactional
-    @Override
-    public void process(SequencingObject sequencingObject) {
-        //we don't want to unzip fast5 objects for now because it may be a directory of objects
-        if (!disableFileProcessor && !(sequencingObject instanceof Fast5Object)) {
-            for (SequenceFile file : sequencingObject.getFiles()) {
-                processSingleFile(file);
-            }
-        } else {
+	 */
+	@Transactional
+	@Override
+	public void process(SequencingObject sequencingObject) {
+		if (!disableFileProcessor) {
+			for (SequenceFile file : sequencingObject.getFiles()) {
+				processSingleFile(file);
+			}
+		} else {
 			logger.debug("Not running process. It has been disabled");
 		}
 	}
@@ -172,5 +171,14 @@ public class GzipFileProcessor implements FileProcessor {
 	@Override
 	public Boolean modifiesFile() {
 		return !disableFileProcessor;
+	}
+
+	@Override
+	public boolean shouldProcessFile(SequencingObject sequencingObject) {
+		//we don't want to unzip fast5 objects for now because it may be a directory of objects
+		if (sequencingObject instanceof Fast5Object) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/impl/unit/AutomatedAnalysisFileProcessorTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/impl/unit/AutomatedAnalysisFileProcessorTest.java
@@ -133,7 +133,7 @@ public class AutomatedAnalysisFileProcessorTest {
 				ImmutableList.of(new ProjectSampleJoin(project, sample, true)));
 		when(submissionRepository.save(any(AnalysisSubmission.class))).thenReturn(built);
 
-		assertTrue("should want to assemble file", processor.shouldProcessFile(sequenceFileId));
+		assertTrue("should want to assemble file", processor.shouldProcessFile(pair));
 		processor.process(pair);
 
 		verify(submissionRepository).save(any(AnalysisSubmission.class));
@@ -174,7 +174,7 @@ public class AutomatedAnalysisFileProcessorTest {
 				ImmutableList.of(new ProjectSampleJoin(project, sample, true)));
 		when(submissionRepository.save(any(AnalysisSubmission.class))).thenReturn(built);
 
-		assertTrue("should want to assemble file", processor.shouldProcessFile(sequenceFileId));
+		assertTrue("should want to assemble file", processor.shouldProcessFile(pair));
 		processor.process(pair);
 
 		verify(submissionRepository).save(any(AnalysisSubmission.class));

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/impl/unit/FastqcFileProcessorTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/impl/unit/FastqcFileProcessorTest.java
@@ -1,9 +1,6 @@
 package ca.corefacility.bioinformatics.irida.processing.impl.unit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
@@ -73,14 +70,18 @@ public class FastqcFileProcessorTest {
 	}
 
 	@Test
-	public void testHandleFast5FileZipped() throws IOException {
+	public void testHandleFast5File() throws IOException {
 		//ensure we don't process zipped fast5 files
 		Fast5Object obj = new Fast5Object(new SequenceFile(null));
+
+		obj.setFast5Type(Fast5Object.Fast5Type.SINGLE);
+		assertTrue("should want to process single fast5 file)", fileProcessor.shouldProcessFile(obj));
+
 		obj.setFast5Type(Fast5Object.Fast5Type.ZIPPED);
+		assertFalse("should not want to process zipped fast5 file)", fileProcessor.shouldProcessFile(obj));
 
-		fileProcessor.process(obj);
-
-		verifyZeroInteractions(sequenceFileRepository);
+		obj.setFast5Type(Fast5Object.Fast5Type.UNKNOWN);
+		assertFalse("should not want to process unknown fast5 file)", fileProcessor.shouldProcessFile(obj));
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/processing/impl/unit/FastqcFileProcessorTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/processing/impl/unit/FastqcFileProcessorTest.java
@@ -5,9 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -16,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Iterator;
 
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.Fast5Object;
 import ca.corefacility.bioinformatics.irida.model.workflow.analysis.AnalysisOutputFile;
 import ca.corefacility.bioinformatics.irida.repositories.analysis.AnalysisOutputFileRepository;
 import org.junit.Before;
@@ -71,6 +70,17 @@ public class FastqcFileProcessorTest {
 		SingleEndSequenceFile so = new SingleEndSequenceFile(sf);
 
 		fileProcessor.process(so);
+	}
+
+	@Test
+	public void testHandleFast5FileZipped() throws IOException {
+		//ensure we don't process zipped fast5 files
+		Fast5Object obj = new Fast5Object(new SequenceFile(null));
+		obj.setFast5Type(Fast5Object.Fast5Type.ZIPPED);
+
+		fileProcessor.process(obj);
+
+		verifyZeroInteractions(sequenceFileRepository);
 	}
 
 	@Test


### PR DESCRIPTION
## Description of changes
Disabling the FastQC file processor for zipped fast5 files (`.fast5.tar.gz`).  Previously it was failing "gracefully", but that was creating qc entries for the failure even though it was working as intended.  Now it just skips the processor for that file type.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
