### PR TITLE
Metadata Phylogeny-tree Advanced Visualisation fix 

### DIFF
--- a/src/main/webapp/resources/js/pages/visualizations/phylogenetics/components/phylocanvas/phylocanvas.component.js
+++ b/src/main/webapp/resources/js/pages/visualizations/phylogenetics/components/phylocanvas/phylocanvas.component.js
@@ -122,13 +122,13 @@ function phylocanvasController(
     // Add the metadata to the branches before the tree is drawn.
     tree.on("beforeFirstDraw", () => {
       for (const leaf of tree.leaves) {
-        if (metadata.hasOwnProperty(leaf.label)){
+        if (metadata.hasOwnProperty(leaf.label)) {
           leaf.data = metadata[leaf.label];
-        }else{          
+        } else {
           leaf.data = metadata.reference;
         }
       }
-    });    
+    });
     metadataPromise.resolve();
   });
 

--- a/src/main/webapp/resources/js/pages/visualizations/phylogenetics/components/phylocanvas/phylocanvas.component.js
+++ b/src/main/webapp/resources/js/pages/visualizations/phylogenetics/components/phylocanvas/phylocanvas.component.js
@@ -120,11 +120,17 @@ function phylocanvasController(
   $scope.$on(METADATA.LOADED, (event, args) => {
     const { metadata } = args;
     // Add the metadata to the branches before the tree is drawn.
+    console.log("METADATA: ", metadata);
     tree.on("beforeFirstDraw", () => {
       for (const leaf of tree.leaves) {
-        leaf.data = metadata[leaf.label];
+        console.log("LEAF: ", leaf.label);
+        if (metadata.hasOwnProperty(leaf.label)){
+          leaf.data = metadata[leaf.label];
+        }else{          
+          leaf.data = metadata.reference;
+        }
       }
-    });
+    });    
     metadataPromise.resolve();
   });
 

--- a/src/main/webapp/resources/js/pages/visualizations/phylogenetics/components/phylocanvas/phylocanvas.component.js
+++ b/src/main/webapp/resources/js/pages/visualizations/phylogenetics/components/phylocanvas/phylocanvas.component.js
@@ -120,10 +120,8 @@ function phylocanvasController(
   $scope.$on(METADATA.LOADED, (event, args) => {
     const { metadata } = args;
     // Add the metadata to the branches before the tree is drawn.
-    console.log("METADATA: ", metadata);
     tree.on("beforeFirstDraw", () => {
       for (const leaf of tree.leaves) {
-        console.log("LEAF: ", leaf.label);
         if (metadata.hasOwnProperty(leaf.label)){
           leaf.data = metadata[leaf.label];
         }else{          


### PR DESCRIPTION
## Description of changes
If you use any reference file starting with line, other than `>reference`,  the for loop which adds data to the leaves of the tree would throw an error `can't convert undefined to object.`, basically happens when it tries to set `leaf.data = metadata['anything other than reference'];` - the result would be that `leaf.data = undefined` and the phylocanvas plugin would break when trying to run `tree.load(newick)`.

I  added an `if statement` to check the existence of leaf.label as a key in metadata object, which is the case for the samples and when it doesn't, as the case of a custom named reference e.g `>Chromosome`/`NC_000962.3` for my case, it would lookup the contents of `metadata.reference`.

## Related issue
https://github.com/phac-nml/irida/issues/941

![Screenshot from 2021-02-13 09-12-07](https://user-images.githubusercontent.com/2108971/107844392-a47f3e80-6ddb-11eb-9068-d455742c920c.png)
