### PR TITLE
HOTFIX: Fix tabular result viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+21.01 to 20.05
+--------------
+*[UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
+
 20.09 to 21.01
 --------------
 * [UI]: Fixed bug where sequencing runs could not be deleted on sequencing runs details page. (20.09.1)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.01</version>
+	<version>21.01.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/resources/js/pages/analysis/components/AnalysisTabularPreview.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/AnalysisTabularPreview.jsx
@@ -11,7 +11,6 @@ import styled from "styled-components";
 import { OutputFileHeader } from "../../../components/OutputFiles/OutputFileHeader";
 
 const TabularOutputWrapper = styled.div`
-  max-height: 300px;
   width: 100%;
   margin-bottom: ${SPACE_XS};
 `;
@@ -58,7 +57,10 @@ export function AnalysisTabularPreview({ output }) {
           pagination={
             fileRows.length <= MAX_TABLE_ROWS_PER_PAGE
               ? false
-              : { pageSize: MAX_TABLE_ROWS_PER_PAGE }
+              : {
+                  defaultPageSize: MAX_TABLE_ROWS_PER_PAGE,
+                  pageSizeOptions: [5, 10, 20, 50, 100],
+                }
           }
         />
       </TabularOutputWrapper>


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed bug which wouldn't let user preview more than 5 lines of an analysis tabular result file by removing max-height of the table in which the tab file is displayed.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

Fixes #926 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
