### PR TITLE
HOTFIX: Added ownership flag to copying sample to project in REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ Changes
 
 21.01 to 20.05
 --------------
-*[UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
+* [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
+* [REST]: Added `ownership` option when copying sample to project in REST API (21.01.2)
 
 20.09 to 21.01
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.01.1</version>
+	<version>21.01.2</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -14,10 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -91,14 +88,16 @@ public class RESTProjectSamplesController {
 	 *
 	 * @param projectId the project to copy the sample to.
 	 * @param sampleIds the collection of sample IDs to copy.
+	 * @param ownership Whether the recieving project should have ownership of the sample
 	 * @param response  a reference to the servlet response.
-	 * @param locale The user's in case a warning message is needed
+	 * @param locale    The user's in case a warning message is needed
 	 * @return the response indicating that the sample was joined to the
 	 * project.
 	 */
 	@RequestMapping(value = "/api/projects/{projectId}/samples", method = RequestMethod.POST, consumes = "application/idcollection+json")
 	public ModelMap copySampleToProject(final @PathVariable Long projectId, final @RequestBody List<Long> sampleIds,
-			HttpServletResponse response, Locale locale) {
+			@RequestParam(name = "ownership", defaultValue = "false") boolean ownership, HttpServletResponse response,
+			Locale locale) {
 
 		ModelMap modelMap = new ModelMap();
 
@@ -112,7 +111,7 @@ public class RESTProjectSamplesController {
 			Sample sample = sampleService.read(sampleId);
 			Join<Project, Sample> join = null;
 			try {
-				join = projectService.addSampleToProject(p, sample, false);
+				join = projectService.addSampleToProject(p, sample, ownership);
 			} catch (ExistingSampleNameException e) {
 				logger.error(
 						"Could not add sample to project because another sample exists with this name :" + e.getSample()

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -88,7 +88,7 @@ public class RESTProjectSamplesController {
 	 *
 	 * @param projectId the project to copy the sample to.
 	 * @param sampleIds the collection of sample IDs to copy.
-	 * @param ownership Whether the recieving project should have ownership of the sample
+	 * @param ownership Whether the receiving project should have ownership of the sample
 	 * @param response  a reference to the servlet response.
 	 * @param locale    The user's in case a warning message is needed
 	 * @return the response indicating that the sample was joined to the

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
@@ -233,8 +233,8 @@ public class RESTProjectSamplesControllerTest {
 		when(projectService.read(p.getId())).thenReturn(p);
 		when(sampleService.read(s.getId())).thenReturn(s);
 		when(projectService.addSampleToProject(p, s, false)).thenReturn(r);
-		ModelMap modelMap = controller
-				.copySampleToProject(p.getId(), Lists.newArrayList(s.getId()), response, Locale.ENGLISH);
+		ModelMap modelMap = controller.copySampleToProject(p.getId(), Lists.newArrayList(s.getId()), false, response,
+				Locale.ENGLISH);
 		
 		verify(projectService).addSampleToProject(p, s, false);
 		assertEquals("response should have CREATED status", HttpStatus.CREATED.value(), response.getStatus());
@@ -283,7 +283,7 @@ public class RESTProjectSamplesControllerTest {
 		when(sampleService.getSampleForProject(p, s.getId())).thenReturn(r);
 
 		ModelMap modelMap = controller
-				.copySampleToProject(p.getId(), Lists.newArrayList(s.getId()), response, Locale.ENGLISH);
+				.copySampleToProject(p.getId(), Lists.newArrayList(s.getId()), false, response, Locale.ENGLISH);
 
 		verify(projectService).addSampleToProject(p, s, false);
 		verify(sampleService).getSampleForProject(p,s.getId());

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
@@ -229,14 +229,15 @@ public class RESTProjectSamplesControllerTest {
 		final Project p = TestDataFactory.constructProject();
 		final Sample s = TestDataFactory.constructSample();
 		final ProjectSampleJoin r = new ProjectSampleJoin(p,s, true);
+		boolean copyOwner = false;
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		when(projectService.read(p.getId())).thenReturn(p);
 		when(sampleService.read(s.getId())).thenReturn(s);
 		when(projectService.addSampleToProject(p, s, false)).thenReturn(r);
-		ModelMap modelMap = controller.copySampleToProject(p.getId(), Lists.newArrayList(s.getId()), false, response,
+		ModelMap modelMap = controller.copySampleToProject(p.getId(), Lists.newArrayList(s.getId()), copyOwner, response,
 				Locale.ENGLISH);
-		
-		verify(projectService).addSampleToProject(p, s, false);
+
+		verify(projectService).addSampleToProject(p, s, copyOwner);
 		assertEquals("response should have CREATED status", HttpStatus.CREATED.value(), response.getStatus());
 		final String location = response.getHeader(HttpHeaders.LOCATION);
 		assertEquals("location should include sample and project IDs", "http://localhost/api/projects/" + p.getId()

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
@@ -228,8 +228,9 @@ public class RESTProjectSamplesControllerTest {
 	public void testCopySampleToProject() {
 		final Project p = TestDataFactory.constructProject();
 		final Sample s = TestDataFactory.constructSample();
-		final ProjectSampleJoin r = new ProjectSampleJoin(p,s, true);
 		boolean copyOwner = false;
+
+		final ProjectSampleJoin r = new ProjectSampleJoin(p,s, copyOwner);
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		when(projectService.read(p.getId())).thenReturn(p);
 		when(sampleService.read(s.getId())).thenReturn(s);


### PR DESCRIPTION
## Description of changes
Added an ownership flag API endpoint copying samples to another project via the REST API.  Add ownership flag as URL variable with `?ownership=true/false`.  Default is `false`

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
