### PR TITLE
Changed git ignore for apidocs down to the main gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/main/webapp/node
 /src/main/webapp/dist
 /src/main/webapp/pages/templates/i18n/*.html
 /doc/.jekyll-cache/Jekyll/Cache/
+/doc/developer/apidocs

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,4 +1,3 @@
 _site
 .sass-cache
 vendor
-developer/apidocs


### PR DESCRIPTION
## Description of changes
Moved ignoring the apidocs from the `/docs` directory gitignore down to the project root gitignore.  On deploying the new docs it was accidentally ignoring the apidocs changes.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
* [x] User documentation updated for UI or technical changes.
