### PR TITLE
Syncing with older versions of IRIDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ Changes
 --------------
 * [UI]: Fixed bug where sequencing runs could not be deleted on sequencing runs details page. (20.09.1)
 * [Developer] Fixed `SISTR viewer` so plugin and built-in pipelines can use it (20.09.1)
-* [UI] Added two additional fields to SISTR viewer describing the number of alleles found (20.09.1)
+* [UI]: Added two additional fields to SISTR viewer describing the number of alleles found (20.09.1)
+* [REST]: Added handling for synchronizing data from older IRIDA instances.  It was failing for APIs without assembly functionality addded in 20.09. (20.09.2)
 
 20.05 to 20.09
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>20.09.1</version>
+	<version>20.09.2</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/LinkNotFoundException.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/LinkNotFoundException.java
@@ -1,5 +1,8 @@
 package ca.corefacility.bioinformatics.irida.exceptions;
 
+/**
+ * Exception thrown when there is no link for a given rel when reading from an API
+ */
 public class LinkNotFoundException extends RuntimeException {
 
 	public LinkNotFoundException(String message) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/LinkNotFoundException.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/LinkNotFoundException.java
@@ -1,0 +1,8 @@
+package ca.corefacility.bioinformatics.irida.exceptions;
+
+public class LinkNotFoundException extends RuntimeException {
+
+	public LinkNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/GenomeAssemblyRemoteService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/GenomeAssemblyRemoteService.java
@@ -1,5 +1,6 @@
 package ca.corefacility.bioinformatics.irida.service.remote;
 
+import ca.corefacility.bioinformatics.irida.exceptions.LinkNotFoundException;
 import ca.corefacility.bioinformatics.irida.model.assembly.GenomeAssembly;
 import ca.corefacility.bioinformatics.irida.model.assembly.UploadedAssembly;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
@@ -15,8 +16,9 @@ public interface GenomeAssemblyRemoteService extends RemoteService<UploadedAssem
 	 *
 	 * @param sample the Sample to get assemblies for
 	 * @return a list of {@link UploadedAssembly}
+	 * @throws LinkNotFoundException if the targeted API does not support assemblies
 	 */
-	public List<UploadedAssembly> getGenomeAssembliesForSample(Sample sample);
+	public List<UploadedAssembly> getGenomeAssembliesForSample(Sample sample) throws LinkNotFoundException;
 
 	/**
 	 * Download the given {@link UploadedAssembly} to the local server

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -1,6 +1,7 @@
 package ca.corefacility.bioinformatics.irida.service.remote;
 
 import ca.corefacility.bioinformatics.irida.exceptions.IridaOAuthException;
+import ca.corefacility.bioinformatics.irida.exceptions.LinkNotFoundException;
 import ca.corefacility.bioinformatics.irida.exceptions.ProjectSynchronizationException;
 import ca.corefacility.bioinformatics.irida.model.MutableIridaThing;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
@@ -35,6 +36,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
+
+import com.google.common.collect.Lists;
 
 /**
  * Service class to run a project synchornization task. Ths class will be
@@ -372,7 +375,13 @@ public class ProjectSynchronizationService {
 		}
 
 		//list the remote assemblies for the sample
-		List<UploadedAssembly> genomeAssembliesForSample = assemblyRemoteService.getGenomeAssembliesForSample(sample);
+		List<UploadedAssembly> genomeAssembliesForSample = Lists.newArrayList();
+		try {
+			genomeAssembliesForSample = assemblyRemoteService.getGenomeAssembliesForSample(sample);
+		} catch (LinkNotFoundException e) {
+			logger.warn("The referenced IRIDA instance doesn't support assemblies.");
+		}
+
 
 		//for each assembly
 		for (UploadedAssembly file : genomeAssembliesForSample) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -374,12 +374,14 @@ public class ProjectSynchronizationService {
 			}
 		}
 
-		//list the remote assemblies for the sample
-		List<UploadedAssembly> genomeAssembliesForSample = Lists.newArrayList();
+		//list the remote assemblies for the sample.
+		List<UploadedAssembly> genomeAssembliesForSample;
 		try {
 			genomeAssembliesForSample = assemblyRemoteService.getGenomeAssembliesForSample(sample);
 		} catch (LinkNotFoundException e) {
+			//if the target IRIDA doesn't support assemblies yet, warn and ignore assemblies.
 			logger.warn("The referenced IRIDA instance doesn't support assemblies.");
+			genomeAssembliesForSample = Lists.newArrayList();
 		}
 
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -380,10 +380,9 @@ public class ProjectSynchronizationService {
 			genomeAssembliesForSample = assemblyRemoteService.getGenomeAssembliesForSample(sample);
 		} catch (LinkNotFoundException e) {
 			//if the target IRIDA doesn't support assemblies yet, warn and ignore assemblies.
-			logger.warn("The referenced IRIDA instance doesn't support assemblies.");
+			logger.warn("The sample on the referenced IRIDA doesn't support assemblies: " + sample.getSelfHref());
 			genomeAssembliesForSample = Lists.newArrayList();
 		}
-
 
 		//for each assembly
 		for (UploadedAssembly file : genomeAssembliesForSample) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/impl/GenomeAssemblyRemoteServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/impl/GenomeAssemblyRemoteServiceImpl.java
@@ -43,7 +43,7 @@ public class GenomeAssemblyRemoteServiceImpl extends RemoteServiceImpl<UploadedA
 	 * {@inheritDoc}
 	 */
 	@Override
-	public List<UploadedAssembly> getGenomeAssembliesForSample(Sample sample) {
+	public List<UploadedAssembly> getGenomeAssembliesForSample(Sample sample) throws LinkNotFoundException {
 		if (!sample.hasLink(SAMPLE_ASSEMBLY_REL)) {
 			throw new LinkNotFoundException("No link for rel: " + SAMPLE_ASSEMBLY_REL);
 		}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/impl/GenomeAssemblyRemoteServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/impl/GenomeAssemblyRemoteServiceImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Service;
 
+import ca.corefacility.bioinformatics.irida.exceptions.LinkNotFoundException;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
 import ca.corefacility.bioinformatics.irida.model.assembly.UploadedAssembly;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
@@ -43,6 +44,9 @@ public class GenomeAssemblyRemoteServiceImpl extends RemoteServiceImpl<UploadedA
 	 */
 	@Override
 	public List<UploadedAssembly> getGenomeAssembliesForSample(Sample sample) {
+		if (!sample.hasLink(SAMPLE_ASSEMBLY_REL)) {
+			throw new LinkNotFoundException("No link for rel: " + SAMPLE_ASSEMBLY_REL);
+		}
 		Link link = sample.getLink(SAMPLE_ASSEMBLY_REL);
 		String href = link.getHref();
 


### PR DESCRIPTION
## Description of changes
Allowing IRIDA 20.09 to synchronize with older versions which do not yet have the assemblies available in the REST API.

## Related issue
Fixes #819 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
