### PR TITLE
Hotfix remove unnecessary tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes
 --------------
 * [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
 * [REST]: Added `ownership` option when copying sample to project in REST API (21.01.2)
+* [Database]: Removed `sample_metadata_entry` table which should have been dropped in 21.01 release. (21.01.3)
 
 20.09 to 21.01
 --------------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,11 @@ Upgrading
 This document summarizes the environmental changes that need to be made when
 upgrading IRIDA that cannot be automated.
 
+
+21.01 to 21.01.3
+--------------
+* This upgrade makes schema changes to the databases and cannot be parallel deployed.  Servlet container must be stopped before deploying the new `war` file.
+
 20.09 to 21.01
 --------------
 * This upgrade makes schema changes to the databases and cannot be parallel deployed.  Servlet container must be stopped before deploying the new `war` file.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.01.2</version>
+	<version>21.01.3</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/21.01/all-changes.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/21.01/all-changes.xml
@@ -10,4 +10,6 @@
     <include file="full-project-hash.xml" relativeToChangelogFile="true"/>
     <include file="analysis-submission-email-pipeline-result-on-error.xml"
              relativeToChangelogFile="true"/>
+    <include file="remove-sample-metadata-entry.xml"
+             relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/21.01/remove-sample-metadata-entry.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/21.01/remove-sample-metadata-entry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="remove-sample-metadata-entry" author="tom">
+        <dropTable tableName="sample_metadata_entry"/>
+        <dropTable tableName="sample_metadata_entry_AUD"/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
## Description of changes
Removing the `sample_metadata_entry` tables that should have been dropped in the 21.01 update.  They should have been removed in the `metadata-entry-refactor` changeset.  The tables are no longer used in the model.

Note this is a hotfix upgrade and should be merged to both `master` and `development` branches.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
