### PR TITLE
Documentation fix

### DIFF
--- a/doc/administrator/galaxy/index.md
+++ b/doc/administrator/galaxy/index.md
@@ -31,7 +31,7 @@ The easiest way to get Galaxy up and running for use with IRIDA is to use a cust
 docker run -d -p 48888:80 -v /path/to/irida/data:/path/to/irida/data phacnml/galaxy-irida-20.05
 ```
 
-Where `48888` is the port on your local system where Galaxy should be accessible, and `/path/to/irida/data` should point to the location where the sequencing data for IRIDA is stored (i.e., the parent directory of `{sequence,reference,output}.file.base.directory` in [/etc/irida/irida.conf][irida-conf]).
+Where `48888` is the port on your local system where Galaxy should be accessible, and `/path/to/irida/data` should point to the location where the sequencing data for IRIDA is stored (i.e., the parent directory of `{sequence,reference,output}.file.base.directory` in [/etc/irida/irida.conf][irida-conf]). Note: You may have to create these directories manually the first time you set up IRIDA.
 
 Now proceed to installing the [IRIDA web interface][irida-web], making sure to set the following Galaxy connection parameters in `/etc/irida/irida.conf`.
 

--- a/doc/administrator/galaxy/index.md
+++ b/doc/administrator/galaxy/index.md
@@ -31,7 +31,7 @@ The easiest way to get Galaxy up and running for use with IRIDA is to use a cust
 docker run -d -p 48888:80 -v /path/to/irida/data:/path/to/irida/data phacnml/galaxy-irida-20.05
 ```
 
-Where `48888` is the port on your local system where Galaxy should be accessible, and `/path/to/irida/data` should point to the location where the sequencing data for IRIDA is stored (i.e., the parent directory of `{sequence,reference,output}.file.base.directory` in [/etc/irida/irida.conf][irida-conf]). Note: You may have to create these directories manually the first time you set up IRIDA.
+Where `48888` is the port on your local system where Galaxy should be accessible, and `/path/to/irida/data` should point to the location where the sequencing data for IRIDA is stored (i.e., the parent directory of `{sequence,reference,output,assembly}.file.base.directory` in [/etc/irida/irida.conf][irida-conf]). Note: You may have to create these directories manually the first time you set up IRIDA.
 
 Now proceed to installing the [IRIDA web interface][irida-web], making sure to set the following Galaxy connection parameters in `/etc/irida/irida.conf`.
 

--- a/doc/developer/getting-started/index.md
+++ b/doc/developer/getting-started/index.md
@@ -179,8 +179,8 @@ The advanced profiles allow you to configure your server to run specific compone
 
 ##### Testing profiles
 * `it` - Integration test.
-  * Liquibase used for database setup, but should only be used for integration testing.
-* `test` - This profile is generally used when testing connecting to Galaxy.
+  * Liquibase is used for database setup, but should only be used for integration testing.
+* `test` - This profile is generally used when testing connection to Galaxy.
 
 When running IRIDA from the command line, a profile can be set by adding the following parameter:
 


### PR DESCRIPTION
## Description of changes
Fix minor typo in IRIDA's developer documentation. Added "assembly" on the list of directories mentioned and included a sentence about adding directories manually in the guide for setting up Galaxy as these directories do not automatically exist.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] Ensure the sentence added ("`Note: You may have to create these directories manually the first time you set up IRIDA`") is accurate/correct.
* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
