### PR TITLE
Fix issue moving a large number of samples between project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Changes
 * [UI]: Added option for project managers to check for changes using the hash above, or to force a full project sync on the project remote settings page.
 * [Developer/REST/UI]: Updated announcements with a new title and priority fields.
 * [UI]: Added option for user to only receive an email upon pipeline failure.
+* [UI]: Fixed issue with trying to copy a large number of samples between projects.
 
 20.05 to 20.09
 --------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
@@ -136,7 +136,7 @@ public class ProjectSamplesController {
 	 * @param model     UI model
 	 * @return path to remove modal template
 	 */
-	@RequestMapping(value = "/projects/{projectId}/templates/remove-modal", produces = MediaType.TEXT_HTML_VALUE)
+	@PostMapping(value = "/projects/{projectId}/templates/remove-modal", produces = MediaType.TEXT_HTML_VALUE)
 	public String getRemoveSamplesFromProjectModal(@RequestParam(name = "sampleIds[]") List<Long> ids, @PathVariable Long projectId, Model model) {
 		List<Sample> samplesThatAreInMultiple = new ArrayList<>();
 		List<Sample> samplesThatAreInOne = new ArrayList<>();
@@ -166,7 +166,7 @@ public class ProjectSamplesController {
 	 * @param model     UI Model
 	 * @return Path to merge modal template
 	 */
-	@RequestMapping(value = "/projects/{projectId}/templates/merge-modal", produces = MediaType.TEXT_HTML_VALUE)
+	@PostMapping(value = "/projects/{projectId}/templates/merge-modal", produces = MediaType.TEXT_HTML_VALUE)
 	public String getMergeSamplesInProjectModal(@PathVariable Long projectId, @RequestParam(name = "sampleIds[]") List<Long> ids, Model model) {
 		Project project = projectService.read(projectId);
 		List<Sample> samples = new ArrayList<>();
@@ -198,7 +198,7 @@ public class ProjectSamplesController {
 	 * @param move      Whether or not to display share or move wording.
 	 * @return Path to share or move modal template.
 	 */
-	@RequestMapping(value = "/projects/{projectId}/templates/copy-move-modal", produces = MediaType.TEXT_HTML_VALUE)
+	@PostMapping(value = "/projects/{projectId}/templates/copy-move-modal", produces = MediaType.TEXT_HTML_VALUE)
 	public String getShareSamplesModal(@RequestParam(name = "sampleIds[]") List<Long> ids, @PathVariable Long projectId,
 			Model model, @RequestParam(required = false) boolean move) {
 		Project project = projectService.read(projectId);

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -20,7 +20,6 @@ import { FILTERS, SAMPLE_EVENTS } from "./constants";
 import { download } from "../../../utilities/file-utilities";
 import "../../../../css/pages/project-samples.css";
 import { putSampleInCart } from "../../../apis/cart/cart";
-import { samplesAddedToCart } from "../../../utilities/events-utilities";
 import { setBaseUrl } from "../../../utilities/url-utilities";
 
 import "./linker/Linker";

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -20,6 +20,7 @@ import { FILTERS, SAMPLE_EVENTS } from "./constants";
 import { download } from "../../../utilities/file-utilities";
 import "../../../../css/pages/project-samples.css";
 import { putSampleInCart } from "../../../apis/cart/cart";
+import { samplesAddedToCart } from "../../../utilities/events-utilities";
 import { setBaseUrl } from "../../../utilities/url-utilities";
 
 import "./linker/Linker";
@@ -450,10 +451,10 @@ $("#js-modal-wrapper").on("show.bs.modal", function (event) {
   /*
   Find the ids for the currently selected samples.
    */
-  params["sampleIds"] = getSelectedIds();
+  const sampleIds = getSelectedIds();
 
   let script;
-  modal.load(`${url}?${$.param(params)}`, function () {
+  modal.load(`${url}`, { sampleIds, ...params }, function () {
     if (typeof script_src !== "undefined") {
       script = document.createElement("script");
       script.type = "text/javascript";


### PR DESCRIPTION
## Description of changes

Updated the jQuery load function and moved the sampleIds from a query param into a data object (the optional second argument passed to load) which turns this into a POST request.  This should allow the request to handle a larger number of sample identifier.

## Related issue

Fixes #916

## Checklist

Things for the developer to confirm they've done before the PR should be accepted:

*   [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
*   [ ] ~Tests added (or description of how to test) for any new features.~
*   [ ] ~User documentation updated for UI or technical changes.~