### PR TITLE
Added some args to run.sh that I use often

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,13 +1,42 @@
 #!/bin/bash
 export MIN_JS=false
 
-ADD=""
+PROFILE="dev"
+CREATE_DB=""
+YARN="-Dskip.yarn"
 
-if [ "$1" = "--create-db" ]; then
-   ADD="-Dhbm.dev.auto=create"
+for arg in "$@"
+do
+    if [ "$arg" = "--create-db" ]; then
+       CREATE_DB="-Dhbm.dev.auto=create"
+    fi
+
+    if [ "$arg" = "--yarn" ]; then
+       YARN=""
+    fi
+
+    if [ "$arg" = "--prod" ]; then
+       PROFILE="prod"
+    fi
+done
+
+
+if [ "$CREATE_DB" = "-Dhbm.dev.auto=create" ]; then
    echo "Dropping then Creating/Recreating database schema"
 else
    echo "Updating database schema without dropping"
   fi
 
-mvn clean jetty:run -Dspring.profiles.active=dev ${ADD}
+if [ "$YARN" = "" ]; then
+   echo "Building Yarn"
+else
+   echo "Continuing without yarn"
+  fi
+
+if [ "$PROFILE" = "prod" ]; then
+   echo "Running with Production Profile"
+else
+   echo "Running with Development Profile"
+  fi
+
+mvn clean jetty:run -Dspring.profiles.active=${PROFILE} ${CREATE_DB} ${YARN}


### PR DESCRIPTION
## Description of changes
run.sh now defaults to the following
* dev profile
* skip yarn build
* do not rebuild db

adds the following commands to do other things
* `--prod` will run in prod profile
* `--yarn` will force it to build yarn (needed for first time running)
* `--create-db` will force it to remake database (needed for first time running)

This could use feedback on other args people use frequently to build this out a bit more to save time. The way I have set it up is that without any args it works as a quick launch into dev mode.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
