### PR TITLE
Removed deprecated Long constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes
 --------------
 * [UI] Updated project user groups to use Ant Design.
 * [UI/Developer]: Removed most dependency for `momentjs` (only on project samples filters).
+* [Developer]: Removed deprecated Long constructor.
 
 20.01 to 20.05
 --------------

--- a/src/test/java/ca/corefacility/bioinformatics/irida/model/SampleTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/model/SampleTest.java
@@ -155,7 +155,7 @@ public class SampleTest {
 
 		PipelineProvidedMetadataEntry actualEntry = (PipelineProvidedMetadataEntry) sample2.getMetadata().get(field1);
 
-		assertEquals("Updated metadata entry does not point to correct submission", new Long(2),
+		assertEquals("Updated metadata entry does not point to correct submission", Long.valueOf(2),
 				actualEntry.getSubmission().getId());
 		assertEquals("Non-updated metadata entry does not match", this.pipelineEntry2,
 				sample2.getMetadata().get(field2));

--- a/src/test/java/ca/corefacility/bioinformatics/irida/model/UserTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/model/UserTest.java
@@ -238,7 +238,7 @@ public class UserTest {
 	@Test
 	public void testEqualsFields() {
 		User u1 = new User("username", "email", "password", "firstName", "lastName", "phoneNumber");
-		u1.setId(new Long(1111));
+		u1.setId(1111L);
 
 		User u2 = new User("username", "email", "password", "firstName", "notequal", "phoneNumber");
 		u2.setId(u1.getId());

--- a/src/test/java/ca/corefacility/bioinformatics/irida/model/sample/metadata/unit/MetadataEntryTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/model/sample/metadata/unit/MetadataEntryTest.java
@@ -40,7 +40,7 @@ public class MetadataEntryTest {
 		e1.merge(e2);
 
 		assertEquals("Metadata entries did not merge", "e2", e1.getValue());
-		assertEquals("Metadata entries did not merge", new Long(2L), e1.getSubmission().getId());
+		assertEquals("Metadata entries did not merge", Long.valueOf(2), e1.getSubmission().getId());
 	}
 	
 	@Test
@@ -59,7 +59,7 @@ public class MetadataEntryTest {
 
 		assertEquals("Metadata entries did not merge", "e2", e1.getValue());
 		assertEquals("Metadata entries did not merge", "text2", e1.getType());
-		assertEquals("Metadata entries did not merge", new Long(2L), e1.getSubmission().getId());
+		assertEquals("Metadata entries did not merge", Long.valueOf(2), e1.getSubmission().getId());
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/src/test/java/ca/corefacility/bioinformatics/irida/repositories/filesystem/SequenceFileRepositoryImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/repositories/filesystem/SequenceFileRepositoryImplTest.java
@@ -64,7 +64,7 @@ public class SequenceFileRepositoryImplTest {
 
 	@Test
 	public void testCreateFile() throws IOException {
-		Long lid = new Long(1111);
+		Long lid = 1111L;
 		Path f = getTempFile();
 		String filename = f.getFileName().toString();
 		SequenceFile s = new SequenceFile(f);
@@ -112,7 +112,7 @@ public class SequenceFileRepositoryImplTest {
 	public void testUpdateExistingFilename() throws IOException {
 		String originalText = "old text.";
 		String updatedText = "new text.";
-		Long lid = new Long(1111);
+		Long lid = 1111L;
 		Path oldFile = getTempFile();
 		Files.write(oldFile, originalText.getBytes());
 		SequenceFile sf = new SequenceFile(oldFile);
@@ -156,7 +156,7 @@ public class SequenceFileRepositoryImplTest {
 
 	@Test
 	public void testUpdate() throws IOException {
-		Long lId = new Long(9999);
+		Long lId = 9999L;
 		Path originalFile = getTempFile();
 		SequenceFile original = new SequenceFile(originalFile);
 		original.setId(lId);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/repositories/relational/auditing/UserRevListenerIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/repositories/relational/auditing/UserRevListenerIT.java
@@ -53,7 +53,7 @@ public class UserRevListenerIT {
 		Revision<Integer, Project> findLastChangeRevision = projectRepository.findLastChangeRevision(read.getId()).orElse(null);
 		UserRevEntity findRevision = auditReader.findRevision(UserRevEntity.class,
 				findLastChangeRevision.getRevisionNumber().orElse(null));
-		assertEquals("client id should be set in revision", new Long(1), findRevision.getClientId());
+		assertEquals("client id should be set in revision", Long.valueOf(1), findRevision.getClientId());
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/AnnouncementServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/AnnouncementServiceImplIT.java
@@ -369,11 +369,11 @@ public class AnnouncementServiceImplIT {
         for (Announcement a: announcements) {
             Long id = a.getId();
             if (id == 1) {
-                assertEquals(failMessage, new Long(4), counts.get(a));
+                assertEquals(failMessage, Long.valueOf(4), counts.get(a));
             } else if (id >= 2 && id <= 5) {
-                assertEquals(failMessage, new Long(1), counts.get(a));
+                assertEquals(failMessage, Long.valueOf(1), counts.get(a));
             } else if (id == 6) {
-                assertEquals(failMessage, new Long(0), counts.get(a));
+                assertEquals(failMessage, Long.valueOf(0), counts.get(a));
             } else {
                 fail("Error in counting, this announcement shouldn't be counted");
             }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/GenomeAssemblyServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/GenomeAssemblyServiceImplIT.java
@@ -61,7 +61,7 @@ public class GenomeAssemblyServiceImplIT {
 				.next();
 		assertEquals("Should be same sample", s.getId(), join.getSubject()
 				.getId());
-		assertEquals("Should be same assembly", new Long(1L), join.getObject()
+		assertEquals("Should be same assembly", Long.valueOf(1), join.getObject()
 				.getId());
 	}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/ProjectServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/ProjectServiceImplIT.java
@@ -707,7 +707,7 @@ public class ProjectServiceImplIT {
 		assertEquals("should have found 1 project", 1, projectsForSequencingObjects.size());
 		Project project = projectsForSequencingObjects.iterator().next();
 
-		assertEquals("should have found project 2", new Long(2), project.getId());
+		assertEquals("should have found project 2", Long.valueOf(2), project.getId());
 	}
 
 	@Test
@@ -729,7 +729,7 @@ public class ProjectServiceImplIT {
 
 		assertEquals("should have found 1 project", 1, projects.size());
 		ProjectAnalysisSubmissionJoin project = projects.iterator().next();
-		assertEquals("should have found project 2", new Long(2L), project.getSubject().getId());
+		assertEquals("should have found project 2", Long.valueOf(2), project.getSubject().getId());
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/SequencingObjectServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/SequencingObjectServiceImplIT.java
@@ -251,7 +251,7 @@ public class SequencingObjectServiceImplIT {
 		assertEquals(1, sequencesForSampleOfType.size());
 		SampleSequencingObjectJoin join = sequencesForSampleOfType.iterator().next();
 
-		assertEquals(new Long(4), join.getObject().getId());
+		assertEquals(Long.valueOf(4), join.getObject().getId());
 	}
 
 	@Test
@@ -264,7 +264,7 @@ public class SequencingObjectServiceImplIT {
 		assertEquals(1, sequencesForSampleOfType.size());
 		SampleSequencingObjectJoin join = sequencesForSampleOfType.iterator().next();
 
-		assertEquals(new Long(2), join.getObject().getId());
+		assertEquals(Long.valueOf(2), join.getObject().getId());
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/SequencingRunServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/SequencingRunServiceImplIT.java
@@ -241,7 +241,7 @@ public class SequencingRunServiceImplIT {
 		List<SequencingRun> runs = Lists.newArrayList(findAll);
 		assertEquals("user should be able to see 1 run", 1, runs.size());
 		SequencingRun run = runs.iterator().next();
-		assertEquals("id should be 1", new Long(1), run.getId());
+		assertEquals("id should be 1", Long.valueOf(1), run.getId());
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/analysis/submission/AnalysisSubmissionServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/analysis/submission/AnalysisSubmissionServiceImplIT.java
@@ -626,7 +626,7 @@ public class AnalysisSubmissionServiceImplIT {
 	@WithMockUser(username = "otheraaron", roles = "USER")
 	public void testReadSharedAnalysis() {
 		AnalysisSubmission read = analysisSubmissionService.read(3L);
-		assertEquals("id should be 3", new Long(3), read.getId());
+		assertEquals("id should be 3", Long.valueOf(3), read.getId());
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/CRUDServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/CRUDServiceImplTest.java
@@ -143,7 +143,7 @@ public class CRUDServiceImplTest {
 	@Ignore
 	@Test(expected = EntityNotFoundException.class)
 	public void testUpdateMissingEntity() {
-		Long id = new Long(1);
+		Long id = 1L;
 		Map<String, Object> updatedProperties = new HashMap<>();
 		when(crudRepository.existsById(id)).thenReturn(Boolean.FALSE);
 
@@ -169,7 +169,7 @@ public class CRUDServiceImplTest {
 	@Test
 	public void testUpdateWithBadPropertyType() {
 		IdentifiableTestEntity entity = new IdentifiableTestEntity();
-		entity.setId(new Long(1));
+		entity.setId(1L);
 		Map<String, Object> updatedProperties = new HashMap<>();
 		updatedProperties.put("integerValue", new Object());
 		when(crudRepository.findById(1L)).thenReturn(Optional.of(entity));
@@ -187,7 +187,7 @@ public class CRUDServiceImplTest {
 		IdentifiableTestEntity i = new IdentifiableTestEntity();
 		i.setNonNull("Definitely not null.");
 		i.setIntegerValue(Integer.MIN_VALUE);
-		Long id = new Long(1);
+		Long id = 1L;
 		i.setId(id);
 		when(crudRepository.existsById(id)).thenReturn(Boolean.TRUE);
 		when(crudRepository.findById(id)).thenReturn(Optional.of(i));
@@ -208,7 +208,7 @@ public class CRUDServiceImplTest {
 	@Test
 	public void testRead() {
 		IdentifiableTestEntity i = new IdentifiableTestEntity();
-		i.setId(new Long(1));
+		i.setId(1L);
 		i.setNonNull("Definitely not null");
 
 		when(crudRepository.findById(i.getId())).thenReturn(Optional.of(i));
@@ -238,7 +238,7 @@ public class CRUDServiceImplTest {
 	@Test
 	public void testExists() {
 		IdentifiableTestEntity i = new IdentifiableTestEntity();
-		i.setId(new Long(1));
+		i.setId(1L);
 		when(crudRepository.existsById(i.getId())).thenReturn(Boolean.TRUE);
 		assertTrue(crudService.exists(i.getId()));
 	}
@@ -246,7 +246,7 @@ public class CRUDServiceImplTest {
 	@Test
 	public void testValidDelete() {
 		IdentifiableTestEntity i = new IdentifiableTestEntity();
-		i.setId(new Long(1));
+		i.setId(1L);
 
 		when(crudService.exists(i.getId())).thenReturn(Boolean.TRUE);
 
@@ -260,7 +260,7 @@ public class CRUDServiceImplTest {
 	@Ignore
 	@Test(expected = EntityNotFoundException.class)
 	public void testInvalidDelete() {
-		Long id = new Long(1);
+		Long id = 1L;
 		when(crudRepository.existsById(id)).thenReturn(Boolean.FALSE);
 
 		crudService.delete(id);
@@ -269,7 +269,7 @@ public class CRUDServiceImplTest {
 	@Ignore
 	@Test(expected = EntityNotFoundException.class)
 	public void testGetMissingEntity() {
-		Long id = new Long(1);
+		Long id = 1L;
 		when(crudRepository.findById(id)).thenReturn(Optional.of(null));
 
 		crudService.read(id);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/ProjectServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/ProjectServiceImplTest.java
@@ -131,7 +131,7 @@ public class ProjectServiceImplTest {
 	public void testAddSampleToProject() {
 		Sample s = new Sample();
 		s.setSampleName("sample");
-		s.setId(new Long(2222));
+		s.setId(2222L);
 		Project p = project();
 
 		ProjectSampleJoin join = new ProjectSampleJoin(p, s, true);
@@ -152,7 +152,7 @@ public class ProjectServiceImplTest {
 	@Test
 	public void testAddUserToProject() {
 		User u = new User("test", "test@nowhere.com", "PASSWOD!1", "Test", "User", "1234");
-		u.setId(new Long(1111));
+		u.setId(1111L);
 		Project p = project();
 		ProjectRole r = ProjectRole.PROJECT_USER;
 		ProjectUserJoin join = new ProjectUserJoin(p, u, r);
@@ -167,7 +167,7 @@ public class ProjectServiceImplTest {
 	@Test(expected = EntityExistsException.class)
 	public void testAddUserToProjectTwice() {
 		User u = new User("test", "test@nowhere.com", "PASSWOD!1", "Test", "User", "1234");
-		u.setId(new Long(1111));
+		u.setId(1111L);
 		Project p = project();
 		ProjectRole r = ProjectRole.PROJECT_USER;
 		ProjectUserJoin join = new ProjectUserJoin(p, u, r);
@@ -400,7 +400,7 @@ public class ProjectServiceImplTest {
 
 	private Project project() {
 		Project p = new Project("project");
-		p.setId(new Long(2222));
+		p.setId(2222L);
 		return p;
 	}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/util/impl/SequenceFileUtilitiesTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/util/impl/SequenceFileUtilitiesTest.java
@@ -29,7 +29,7 @@ public class SequenceFileUtilitiesTest {
 		Path file = Paths.get(getClass().getResource(
 				"/ca/corefacility/bioinformatics/irida/service/testReference.fasta").toURI());
 		Long sequenceFileLength = sequenceFileUtilities.countSequenceFileLengthInBases(file);
-		assertEquals("Should have 4 bases.", new Long(4), sequenceFileLength);
+		assertEquals("Should have 4 bases.", Long.valueOf(4), sequenceFileLength);
 	}
 
 	@Test


### PR DESCRIPTION
## Description of changes
Removed any uses of `new Long()` as it's deprecated in Java 9.  Updated to using `Long.valueOf(#)` or `#L` which is better supported.  This removes some build warnings in IntelliJ.

To test this PR, verify that the intergration tests complete successfully on TravisCI.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
