### PR TITLE
Fixed webpack not outputting css files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changes
 
 21.01 to 20.05
 --------------
-*[UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
+* [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
+* [Developer]: Fixed webpack not outputting css bundle files.
 
 20.09 to 21.01
 --------------

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -126,7 +126,6 @@
     "prettier": "^2.0.4",
     "properties-reader": "^2.1.1",
     "source-map-loader": "^0.2.4",
-    "style-loader": "^1.1.3",
     "terser-webpack-plugin": "^3.0.6",
     "url-loader": "^4.1.0",
     "webpack": "^4.43.0",

--- a/src/main/webapp/webpack.config.js
+++ b/src/main/webapp/webpack.config.js
@@ -43,7 +43,7 @@ const config = {
         test: /\.less$/,
         use: [
           {
-            loader: "style-loader",
+            loader: MiniCssExtractPlugin.loader,
           },
           {
             loader: "css-loader", // translates CSS into CommonJS

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -10029,14 +10029,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
-style-loader@^1.1.3:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.3.0.tgz#828b4a3b3b7e7aa5847ce7bae9e874512114249e"
-  integrity sha512-V7TCORko8rs9rIqkSrlMfkqA63DfoGBBJmK1kKGCcSi+BWb4cqz0SRsnp4l6rU5iwOEd0/2ePv68SV22VXon4Q==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^2.7.0"
-
 styled-components@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.2.1.tgz#6ed7fad2dc233825f64c719ffbdedd84ad79101a"


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed issue with css bundle files not being written due to a conflict between style-loader and minicssextractplugin

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* ~[ ] Tests added (or description of how to test) for any new features.~
* ~[ ] User documentation updated for UI or technical changes.~
