### PR TITLE
adding the github acitons CI badge to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/phac-nml/irida.svg?branch=development)](https://travis-ci.org/phac-nml/irida)
+![Integration Tests](https://github.com/phac-nml/irida/workflows/Integration%20Tests/badge.svg?branch=development&event=schedule)
 [![GitHub release](https://img.shields.io/github/release/phac-nml/irida.svg)](https://github.com/phac-nml/irida/releases/latest)
 [![Gitter](https://img.shields.io/gitter/room/phac-nml/irida.svg)](https://gitter.im/irida-project/Lobby)
 


### PR DESCRIPTION
## Description of changes
Switched the badge for the CI build status to link to our GitHub actions builds.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
