### PR TITLE
Fixed hashing

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/sample/StaticMetadataTemplateField.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/sample/StaticMetadataTemplateField.java
@@ -1,5 +1,7 @@
 package ca.corefacility.bioinformatics.irida.model.sample;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Inheritance;
@@ -41,5 +43,22 @@ public class StaticMetadataTemplateField extends MetadataTemplateField {
 
 	public String getStaticId() {
 		return staticId;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		if (!super.equals(o))
+			return false;
+		StaticMetadataTemplateField that = (StaticMetadataTemplateField) o;
+		return Objects.equals(staticId, that.staticId);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(super.hashCode(), staticId);
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/sample/metadata/PipelineProvidedMetadataEntry.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/sample/metadata/PipelineProvidedMetadataEntry.java
@@ -1,11 +1,14 @@
 package ca.corefacility.bioinformatics.irida.model.sample.metadata;
 
+import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
 import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
+
 import org.hibernate.envers.Audited;
 
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
 import java.util.Objects;
 
 /**
@@ -36,6 +39,12 @@ public class PipelineProvidedMetadataEntry extends MetadataEntry {
 		this.submission = submission;
 	}
 
+	public PipelineProvidedMetadataEntry(String value, String type, MetadataTemplateField field,
+			AnalysisSubmission submission) {
+		super(value, type, field);
+		this.submission = submission;
+	}
+
 	/**
 	 * Get the {@link AnalysisSubmission} that created this metadata
 	 *
@@ -44,7 +53,7 @@ public class PipelineProvidedMetadataEntry extends MetadataEntry {
 	public AnalysisSubmission getSubmission() {
 		return submission;
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/analysis/Analysis.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/analysis/Analysis.java
@@ -156,7 +156,7 @@ public class Analysis extends IridaResourceSupport implements IridaThing {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(createdDate, description, executionManagerAnalysisId, analysisOutputFilesMap.values());
+		return Objects.hash(createdDate, description, executionManagerAnalysisId, analysisOutputFilesMap);
 	}
 
 	@Override

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/analysis/Analysis.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/analysis/Analysis.java
@@ -156,7 +156,7 @@ public class Analysis extends IridaResourceSupport implements IridaThing {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(createdDate, description, executionManagerAnalysisId, analysisOutputFilesMap);
+		return Objects.hash(createdDate, description, executionManagerAnalysisId, analysisOutputFilesMap.values());
 	}
 
 	@Override

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/submission/IridaWorkflowNamedParameters.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/submission/IridaWorkflowNamedParameters.java
@@ -2,6 +2,7 @@ package ca.corefacility.bioinformatics.irida.model.workflow.submission;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import javax.persistence.CollectionTable;
@@ -107,5 +108,21 @@ public class IridaWorkflowNamedParameters implements IridaThing {
 
 	public final Map<String, String> getInputParameters() {
 		return namedParameters;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		IridaWorkflowNamedParameters that = (IridaWorkflowNamedParameters) o;
+		return Objects.equals(name, that.name) && Objects.equals(workflowId, that.workflowId) && Objects.equals(
+				namedParameters, that.namedParameters);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(name, workflowId, namedParameters.values());
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/submission/IridaWorkflowNamedParameters.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/submission/IridaWorkflowNamedParameters.java
@@ -123,6 +123,6 @@ public class IridaWorkflowNamedParameters implements IridaThing {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(name, workflowId, namedParameters.values());
+		return Objects.hash(name, workflowId, namedParameters);
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -472,7 +472,6 @@ public class ProjectSynchronizationService {
 	 *
 	 * @param remoteSample the sample read from the remote api
 	 * @param localSample  the local sample being saved
-	 * @return the synchronized sample
 	 */
 	public void syncSampleMetadata(Sample remoteSample, Sample localSample) {
 		Map<String, MetadataEntry> sampleMetadata = sampleRemoteService.getSampleMetadata(remoteSample);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -321,7 +321,7 @@ public class ProjectSynchronizationService {
 
 				localSample = sampleService.update(sample);
 
-				localSample = syncSampleMetadata(sample, localSample);
+				syncSampleMetadata(sample, localSample);
 			}
 
 		} else {
@@ -330,7 +330,7 @@ public class ProjectSynchronizationService {
 			localSample = sampleService.create(sample);
 			projectService.addSampleToProject(project, sample, true);
 
-			localSample = syncSampleMetadata(sample, localSample);
+			syncSampleMetadata(sample, localSample);
 		}
 
 		//get a collection of the files already sync'd.  we don't want to grab them a 2nd time.
@@ -474,16 +474,14 @@ public class ProjectSynchronizationService {
 	 * @param localSample  the local sample being saved
 	 * @return the synchronized sample
 	 */
-	public Sample syncSampleMetadata(Sample remoteSample, Sample localSample) {
+	public void syncSampleMetadata(Sample remoteSample, Sample localSample) {
 		Map<String, MetadataEntry> sampleMetadata = sampleRemoteService.getSampleMetadata(remoteSample);
 
 		sampleMetadata.values()
 				.forEach(e -> e.setId(null));
 
 		Set<MetadataEntry> metadata = metadataTemplateService.convertMetadataStringsToSet(sampleMetadata);
-		localSample = sampleService.updateSampleMetadata(localSample, metadata);
-
-		return localSample;
+		sampleService.updateSampleMetadata(localSample, metadata);
 	}
 
 	/**

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/ProjectHashingServiceIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/ProjectHashingServiceIT.java
@@ -2,20 +2,30 @@ package ca.corefacility.bioinformatics.irida.service;
 
 import ca.corefacility.bioinformatics.irida.config.data.IridaApiJdbcDataSourceConfig;
 import ca.corefacility.bioinformatics.irida.config.services.IridaApiServicesConfig;
+import ca.corefacility.bioinformatics.irida.exceptions.AnalysisAlreadySetException;
 import ca.corefacility.bioinformatics.irida.model.joins.Join;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.SampleSequencingObjectJoin;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
+import ca.corefacility.bioinformatics.irida.model.sample.metadata.PipelineProvidedMetadataEntry;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
+import ca.corefacility.bioinformatics.irida.model.workflow.analysis.Analysis;
+import ca.corefacility.bioinformatics.irida.model.workflow.analysis.AnalysisOutputFile;
+import ca.corefacility.bioinformatics.irida.model.workflow.analysis.ToolExecution;
+import ca.corefacility.bioinformatics.irida.model.workflow.analysis.type.BuiltInAnalysisTypes;
+import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
+import ca.corefacility.bioinformatics.irida.model.workflow.submission.IridaWorkflowNamedParameters;
 import ca.corefacility.bioinformatics.irida.service.remote.ProjectHashingService;
 import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
+import ca.corefacility.bioinformatics.irida.service.workflow.WorkflowNamedParametersService;
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 
 import org.junit.Test;
@@ -30,9 +40,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -55,6 +66,12 @@ public class ProjectHashingServiceIT {
 	SequencingObjectService sequencingObjectService;
 	@Autowired
 	MetadataTemplateService metadataTemplateService;
+	@Autowired
+	AnalysisSubmissionService analysisSubmissionService;
+	@Autowired
+	AnalysisService analysisService;
+	@Autowired
+	WorkflowNamedParametersService namedParametersService;
 
 	@Autowired
 	ProjectHashingService hashingService;
@@ -67,7 +84,7 @@ public class ProjectHashingServiceIT {
 
 		Integer projectHash = hashingService.getProjectHash(project);
 
-		assertEquals(expectedHash, projectHash);
+		assertEquals("Should get the referenced hash", expectedHash, projectHash);
 	}
 
 	@WithMockUser(username = "admin", roles = "ADMIN")
@@ -82,7 +99,10 @@ public class ProjectHashingServiceIT {
 
 		Integer newHash = hashingService.getProjectHash(project);
 
-		assertNotEquals(originalHash, newHash);
+		assertNotEquals("hash should have changed", originalHash, newHash);
+
+		Integer rerunHash = hashingService.getProjectHash(project);
+		assertEquals("hash should be the same on 2nd run", newHash, rerunHash);
 	}
 
 	@WithMockUser(username = "admin", roles = "ADMIN")
@@ -101,7 +121,10 @@ public class ProjectHashingServiceIT {
 
 		Integer newHash = hashingService.getProjectHash(project);
 
-		assertNotEquals(originalHash, newHash);
+		assertNotEquals("hash should change", originalHash, newHash);
+
+		Integer rerunHash = hashingService.getProjectHash(project);
+		assertEquals("hash should be the same on 2nd run", newHash, rerunHash);
 	}
 
 	@WithMockUser(username = "admin", roles = "ADMIN")
@@ -126,12 +149,15 @@ public class ProjectHashingServiceIT {
 
 		Integer newHash = hashingService.getProjectHash(project);
 
-		assertNotEquals(originalHash, newHash);
+		assertNotEquals("hash should change", originalHash, newHash);
+
+		Integer rerunHash = hashingService.getProjectHash(project);
+		assertEquals("hash should be the same on 2nd run", newHash, rerunHash);
 	}
 
 	@WithMockUser(username = "admin", roles = "ADMIN")
 	@Test
-	public void hashChangesWithMetadataSequencingObject() {
+	public void hashChangesWithMetadata() {
 		Project project = projectService.read(2L);
 
 		Integer originalHash = hashingService.getProjectHash(project);
@@ -151,7 +177,50 @@ public class ProjectHashingServiceIT {
 
 		Integer newHash = hashingService.getProjectHash(project);
 
-		assertNotEquals(originalHash, newHash);
+		assertNotEquals("hash should change", originalHash, newHash);
+
+		Integer rerunHash = hashingService.getProjectHash(project);
+		assertEquals("hash should be the same on 2nd run", newHash, rerunHash);
+	}
+
+	@WithMockUser(username = "admin", roles = "ADMIN")
+	@Test
+	public void hashChangesWithPipelineMetadataChanges() {
+		Project project = projectService.read(2L);
+
+		//Setting up analysis submission details
+		IridaWorkflowNamedParameters namedParameters = new IridaWorkflowNamedParameters("name", UUID.randomUUID(),
+				new HashMap<>());
+		namedParameters = namedParametersService.create(namedParameters);
+		SequencingObject sequencingObject = sequencingObjectService.read(1L);
+		AnalysisSubmission analysisSubmission = AnalysisSubmission.builder(UUID.randomUUID())
+				.name("test")
+				.inputFiles(Sets.newHashSet(sequencingObject))
+				.withNamedParameters(namedParameters)
+				.build();
+		analysisSubmission = analysisSubmissionService.create(analysisSubmission);
+
+		Integer originalHash = hashingService.getProjectHash(project);
+
+		List<Join<Project, Sample>> samplesForProject = sampleService.getSamplesForProject(project);
+		Sample sample = samplesForProject.iterator()
+				.next()
+				.getObject();
+
+		//adding the analysis metadata
+		MetadataTemplateField field = new MetadataTemplateField("test", "text");
+		field = metadataTemplateService.saveMetadataField(field);
+		MetadataEntry entry = new PipelineProvidedMetadataEntry("value", "text", field, analysisSubmission);
+		HashSet<MetadataEntry> metadataEntries = Sets.newHashSet(entry);
+
+		sampleService.mergeSampleMetadata(sample, metadataEntries);
+
+		Integer newHash = hashingService.getProjectHash(project);
+
+		assertNotEquals("hash should change", originalHash, newHash);
+
+		Integer rerunHash = hashingService.getProjectHash(project);
+		assertEquals("hash should be the same on 2nd run", newHash, rerunHash);
 	}
 
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/ProjectHashingServiceIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/ProjectHashingServiceIT.java
@@ -1,32 +1,6 @@
 package ca.corefacility.bioinformatics.irida.service;
 
-import ca.corefacility.bioinformatics.irida.config.data.IridaApiJdbcDataSourceConfig;
-import ca.corefacility.bioinformatics.irida.config.services.IridaApiServicesConfig;
-import ca.corefacility.bioinformatics.irida.exceptions.AnalysisAlreadySetException;
-import ca.corefacility.bioinformatics.irida.model.joins.Join;
-import ca.corefacility.bioinformatics.irida.model.project.Project;
-import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
-import ca.corefacility.bioinformatics.irida.model.sample.Sample;
-import ca.corefacility.bioinformatics.irida.model.sample.SampleSequencingObjectJoin;
-import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
-import ca.corefacility.bioinformatics.irida.model.sample.metadata.PipelineProvidedMetadataEntry;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
-import ca.corefacility.bioinformatics.irida.model.workflow.analysis.Analysis;
-import ca.corefacility.bioinformatics.irida.model.workflow.analysis.AnalysisOutputFile;
-import ca.corefacility.bioinformatics.irida.model.workflow.analysis.ToolExecution;
-import ca.corefacility.bioinformatics.irida.model.workflow.analysis.type.BuiltInAnalysisTypes;
-import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
-import ca.corefacility.bioinformatics.irida.model.workflow.submission.IridaWorkflowNamedParameters;
-import ca.corefacility.bioinformatics.irida.service.remote.ProjectHashingService;
-import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
-import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
-import ca.corefacility.bioinformatics.irida.service.workflow.WorkflowNamedParametersService;
-
-import com.github.springtestdbunit.DbUnitTestExecutionListener;
-import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
+import java.util.*;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,10 +14,27 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.support.AnnotationConfigContextLoader;
 import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.*;
+import ca.corefacility.bioinformatics.irida.config.data.IridaApiJdbcDataSourceConfig;
+import ca.corefacility.bioinformatics.irida.config.services.IridaApiServicesConfig;
+import ca.corefacility.bioinformatics.irida.model.joins.Join;
+import ca.corefacility.bioinformatics.irida.model.project.Project;
+import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
+import ca.corefacility.bioinformatics.irida.model.sample.Sample;
+import ca.corefacility.bioinformatics.irida.model.sample.SampleSequencingObjectJoin;
+import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
+import ca.corefacility.bioinformatics.irida.model.sample.metadata.PipelineProvidedMetadataEntry;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
+import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
+import ca.corefacility.bioinformatics.irida.model.workflow.submission.IridaWorkflowNamedParameters;
+import ca.corefacility.bioinformatics.irida.service.remote.ProjectHashingService;
+import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
+import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
+import ca.corefacility.bioinformatics.irida.service.workflow.WorkflowNamedParametersService;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
+import com.google.common.collect.Sets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -68,8 +59,6 @@ public class ProjectHashingServiceIT {
 	MetadataTemplateService metadataTemplateService;
 	@Autowired
 	AnalysisSubmissionService analysisSubmissionService;
-	@Autowired
-	AnalysisService analysisService;
 	@Autowired
 	WorkflowNamedParametersService namedParametersService;
 

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/test/integration/TableReset.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/test/integration/TableReset.xml
@@ -94,6 +94,7 @@
 
 	<metadata_field/>
 	<metadata_entry/>
+	<pipeline_metadata_entry/>
 	<metadata_template/>
 	<metadata_template_metadata_field/>
 	<project_metadata_template/>
@@ -149,6 +150,7 @@
 	<project_metadata_template_AUD/>
 	<project_analysis_submission_AUD/>
 	<metadata_entry_AUD/>
+	<pipeline_metadata_entry_AUD/>
 	<ncbi_export_submission_AUD/>
 	<ncbi_export_biosample_AUD/>
 	<ncbi_export_submission_biosample_AUD/>


### PR DESCRIPTION
## Description of changes
Added `hashCode` functions for 2 classes `StaticMetadataTemplateField.java` and `IridaWorkflowNamedParameters`.  Without the hashcode function it was breaking the full project hashing for any analyses that had `PipelineProvidedMetadata`.  Without `hashCode` being implemented, it the hash would change every time you ran the hash function.

## Related issue
Related to #392 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
