### PR TITLE
Analysis Priority when project setting is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Changes
 * [UI]: Fixed bug preventing advanced visualization view page load.
 * [UI/Developer]: Updated analysis urls to work with a context path.
 * [UI]: Outputs and Tree view now span the full width of the page.
+* [Processing]: Fixed bug where analyses wouldn't run if project didn't have analysis priority.
 
 19.09 to 20.01
 --------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/AutomatedAnalysisFileProcessor.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/processing/impl/AutomatedAnalysisFileProcessor.java
@@ -116,7 +116,11 @@ public class AutomatedAnalysisFileProcessor implements FileProcessor {
 						builder.name(templateName);
 
 						//set the analysis priority to the setting for the project
-						builder.priority(project.getAnalysisPriority());
+						if (project.getAnalysisPriority() != null) {
+							builder.priority(project.getAnalysisPriority());
+						} else {
+							builder.priority(AnalysisSubmission.Priority.LOW);
+						}
 
 						//build the submission and save it
 						AnalysisSubmission submission = builder.inputFiles(Sets.newHashSet(sequencingObject))


### PR DESCRIPTION
## Description of changes
Added default analysis priority when the project doens't have one set.  Previously this would throw a nullpointerexception.  I think it only would happen in the dev database, but worth protecting anyway.

## Related issue
N/A
## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
