### PR TITLE
Rename base permission

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
@@ -53,8 +53,8 @@ public class IridaApiSecurityConfig extends GlobalMethodSecurityConfiguration {
 	private int passwordExpiryInDays = -1;
 
 	/**
-	 * Loads all of the {@link RepositoryBackedPermission} sub-classes found in the security
-	 * package during component scan. {@link RepositoryBackedPermission} classes are used in
+	 * Loads all of the {@link BasePermission} sub-classes found in the security
+	 * package during component scan. {@link BasePermission} classes are used in
 	 * {@link @PreAuthorize} annotations for verifying that a user has
 	 * permission to invoke a method by the expression handler.
 	 */

--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
@@ -3,6 +3,7 @@ package ca.corefacility.bioinformatics.irida.config.security;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
 import ca.corefacility.bioinformatics.irida.security.IgnoreExpiredCredentialsForPasswordChangeChecker;
 import ca.corefacility.bioinformatics.irida.security.PasswordExpiryChecker;
+import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.IridaPermissionEvaluator;
 import com.google.common.base.Joiner;
@@ -58,7 +59,7 @@ public class IridaApiSecurityConfig extends GlobalMethodSecurityConfiguration {
 	 * permission to invoke a method by the expression handler.
 	 */
 	@Autowired
-	private List<RepositoryBackedPermission<?,?>> basePermissions;
+	private List<BasePermission<?>> basePermissions;
 
 	@Autowired
 	private UserRepository userRepository;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
@@ -1,12 +1,7 @@
 package ca.corefacility.bioinformatics.irida.config.security;
 
-import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.IgnoreExpiredCredentialsForPasswordChangeChecker;
-import ca.corefacility.bioinformatics.irida.security.PasswordExpiryChecker;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
-import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
-import ca.corefacility.bioinformatics.irida.security.permissions.IridaPermissionEvaluator;
-import com.google.common.base.Joiner;
+import java.util.List;
+
 import org.apache.oltu.oauth2.client.OAuthClient;
 import org.apache.oltu.oauth2.client.URLConnectionClient;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +24,13 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
 
-import java.util.List;
+import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
+import ca.corefacility.bioinformatics.irida.security.IgnoreExpiredCredentialsForPasswordChangeChecker;
+import ca.corefacility.bioinformatics.irida.security.PasswordExpiryChecker;
+import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.IridaPermissionEvaluator;
+
+import com.google.common.base.Joiner;
 
 /**
  * Configuration for IRIDA's spring security modules

--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaApiSecurityConfig.java
@@ -3,7 +3,7 @@ package ca.corefacility.bioinformatics.irida.config.security;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
 import ca.corefacility.bioinformatics.irida.security.IgnoreExpiredCredentialsForPasswordChangeChecker;
 import ca.corefacility.bioinformatics.irida.security.PasswordExpiryChecker;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.IridaPermissionEvaluator;
 import com.google.common.base.Joiner;
 import org.apache.oltu.oauth2.client.OAuthClient;
@@ -52,13 +52,13 @@ public class IridaApiSecurityConfig extends GlobalMethodSecurityConfiguration {
 	private int passwordExpiryInDays = -1;
 
 	/**
-	 * Loads all of the {@link BasePermission} sub-classes found in the security
-	 * package during component scan. {@link BasePermission} classes are used in
+	 * Loads all of the {@link RepositoryBackedPermission} sub-classes found in the security
+	 * package during component scan. {@link RepositoryBackedPermission} classes are used in
 	 * {@link @PreAuthorize} annotations for verifying that a user has
 	 * permission to invoke a method by the expression handler.
 	 */
 	@Autowired
-	private List<BasePermission<?,?>> basePermissions;
+	private List<RepositoryBackedPermission<?,?>> basePermissions;
 
 	@Autowired
 	private UserRepository userRepository;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/BasePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/BasePermission.java
@@ -2,6 +2,12 @@ package ca.corefacility.bioinformatics.irida.security.permissions;
 
 import org.springframework.security.core.Authentication;
 
+/**
+ * Root interface for any permissions being built within IRIDA.  This interface defines the methods required for evaluating a permission in {@link IridaPermissionEvaluator}.
+ *
+ * @param <DomainObjectType>
+ * @see IridaPermissionEvaluator
+ */
 public interface BasePermission<DomainObjectType> {
 
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/BasePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/BasePermission.java
@@ -1,0 +1,10 @@
+package ca.corefacility.bioinformatics.irida.security.permissions;
+
+import org.springframework.security.core.Authentication;
+
+public interface BasePermission<DomainObjectType> {
+
+	String getPermissionProvided();
+	
+	boolean isAllowed(Authentication authentication, Object targetDomainObject);
+}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/BasePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/BasePermission.java
@@ -4,7 +4,20 @@ import org.springframework.security.core.Authentication;
 
 public interface BasePermission<DomainObjectType> {
 
+	/**
+	 * Get the implementation-specific permission provided.
+	 *
+	 * @return the permission provided by the permission class.
+	 */
 	String getPermissionProvided();
-	
+
+	/**
+	 * Is the authenticated user allowed to perform some action on the target
+	 * domain object?
+	 *
+	 * @param authentication     the authenticated user.
+	 * @param targetDomainObject the object the user is requesting to perform an action on.
+	 * @return true if the action is allowed, false otherwise.
+	 */
 	boolean isAllowed(Authentication authentication, Object targetDomainObject);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/IridaPermissionEvaluator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/IridaPermissionEvaluator.java
@@ -26,14 +26,14 @@ public class IridaPermissionEvaluator implements PermissionEvaluator {
 
 	private static final Logger logger = LoggerFactory.getLogger(IridaPermissionEvaluator.class);
 
-	private Collection<RepositoryBackedPermission<?,?>> permissions;
-	private Map<String, RepositoryBackedPermission<?,?>> namedPermissionMap;
+	private Collection<BasePermission<?>> permissions;
+	private Map<String, BasePermission<?>> namedPermissionMap;
 
 	public IridaPermissionEvaluator(RepositoryBackedPermission<?,?>... permissions) {
 		this(Arrays.asList(permissions));
 	}
 
-	public IridaPermissionEvaluator(Collection<RepositoryBackedPermission<?,?>> permissions) {
+	public IridaPermissionEvaluator(Collection<BasePermission<?>> permissions) {
 		this.permissions = permissions;
 		this.namedPermissionMap = new HashMap<>();
 	}
@@ -43,7 +43,7 @@ public class IridaPermissionEvaluator implements PermissionEvaluator {
 	 */
 	@PostConstruct
 	public void init() {
-		for (RepositoryBackedPermission<?,?> p : permissions) {
+		for (BasePermission<?> p : permissions) {
 			logger.trace("Registering permission [" + p.getPermissionProvided() + "] with class ["
 					+ p.getClass().getName() + "]");
 			namedPermissionMap.put(p.getPermissionProvided(), p);
@@ -60,7 +60,7 @@ public class IridaPermissionEvaluator implements PermissionEvaluator {
 					+ "] is not registered with " + getClass().getName() + ".");
 		}
 
-		RepositoryBackedPermission<?,?> permissionEvaluator = namedPermissionMap.get(permission.toString());
+		BasePermission<?> permissionEvaluator = namedPermissionMap.get(permission.toString());
 		boolean allowed = permissionEvaluator.isAllowed(authentication, targetDomainObject);
 
 		logger.trace("Permission request for access to [" + targetDomainObject + "] with permission [" + permission

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/IridaPermissionEvaluator.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/IridaPermissionEvaluator.java
@@ -26,14 +26,14 @@ public class IridaPermissionEvaluator implements PermissionEvaluator {
 
 	private static final Logger logger = LoggerFactory.getLogger(IridaPermissionEvaluator.class);
 
-	private Collection<BasePermission<?,?>> permissions;
-	private Map<String, BasePermission<?,?>> namedPermissionMap;
+	private Collection<RepositoryBackedPermission<?,?>> permissions;
+	private Map<String, RepositoryBackedPermission<?,?>> namedPermissionMap;
 
-	public IridaPermissionEvaluator(BasePermission<?,?>... permissions) {
+	public IridaPermissionEvaluator(RepositoryBackedPermission<?,?>... permissions) {
 		this(Arrays.asList(permissions));
 	}
 
-	public IridaPermissionEvaluator(Collection<BasePermission<?,?>> permissions) {
+	public IridaPermissionEvaluator(Collection<RepositoryBackedPermission<?,?>> permissions) {
 		this.permissions = permissions;
 		this.namedPermissionMap = new HashMap<>();
 	}
@@ -43,7 +43,7 @@ public class IridaPermissionEvaluator implements PermissionEvaluator {
 	 */
 	@PostConstruct
 	public void init() {
-		for (BasePermission<?,?> p : permissions) {
+		for (RepositoryBackedPermission<?,?> p : permissions) {
 			logger.trace("Registering permission [" + p.getPermissionProvided() + "] with class ["
 					+ p.getClass().getName() + "]");
 			namedPermissionMap.put(p.getPermissionProvided(), p);
@@ -60,7 +60,7 @@ public class IridaPermissionEvaluator implements PermissionEvaluator {
 					+ "] is not registered with " + getClass().getName() + ".");
 		}
 
-		BasePermission<?,?> permissionEvaluator = namedPermissionMap.get(permission.toString());
+		RepositoryBackedPermission<?,?> permissionEvaluator = namedPermissionMap.get(permission.toString());
 		boolean allowed = permissionEvaluator.isAllowed(authentication, targetDomainObject);
 
 		logger.trace("Permission request for access to [" + targetDomainObject + "] with permission [" + permission

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
@@ -18,7 +18,8 @@ import ca.corefacility.bioinformatics.irida.model.user.Role;
  * @param <DomainObjectType> the type of domain object that this permission is evaluating.
  * @param <IdentifierType>   The identifier for the domain object in the database
  */
-public abstract class RepositoryBackedPermission<DomainObjectType, IdentifierType extends Serializable> {
+public abstract class RepositoryBackedPermission<DomainObjectType, IdentifierType extends Serializable>
+		implements BasePermission<DomainObjectType> {
 
 	private static final Logger logger = LoggerFactory.getLogger(RepositoryBackedPermission.class);
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
@@ -13,7 +13,7 @@ import ca.corefacility.bioinformatics.irida.exceptions.EntityNotFoundException;
 import ca.corefacility.bioinformatics.irida.model.user.Role;
 
 /**
- * Generic super-class for permission types to extend from.
+ * Superclass for permissions on objects which can be read from a {@link CrudRepository}
  *
  * @param <DomainObjectType> the type of domain object that this permission is evaluating.
  * @param <IdentifierType>   The identifier for the domain object in the database

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
@@ -26,13 +26,6 @@ public abstract class RepositoryBackedPermission<DomainObjectType, IdentifierTyp
 	private static final String ADMIN_AUTHORITY = Role.ROLE_ADMIN.getAuthority();
 
 	/**
-	 * Get the implementation-specific permission provided.
-	 * 
-	 * @return the permission provided by the permission class.
-	 */
-	public abstract String getPermissionProvided();
-
-	/**
 	 * This method is called by {@link RepositoryBackedPermission} to evaluate the custom
 	 * permissions provided by implementing classes.
 	 * 
@@ -139,17 +132,10 @@ public abstract class RepositoryBackedPermission<DomainObjectType, IdentifierTyp
 	}
 
 	/**
-	 * Is the authenticated user allowed to perform some action on the target
-	 * domain object?
-	 * 
-	 * @param authentication
-	 *            the authenticated user.
-	 * @param targetDomainObject
-	 *            the object the user is requesting to perform an action on.
-	 * @return true if the action is allowed, false otherwise.
+	 * {@inheritDoc}
 	 */
 	public boolean isAllowed(Authentication authentication, Object targetDomainObject) {
-		
+
 		// fast fail on anonymous users:
 		if (authentication instanceof AnonymousAuthenticationToken) {
 			return false;
@@ -161,7 +147,7 @@ public abstract class RepositoryBackedPermission<DomainObjectType, IdentifierTyp
 			return customPermissionAllowedSingleObject(authentication, targetDomainObject);
 		}
 	}
-	
+
 	/**
 	 * Check whether admins should be quick-approved for this permission. This
 	 * may be overridden for special cases

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermission.java
@@ -18,9 +18,9 @@ import ca.corefacility.bioinformatics.irida.model.user.Role;
  * @param <DomainObjectType> the type of domain object that this permission is evaluating.
  * @param <IdentifierType>   The identifier for the domain object in the database
  */
-public abstract class BasePermission<DomainObjectType, IdentifierType extends Serializable> {
+public abstract class RepositoryBackedPermission<DomainObjectType, IdentifierType extends Serializable> {
 
-	private static final Logger logger = LoggerFactory.getLogger(BasePermission.class);
+	private static final Logger logger = LoggerFactory.getLogger(RepositoryBackedPermission.class);
 
 	private static final String ADMIN_AUTHORITY = Role.ROLE_ADMIN.getAuthority();
 
@@ -32,7 +32,7 @@ public abstract class BasePermission<DomainObjectType, IdentifierType extends Se
 	public abstract String getPermissionProvided();
 
 	/**
-	 * This method is called by {@link BasePermission} to evaluate the custom
+	 * This method is called by {@link RepositoryBackedPermission} to evaluate the custom
 	 * permissions provided by implementing classes.
 	 * 
 	 * @param authentication
@@ -71,7 +71,7 @@ public abstract class BasePermission<DomainObjectType, IdentifierType extends Se
 	 *            the repository to load objects of the type for this
 	 *            permission.
 	 */
-	protected BasePermission(Class<DomainObjectType> domainObjectType, Class<IdentifierType> identifierType,
+	protected RepositoryBackedPermission(Class<DomainObjectType> domainObjectType, Class<IdentifierType> identifierType,
 			CrudRepository<DomainObjectType, IdentifierType> repository) {
 		this.repository = repository;
 		this.domainObjectType = domainObjectType;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/ReadAnalysisPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/ReadAnalysisPermission.java
@@ -12,7 +12,7 @@ import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSu
 import ca.corefacility.bioinformatics.irida.repositories.analysis.AnalysisRepository;
 import ca.corefacility.bioinformatics.irida.repositories.analysis.submission.AnalysisSubmissionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Confirms if a {@link User} can read a {@link Analysis}.
@@ -20,7 +20,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
  *
  */
 @Component
-public class ReadAnalysisPermission extends BasePermission<Analysis, Long> {
+public class ReadAnalysisPermission extends RepositoryBackedPermission<Analysis, Long> {
 
 	private static final Logger logger = LoggerFactory
 			.getLogger(ReadAnalysisPermission.class);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/ReadAnalysisSubmissionPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/ReadAnalysisSubmissionPermission.java
@@ -17,7 +17,7 @@ import ca.corefacility.bioinformatics.irida.repositories.analysis.submission.Ana
 import ca.corefacility.bioinformatics.irida.repositories.analysis.submission.ProjectAnalysisSubmissionJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sequencefile.SequencingObjectRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.files.ReadSequencingObjectPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadProjectPermission;
 
@@ -27,7 +27,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadPro
  *
  */
 @Component
-public class ReadAnalysisSubmissionPermission extends BasePermission<AnalysisSubmission, Long> {
+public class ReadAnalysisSubmissionPermission extends RepositoryBackedPermission<AnalysisSubmission, Long> {
 
 	private static final Logger logger = LoggerFactory.getLogger(ReadAnalysisSubmissionPermission.class);
 	private static final String PERMISSION_PROVIDED = "canReadAnalysisSubmission";

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/UpdateAnalysisSubmissionPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/UpdateAnalysisSubmissionPermission.java
@@ -10,7 +10,7 @@ import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
 import ca.corefacility.bioinformatics.irida.repositories.analysis.submission.AnalysisSubmissionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Confirms if a {@link User} can update a {@link AnalysisSubmission}.
@@ -18,7 +18,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
  *
  */
 @Component
-public class UpdateAnalysisSubmissionPermission extends BasePermission<AnalysisSubmission, Long> {
+public class UpdateAnalysisSubmissionPermission extends RepositoryBackedPermission<AnalysisSubmission, Long> {
 
 	private static final Logger logger = LoggerFactory.getLogger(UpdateAnalysisSubmissionPermission.class);
 	private static final String PERMISSION_PROVIDED = "canUpdateAnalysisSubmission";

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/UpdateSamplesFromAnalysisSubmissionPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/analysis/UpdateSamplesFromAnalysisSubmissionPermission.java
@@ -12,14 +12,15 @@ import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSubmission;
 import ca.corefacility.bioinformatics.irida.repositories.analysis.submission.AnalysisSubmissionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.SampleRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.sample.UpdateSamplePermission;
 
 /**
  * Permission for whether a user can update samples in a given analysis submission.
  */
 @Component
-public class UpdateSamplesFromAnalysisSubmissionPermission extends BasePermission<AnalysisSubmission, Long> {
+public class UpdateSamplesFromAnalysisSubmissionPermission extends
+		RepositoryBackedPermission<AnalysisSubmission, Long> {
 
 	private static final Logger logger = LoggerFactory.getLogger(UpdateSamplesFromAnalysisSubmissionPermission.class);
 	private static final String PERMISSION_PROVIDED = "canUpdateSamplesFromAnalysisSubmission";

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/ReadReferenceFilePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/ReadReferenceFilePermission.java
@@ -14,7 +14,7 @@ import ca.corefacility.bioinformatics.irida.model.workflow.submission.AnalysisSu
 import ca.corefacility.bioinformatics.irida.repositories.analysis.submission.AnalysisSubmissionRepository;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectReferenceFileJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.referencefile.ReferenceFileRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.analysis.ReadAnalysisSubmissionPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadProjectPermission;
 
@@ -24,7 +24,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadPro
  *
  */
 @Component
-public class ReadReferenceFilePermission extends BasePermission<ReferenceFile, Long> {
+public class ReadReferenceFilePermission extends RepositoryBackedPermission<ReferenceFile, Long> {
 
 	public static final String PERMISSION_PROVIDED = "canReadReferenceFile";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/ReadSequencingObjectPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/ReadSequencingObjectPermission.java
@@ -11,14 +11,14 @@ import ca.corefacility.bioinformatics.irida.model.sample.SampleSequencingObjectJ
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
 import ca.corefacility.bioinformatics.irida.repositories.joins.sample.SampleSequencingObjectJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sequencefile.SequencingObjectRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.sample.ReadSamplePermission;
 
 /**
  * Evaluate whether or not a user can read a {@link SequencingObject}
  */
 @Component
-public class ReadSequencingObjectPermission extends BasePermission<SequencingObject, Long> {
+public class ReadSequencingObjectPermission extends RepositoryBackedPermission<SequencingObject, Long> {
 	private static final String PERMISSION_PROVIDED = "canReadSequencingObject";
 	
 	private static final Logger logger = LoggerFactory.getLogger(ReadSequencingObjectPermission.class);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/ReadSequencingRunPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/ReadSequencingRunPermission.java
@@ -11,13 +11,13 @@ import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.repositories.SequencingRunRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Permission allowing a user to read a {@link SequencingRun}
  */
 @Component
-public class ReadSequencingRunPermission extends BasePermission<SequencingRun, Long> {
+public class ReadSequencingRunPermission extends RepositoryBackedPermission<SequencingRun, Long> {
 
 	private static String PERMISSION_PROVIDED = "canReadSequencingRun";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/UpdateReferenceFilePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/UpdateReferenceFilePermission.java
@@ -11,7 +11,7 @@ import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.project.ReferenceFile;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectReferenceFileJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.referencefile.ReferenceFileRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ProjectOwnerPermission;
 
 /**
@@ -20,7 +20,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.project.Project
  * 
  */
 @Component
-public class UpdateReferenceFilePermission extends BasePermission<ReferenceFile, Long> {
+public class UpdateReferenceFilePermission extends RepositoryBackedPermission<ReferenceFile, Long> {
 
 	public static final String PERMISSION_PROVIDED = "canUpdateReferenceFile";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/UpdateSequencingRunPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/files/UpdateSequencingRunPermission.java
@@ -11,14 +11,14 @@ import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.repositories.SequencingRunRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Permission checking if a user is the owner of a {@link SequencingRun} or if
  * they are ROLE_SEQUENCER
  */
 @Component
-public class UpdateSequencingRunPermission extends BasePermission<SequencingRun, Long> {
+public class UpdateSequencingRunPermission extends RepositoryBackedPermission<SequencingRun, Long> {
 
 	private static final String PERMISSION_PROVIDED = "canUpdateSequencingRun";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadMetadataTemplatePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/ReadMetadataTemplatePermission.java
@@ -10,14 +10,14 @@ import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectMetadataTemp
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplate;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectMetadataTemplateJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.MetadataTemplateRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadProjectPermission;
 
 /**
  * Permission for reading {@link MetadataTemplate}
  */
 @Component
-public class ReadMetadataTemplatePermission extends BasePermission<MetadataTemplate, Long> {
+public class ReadMetadataTemplatePermission extends RepositoryBackedPermission<MetadataTemplate, Long> {
 
 	public static final String PERMISSION_PROVIDED = "canReadMetadataTemplate";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/UpdateMetadataTemplatePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/metadata/UpdateMetadataTemplatePermission.java
@@ -10,14 +10,14 @@ import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectMetadataTemp
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplate;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectMetadataTemplateJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.MetadataTemplateRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ManageLocalProjectSettingsPermission;
 
 /**
  * Permission for updating a {@link MetadataTemplate}
  */
 @Component
-public class UpdateMetadataTemplatePermission extends BasePermission<MetadataTemplate, Long> {
+public class UpdateMetadataTemplatePermission extends RepositoryBackedPermission<MetadataTemplate, Long> {
 
 	public static final String PERMISSION_PROVIDED = "canUpdateMetadataTemplate";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ModifyProjectPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ModifyProjectPermission.java
@@ -19,12 +19,12 @@ import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectUs
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.UserGroupProjectJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserGroupJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Superclass permission whether a user can modify project settings.  This superclass checks if a user has ownership of a project. This can be extended for specific settings.
  */
-public abstract class ModifyProjectPermission extends BasePermission<Project,Long>{
+public abstract class ModifyProjectPermission extends RepositoryBackedPermission<Project,Long> {
 	private static final Logger logger = LoggerFactory.getLogger(ModifyProjectPermission.class);
 
 	private final UserRepository userRepository;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ReadExportSubmissionPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ReadExportSubmissionPermission.java
@@ -8,13 +8,13 @@ import ca.corefacility.bioinformatics.irida.model.NcbiExportSubmission;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.repositories.NcbiExportSubmissionRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Whether or not a {@link User} can read a given {@link NcbiExportSubmission}
  */
 @Component
-public class ReadExportSubmissionPermission extends BasePermission<NcbiExportSubmission, Long> {
+public class ReadExportSubmissionPermission extends RepositoryBackedPermission<NcbiExportSubmission, Long> {
 
 	private static final String PERMISSION_PROVIDED = "canReadExportSubmission";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ReadProjectPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/project/ReadProjectPermission.java
@@ -20,13 +20,13 @@ import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectUs
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.UserGroupProjectJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserGroupJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Confirms that the authenticated user is allowed to read a project.
  */
 @Component
-public class ReadProjectPermission extends BasePermission<Project, Long> {
+public class ReadProjectPermission extends RepositoryBackedPermission<Project, Long> {
 
 	private static final Logger logger = LoggerFactory.getLogger(ReadProjectPermission.class);
 	public static final String PERMISSION_PROVIDED = "canReadProject";

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/sample/ReadSamplePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/sample/ReadSamplePermission.java
@@ -11,7 +11,7 @@ import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectSampleJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.SampleRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadProjectPermission;
 
 /**
@@ -20,7 +20,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.project.ReadPro
  * 
  */
 @Component
-public class ReadSamplePermission extends BasePermission<Sample, Long> {
+public class ReadSamplePermission extends RepositoryBackedPermission<Sample, Long> {
 
 	private static final String PERMISSION_PROVIDED = "canReadSample";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/sample/UpdateSamplePermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/sample/UpdateSamplePermission.java
@@ -13,7 +13,7 @@ import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.repositories.joins.project.ProjectSampleJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.sample.SampleRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 import ca.corefacility.bioinformatics.irida.security.permissions.project.ProjectOwnerPermission;
 
 /**
@@ -21,7 +21,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.project.Project
  *
  */
 @Component
-public class UpdateSamplePermission extends BasePermission<Sample, Long> {
+public class UpdateSamplePermission extends RepositoryBackedPermission<Sample, Long> {
 
 	private static final String PERMISSION_PROVIDED = "canUpdateSample";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/user/UpdateUserGroupPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/user/UpdateUserGroupPermission.java
@@ -15,13 +15,13 @@ import ca.corefacility.bioinformatics.irida.model.user.group.UserGroupJoin.UserG
 import ca.corefacility.bioinformatics.irida.repositories.user.UserGroupJoinRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserGroupRepository;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Confirms that the authenticated user is allowed to modify a user group.
  */
 @Component
-public class UpdateUserGroupPermission extends BasePermission<UserGroup, Long> {
+public class UpdateUserGroupPermission extends RepositoryBackedPermission<UserGroup, Long> {
 
 	private static final String PERMISSION_PROVIDED = "canUpdateUserGroup";
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/user/UpdateUserPermission.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/security/permissions/user/UpdateUserPermission.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 import ca.corefacility.bioinformatics.irida.model.user.Role;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
-import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
+import ca.corefacility.bioinformatics.irida.security.permissions.RepositoryBackedPermission;
 
 /**
  * Confirms that the authenticated user is allowed to modify another (or their
@@ -18,7 +18,7 @@ import ca.corefacility.bioinformatics.irida.security.permissions.BasePermission;
  * 
  */
 @Component
-public class UpdateUserPermission extends BasePermission<User, Long> {
+public class UpdateUserPermission extends RepositoryBackedPermission<User, Long> {
 
 	private static final String PERMISSION_PROVIDED = "canUpdateUser";
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermissionTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/security/permissions/RepositoryBackedPermissionTest.java
@@ -22,12 +22,12 @@ import ca.corefacility.bioinformatics.irida.exceptions.EntityNotFoundException;
 import com.google.common.collect.Sets;
 
 /**
- * Tests for {@link BasePermission}.
+ * Tests for {@link RepositoryBackedPermission}.
  * 
  * 
  */
-public class BasePermissionTest {
-	private BasePermission<Permittable, Long> basePermission;
+public class RepositoryBackedPermissionTest {
+	private RepositoryBackedPermission<Permittable, Long> repositoryBackedPermission;
 	private CrudRepository<Permittable, Long> crudRepository;
 
 	private Authentication auth;
@@ -36,7 +36,7 @@ public class BasePermissionTest {
 	@Before
 	public void setUp() {
 		crudRepository = mock(CrudRepository.class);
-		basePermission = new PermittablePermission(Permittable.class, Long.class, crudRepository);
+		repositoryBackedPermission = new PermittablePermission(Permittable.class, Long.class, crudRepository);
 
 		auth = new UsernamePasswordAuthenticationToken("fbristow", "password1");
 	}
@@ -48,7 +48,7 @@ public class BasePermissionTest {
 	public void testPermissionLongSuccess() {
 		when(crudRepository.findById(1L)).thenReturn(Optional.of(new Permittable(1L)));
 
-		assertTrue(basePermission.isAllowed(auth, 1L));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, 1L));
 	}
 
 	/**
@@ -57,7 +57,7 @@ public class BasePermissionTest {
 	@Ignore
 	@Test(expected = EntityNotFoundException.class)
 	public void testEntityNotFound() {
-		basePermission.isAllowed(auth, 1L);
+		repositoryBackedPermission.isAllowed(auth, 1L);
 	}
 
 	/**
@@ -67,7 +67,7 @@ public class BasePermissionTest {
 	public void testPermissionSingleCollectionLongSuccess() {
 		when(crudRepository.findById(1L)).thenReturn(Optional.of(new Permittable(1L)));
 
-		assertTrue(basePermission.isAllowed(auth, Sets.newHashSet(1L)));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(1L)));
 	}
 
 	/**
@@ -76,7 +76,7 @@ public class BasePermissionTest {
 	@Ignore
 	@Test(expected = EntityNotFoundException.class)
 	public void testPermissionSingleCollectionLongFail() {
-		basePermission.isAllowed(auth, Sets.newHashSet(1L));
+		repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(1L));
 	}
 
 	/**
@@ -87,7 +87,7 @@ public class BasePermissionTest {
 		when(crudRepository.findById(1L)).thenReturn(Optional.of(new Permittable(1L)));
 		when(crudRepository.findById(2L)).thenReturn(Optional.of(new Permittable(2L)));
 
-		assertTrue(basePermission.isAllowed(auth, Sets.newHashSet(1L, 2L)));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(1L, 2L)));
 	}
 
 	/**
@@ -99,7 +99,7 @@ public class BasePermissionTest {
 	public void testPermissionTwoCollectionLongFail() {
 		when(crudRepository.findById(1L)).thenReturn(Optional.of(new Permittable(1L)));
 
-		basePermission.isAllowed(auth, Sets.newHashSet(1L, 2L));
+		repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(1L, 2L));
 	}
 
 	/**
@@ -108,9 +108,9 @@ public class BasePermissionTest {
 	@Test
 	public void testPermissionSuccess() {
 		Permittable permittable1 = new Permittable(1L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
-		assertTrue(basePermission.isAllowed(auth, permittable1));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, permittable1));
 	}
 
 	/**
@@ -119,9 +119,9 @@ public class BasePermissionTest {
 	@Test
 	public void testPermissionFailNotPermitted() {
 		Permittable permittable1 = new Permittable(1L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
-		assertFalse(basePermission.isAllowed(auth, new Permittable(2L)));
+		assertFalse(repositoryBackedPermission.isAllowed(auth, new Permittable(2L)));
 	}
 
 	/**
@@ -129,9 +129,9 @@ public class BasePermissionTest {
 	 */
 	@Test
 	public void testPermissionCollectionEmptySuccess() {
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository);
 
-		assertTrue(basePermission.isAllowed(auth, Sets.newHashSet()));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet()));
 	}
 
 	/**
@@ -140,9 +140,9 @@ public class BasePermissionTest {
 	@Test
 	public void testPermissionCollectionSuccess() {
 		Permittable permittable1 = new Permittable(1L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
-		assertTrue(basePermission.isAllowed(auth, Sets.newHashSet(permittable1)));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(permittable1)));
 	}
 
 	/**
@@ -151,9 +151,9 @@ public class BasePermissionTest {
 	@Test
 	public void testPermissionCollectionFailNotPermitted() {
 		Permittable permittable1 = new Permittable(1L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
-		assertFalse(basePermission.isAllowed(auth, Sets.newHashSet(new Permittable(2L))));
+		assertFalse(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(new Permittable(2L))));
 	}
 
 	/**
@@ -163,10 +163,10 @@ public class BasePermissionTest {
 	public void testPermissionCollectionSuccessTwoElements() {
 		Permittable permittable1 = new Permittable(1L);
 		Permittable permittable2 = new Permittable(2L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1,
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1,
 				permittable2);
 
-		assertTrue(basePermission.isAllowed(auth, Sets.newHashSet(permittable1, permittable2)));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(permittable1, permittable2)));
 	}
 
 	/**
@@ -177,9 +177,9 @@ public class BasePermissionTest {
 	public void testPermissionCollectionFailTwoElementsOneFail() {
 		Permittable permittable1 = new Permittable(1L);
 		Permittable permittable2 = new Permittable(2L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
-		assertFalse(basePermission.isAllowed(auth, Sets.newHashSet(permittable1, permittable2)));
+		assertFalse(repositoryBackedPermission.isAllowed(auth, Sets.newHashSet(permittable1, permittable2)));
 	}
 
 	/**
@@ -187,9 +187,9 @@ public class BasePermissionTest {
 	 */
 	@Test(expected = IllegalArgumentException.class)
 	public void testPermissionCollectionFailInvalidType() {
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository);
 
-		basePermission.isAllowed(auth, Sets.newHashSet("invalid"));
+		repositoryBackedPermission.isAllowed(auth, Sets.newHashSet("invalid"));
 	}
 
 	/**
@@ -199,12 +199,12 @@ public class BasePermissionTest {
 	@Test
 	public void testPermissionSucccessNonGenericCollectionType() {
 		Permittable permittable1 = new Permittable(1L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
 		Set set = new HashSet();
 		set.add(permittable1);
 
-		assertTrue(basePermission.isAllowed(auth, set));
+		assertTrue(repositoryBackedPermission.isAllowed(auth, set));
 	}
 
 	/**
@@ -214,18 +214,18 @@ public class BasePermissionTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testPermissionFailMixedCollectionType() {
 		Permittable permittable1 = new Permittable(1L);
-		basePermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
+		repositoryBackedPermission = new VariablePermittablePermission(Permittable.class, Long.class, crudRepository, permittable1);
 
 		Set mixedSet = new HashSet();
 		mixedSet.add(permittable1);
 		mixedSet.add("invalid");
 
-		basePermission.isAllowed(auth, mixedSet);
+		repositoryBackedPermission.isAllowed(auth, mixedSet);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testBizarreExecution() {
-		basePermission.isAllowed(auth, new Object());
+		repositoryBackedPermission.isAllowed(auth, new Object());
 	}
 
 	/**
@@ -233,7 +233,7 @@ public class BasePermissionTest {
 	 * 
 	 *
 	 */
-	private static class VariablePermittablePermission extends BasePermission<Permittable, Long> {
+	private static class VariablePermittablePermission extends RepositoryBackedPermission<Permittable, Long> {
 
 		private Set<Permittable> permittedObjects;
 
@@ -269,7 +269,7 @@ public class BasePermissionTest {
 		}
 	}
 
-	private static class PermittablePermission extends BasePermission<Permittable, Long> {
+	private static class PermittablePermission extends RepositoryBackedPermission<Permittable, Long> {
 
 		protected PermittablePermission(Class<Permittable> domainObjectType, Class<Long> identifierType,
 				CrudRepository<Permittable, Long> repository) {


### PR DESCRIPTION
## Description of changes
Changed the root of the permissions structure to an interface instead of the existing `BasePermission`.  The current permissions expect that all permissions will have a `CrudRepository` to read an object and that we can check the permission based on that read object alone.  We're going to run into some situations in this effort where we'll have to check a response type that can't be directly read from a repository.

For this I refactored `BasePermission` into a new class called `RepositoryBackedPermission`.  Then I created an interface called `BasePermission` that defines the methods needed to evaluate permissions.

All the existing permissions now extend `RepositoryBackedPermission` and `RepositoryBackedPermission` implements `BasePermission`.

## Related issue
Related to #931 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
