### PR TITLE
Fix project settings css hrefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Changes
 * [Developer]: Switched to Chromedriver 86 to match Github Actions chrome version.
 * [UI]: Fixed bug where a user could not click the `Sync Now` button for a remote project if the status was set to `Unauthorized`. (20.09.4)
 * [UI]: Fixed issue with project samples table not displaying `Created Date` and `Modified Date` for samples. (20.09.4)
+* [UI]: Fixed broken CSS bundle links in project settings pages. (20.09.5)
 
 20.05 to 20.09
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>20.09.4</version>
+	<version>20.09.5</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/pages/projects/settings/pages/associated.html
+++ b/src/main/webapp/pages/projects/settings/pages/associated.html
@@ -8,7 +8,7 @@
     <title th:text="#{project.associated.heading(${project.label})}">
       ASSOCIATED PROJECTS
     </title>
-    <link rel="stylesheet" href="/dist/css/associated-projects.bundle.css" />
+    <link rel="stylesheet" href="#" th:href="@{/dist/css/associated-projects.bundle.css}" />
     <script th:inline="javascript">
       window.PAGE = {
         permissions: /*[[${isAdmin or isOwner}]]*/ false,

--- a/src/main/webapp/pages/projects/settings/pages/associated.html
+++ b/src/main/webapp/pages/projects/settings/pages/associated.html
@@ -8,7 +8,7 @@
     <title th:text="#{project.associated.heading(${project.label})}">
       ASSOCIATED PROJECTS
     </title>
-    <link rel="stylesheet" href="#" th:href="@{/dist/css/associated-projects.bundle.css}" />
+    <link rel="stylesheet" th:href="@{/dist/css/associated-projects.bundle.css}" />
     <script th:inline="javascript">
       window.PAGE = {
         permissions: /*[[${isAdmin or isOwner}]]*/ false,

--- a/src/main/webapp/pages/projects/settings/pages/details.html
+++ b/src/main/webapp/pages/projects/settings/pages/details.html
@@ -7,7 +7,7 @@
 >
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="#" th:href="@{/dist/css/project-details.bundle.css}">
+    <link rel="stylesheet" th:href="@{/dist/css/project-details.bundle.css}">
   </head>
   <body>
     <div id="details-root" layout:fragment="settings-content" >

--- a/src/main/webapp/pages/projects/settings/pages/details.html
+++ b/src/main/webapp/pages/projects/settings/pages/details.html
@@ -7,7 +7,7 @@
 >
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="/dist/css/project-details.bundle.css">
+    <link rel="stylesheet" href="#" th:href="@{/dist/css/project-details.bundle.css}">
   </head>
   <body>
     <div id="details-root" layout:fragment="settings-content" >

--- a/src/main/webapp/pages/projects/settings/pages/remote.html
+++ b/src/main/webapp/pages/projects/settings/pages/remote.html
@@ -7,7 +7,7 @@
 >
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="#" th:href="@{/dist/css/project-remote.bundle.css}">
+    <link rel="stylesheet" th:href="@{/dist/css/project-remote.bundle.css}">
     <title th:text="#{ProjectRemoteSettings.title}">Title</title>
   </head>
   <body>

--- a/src/main/webapp/pages/projects/settings/pages/remote.html
+++ b/src/main/webapp/pages/projects/settings/pages/remote.html
@@ -7,7 +7,7 @@
 >
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" href="/dist/css/project-remote.bundle.css">
+    <link rel="stylesheet" href="#" th:href="@{/dist/css/project-remote.bundle.css}">
     <title th:text="#{ProjectRemoteSettings.title}">Title</title>
   </head>
   <body>


### PR DESCRIPTION
## Description of changes
Found a number of broken CSS bundle hrefs in the project settings pages.  They didn't include the context paths and just had a regular `href=/somewhere`.  Added the context paths with thymeleaf to these paths.

## Related issue
FIxes #905 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
