### PR TITLE
Fix for samples not rendering on project samples page when config property ngsarchive.linker.available set to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changes
 * [REST]: Added `ownership` option when copying sample to project in REST API (21.01.2)
 * [UI]: Update to the pipeline launch process.
 * [UI]: Fixed bug where filter menu was missing from the Analsyis Outputs Table.
+* [UI]: Fixed bug where samples not rendering on project samples page when the config setting ngsarchive.linker.available is set to false.
 
 20.09 to 21.01
 --------------

--- a/src/main/webapp/resources/js/pages/projects/samples/linker/Linker.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/linker/Linker.jsx
@@ -35,7 +35,7 @@ function Linker() {
 
   const options = [
     { label: i18n("Linker.fastq"), value: "fastq" },
-    { label: i18n("Linker.assembly"), value: "assembly" }
+    { label: i18n("Linker.assembly"), value: "assembly" },
   ];
 
   function handleSampleIds({ detail }) {
@@ -69,7 +69,7 @@ function Linker() {
         style={{
           margin: `0 inherit`,
           padding: 0,
-          color: grey9
+          color: grey9,
         }}
         className="t-linker-btn"
         onClick={getIds}
@@ -110,4 +110,7 @@ function Linker() {
   );
 }
 
-render(<Linker />, document.querySelector("#linker"));
+let linker_html = document.querySelector("#linker");
+if (linker_html) {
+  render(<Linker />, linker_html);
+}


### PR DESCRIPTION
## Description of changes
Added a conditional check that the html element exists before rendering the Linker component.

## Related issue
Fixes #958

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] ~Tests added (or description of how to test) for any new features.~
* [ ] ~User documentation updated for UI or technical changes.~
