### PR TITLE
Added link to GitHub Actions CI in readme badge

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-doc_testing-${{ hashFiles('**/pom.xml') }}
 
       - name: Set up JDK 11 # Installs java 11
         uses: actions/setup-java@v1

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ matrix.suite }}-${{ hashFiles('**/pom.xml') }}
       - name: Cache Node modules #Pull the cache for node_modules.  This caches all dependencies assuming the yarn.lock file stays the same
         uses: actions/cache@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Integration Tests](https://github.com/phac-nml/irida/workflows/Integration%20Tests/badge.svg?branch=development&event=schedule)
+[![Integration Tests](https://github.com/phac-nml/irida/workflows/Integration%20Tests/badge.svg?branch=development&event=schedule)](https://github.com/phac-nml/irida/actions?query=branch%3Adevelopment)
 [![GitHub release](https://img.shields.io/github/release/phac-nml/irida.svg)](https://github.com/phac-nml/irida/releases/latest)
 [![Gitter](https://img.shields.io/gitter/room/phac-nml/irida.svg)](https://gitter.im/irida-project/Lobby)
 


### PR DESCRIPTION
## Description of changes
Added link to CI results when clicking badge.

In a later change this also changed the maven dependency caching to separate by profile.  Different profiles have different dependencies in some cases and were getting missed by the cache.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
