### PR TITLE
Single request all project metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes
 * [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
 * [REST]: Added `ownership` option when copying sample to project in REST API (21.01.2)
 * [Database]: Removed `sample_metadata_entry` table which should have been dropped in 21.01 release. (21.01.3)
+* [REST]: Added endpoint to request multiple sample's metadata at the same time. (21.01.4)
 
 20.09 to 21.01
 --------------

--- a/doc/developer/rest/index.md
+++ b/doc/developer/rest/index.md
@@ -547,6 +547,7 @@ A sample corresponds to a single isolate and contains the sequencing data and me
 | Name | Description |
 |------|-------------|
 | `self` | The link back to this collection of samples. |
+| `samples/metadata` | Link to the metadata associated with this sample collection. |
 
 ##### Example Response
 {:.no_toc}
@@ -596,6 +597,10 @@ A sample corresponds to a single isolate and contains the sequencing data and me
     "links" : [ {
       "rel" : "self",
       "href" : "http://localhost:8080/api/projects/5/samples"
+    }, {
+      "rel" : "samples/metadata",
+      "href" : "http://localhost:8080/api/projects/5/samples/metadata"
+
     } ]
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.01.3</version>
+	<version>21.01.4</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import ca.corefacility.bioinformatics.irida.model.IridaResourceSupport;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
+import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -14,18 +15,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Response class so we can add links to sample metadata
  */
 public class SampleMetadataResponse extends IridaResourceSupport {
-	Map<MetadataTemplateField, MetadataEntry> metadata;
+	private String sampleName;
+	private Map<MetadataTemplateField, MetadataEntry> metadata;
 
 	@Deprecated
 	public SampleMetadataResponse(Map<MetadataTemplateField, MetadataEntry> metadata) {
 		this.metadata = metadata;
 	}
 
-	public SampleMetadataResponse(Set<MetadataEntry> metadataEntrySet) {
+	public SampleMetadataResponse(Sample sample, Set<MetadataEntry> metadataEntrySet) {
+		this.sampleName = sample.getSampleName();
 		metadata = new HashMap<>();
 		for (MetadataEntry entry : metadataEntrySet) {
 			metadata.put(entry.getField(), entry);
 		}
+	}
+
+	@JsonProperty
+	public String getSampleName() {
+		return sampleName;
 	}
 
 	@JsonProperty

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
@@ -1,0 +1,40 @@
+package ca.corefacility.bioinformatics.irida.web.assembler.resource.sample;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import ca.corefacility.bioinformatics.irida.model.IridaResourceSupport;
+import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
+import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response class so we can add links to sample metadata
+ */
+public class SampleMetadataResponse extends IridaResourceSupport {
+	Map<MetadataTemplateField, MetadataEntry> metadata;
+
+	@Deprecated
+	public SampleMetadataResponse(Map<MetadataTemplateField, MetadataEntry> metadata) {
+		this.metadata = metadata;
+	}
+
+	public SampleMetadataResponse(Set<MetadataEntry> metadataEntrySet) {
+		metadata = new HashMap<>();
+		for (MetadataEntry entry : metadataEntrySet) {
+			metadata.put(entry.getField(), entry);
+		}
+	}
+
+	@JsonProperty
+	public Map<MetadataTemplateField, MetadataEntry> getMetadata() {
+		return metadata;
+	}
+
+	@JsonProperty
+	public void setMetadata(Map<MetadataTemplateField, MetadataEntry> metadata) {
+		this.metadata = metadata;
+	}
+}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
@@ -6,7 +6,6 @@ import java.util.Set;
 
 import ca.corefacility.bioinformatics.irida.model.IridaResourceSupport;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
-import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -15,25 +14,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * Response class so we can add links to sample metadata
  */
 public class SampleMetadataResponse extends IridaResourceSupport {
-	private String sampleName;
-	private Map<MetadataTemplateField, MetadataEntry> metadata;
+	Map<MetadataTemplateField, MetadataEntry> metadata;
 
 	@Deprecated
 	public SampleMetadataResponse(Map<MetadataTemplateField, MetadataEntry> metadata) {
 		this.metadata = metadata;
 	}
 
-	public SampleMetadataResponse(Sample sample, Set<MetadataEntry> metadataEntrySet) {
-		this.sampleName = sample.getSampleName();
+	public SampleMetadataResponse(Set<MetadataEntry> metadataEntrySet) {
 		metadata = new HashMap<>();
 		for (MetadataEntry entry : metadataEntrySet) {
 			metadata.put(entry.getField(), entry);
 		}
-	}
-
-	@JsonProperty
-	public String getSampleName() {
-		return sampleName;
 	}
 
 	@JsonProperty

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/assembler/resource/sample/SampleMetadataResponse.java
@@ -11,7 +11,7 @@ import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * Response class so we can add links to sample metadata
+ * Response class for grouping {@link MetadataEntry}s for response in the REST API
  */
 public class SampleMetadataResponse extends IridaResourceSupport {
 	Map<MetadataTemplateField, MetadataEntry> metadata;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -226,6 +226,8 @@ public class RESTProjectSamplesController {
 
 		sampleResources.add(
 				linkTo(methodOn(RESTProjectSamplesController.class).getProjectSamples(projectId)).withSelfRel());
+		sampleResources.add(linkTo(methodOn(RESTSampleMetadataController.class).getProjectSampleMetadata(projectId)).withRel(
+				RESTSampleMetadataController.ALL_METADATA_REL));
 
 		modelMap.addAttribute(RESTGenericController.RESOURCE_NAME, sampleResources);
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -1,9 +1,5 @@
 package ca.corefacility.bioinformatics.irida.web.controller.api.samples;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -18,10 +14,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import ca.corefacility.bioinformatics.irida.model.IridaResourceSupport;
-import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
@@ -30,6 +22,9 @@ import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResourceColle
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.sample.SampleMetadataResponse;
 import ca.corefacility.bioinformatics.irida.web.controller.api.RESTGenericController;
 import ca.corefacility.bioinformatics.irida.web.controller.api.projects.RESTProjectSamplesController;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 /**
  * REST controller to handle storing and retrieving metadata from a

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -79,7 +79,7 @@ public class RESTSampleMetadataController {
 	 * @return A collection of sample metadata for the given project
 	 */
 	@RequestMapping(value = "/api/projects/{projectId}/samples/metadata")
-	public ModelMap getProjectMetadata(final @PathVariable Long projectId) {
+	public ModelMap getProjectSampleMetadata(final @PathVariable Long projectId) {
 		ModelMap modelMap = new ModelMap();
 
 		ResourceCollection<SampleMetadataResponse> resources = new ResourceCollection<>();
@@ -97,7 +97,8 @@ public class RESTSampleMetadataController {
 			resources.add(response);
 		}
 
-		resources.add(linkTo(methodOn(RESTSampleMetadataController.class).getProjectMetadata(projectId)).withSelfRel());
+		resources.add(
+				linkTo(methodOn(RESTSampleMetadataController.class).getProjectSampleMetadata(projectId)).withSelfRel());
 
 		modelMap.addAttribute(RESTGenericController.RESOURCE_NAME, resources);
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -73,36 +73,11 @@ public class RESTSampleMetadataController {
 	}
 
 	/**
-	 * Get multiple sample metadata collections
+	 * Get all the sample metadata for a given project
 	 *
-	 * @param sampleIds the ids of the samples to get metadata for
-	 * @return A collection of sample metadata for the given IDs
+	 * @param projectId the id of the project to get metadata for
+	 * @return A collection of sample metadata for the given project
 	 */
-	@RequestMapping(value = "/api/samples/metadata")
-	public ModelMap getMultipleSampleMetadata(final @RequestBody List<Long> sampleIds) {
-		ModelMap modelMap = new ModelMap();
-
-		ResourceCollection<SampleMetadataResponse> resources = new ResourceCollection<>();
-
-		Iterable<Sample> samples = sampleService.readMultiple(sampleIds);
-
-		for (Sample s : samples) {
-
-			Set<MetadataEntry> metadataForSample = sampleService.getMetadataForSample(s);
-
-			SampleMetadataResponse response = buildSampleMetadataResponse(s, metadataForSample);
-
-			resources.add(response);
-		}
-
-		resources.add(
-				linkTo(methodOn(RESTSampleMetadataController.class).getMultipleSampleMetadata(null)).withSelfRel());
-
-		modelMap.addAttribute(RESTGenericController.RESOURCE_NAME, resources);
-
-		return modelMap;
-	}
-
 	@RequestMapping(value = "/api/projects/{projectId}/samples/metadata")
 	public ModelMap getProjectMetadata(final @PathVariable Long projectId) {
 		ModelMap modelMap = new ModelMap();
@@ -122,8 +97,7 @@ public class RESTSampleMetadataController {
 			resources.add(response);
 		}
 
-		resources.add(
-				linkTo(methodOn(RESTSampleMetadataController.class).getMultipleSampleMetadata(null)).withSelfRel());
+		resources.add(linkTo(methodOn(RESTSampleMetadataController.class).getProjectMetadata(projectId)).withSelfRel());
 
 		modelMap.addAttribute(RESTGenericController.RESOURCE_NAME, resources);
 
@@ -177,7 +151,7 @@ public class RESTSampleMetadataController {
 	 * @return a constructed {@link SampleMetadataResponse}
 	 */
 	private SampleMetadataResponse buildSampleMetadataResponse(final Sample s, Set<MetadataEntry> metadataEntries) {
-		SampleMetadataResponse response = new SampleMetadataResponse(s, metadataEntries);
+		SampleMetadataResponse response = new SampleMetadataResponse(metadataEntries);
 		response.add(linkTo(methodOn(RESTSampleMetadataController.class).getSampleMetadata(s.getId())).withSelfRel());
 		response.add(linkTo(methodOn(RESTProjectSamplesController.class).getSample(s.getId())).withRel(SAMPLE_REL));
 		return response;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -75,10 +75,10 @@ public class RESTSampleMetadataController {
 	}
 
 	/**
-	 * Get all the sample metadata for a given project
+	 * Get all the sample metadata for a given {@link Project}
 	 *
-	 * @param projectId the id of the project to get metadata for
-	 * @return A collection of sample metadata for the given project
+	 * @param projectId the id of the {@link Project} to get metadata for
+	 * @return A collection of metadata for all the {@link Sample}s in the {@link Project}
 	 */
 	@RequestMapping(value = "/api/projects/{projectId}/samples/metadata")
 	public ModelMap getProjectSampleMetadata(final @PathVariable Long projectId) {
@@ -86,19 +86,23 @@ public class RESTSampleMetadataController {
 
 		ResourceCollection<SampleMetadataResponse> resources = new ResourceCollection<>();
 
+		//get the project and samples for the project
 		Project project = projectService.read(projectId);
 		List<Join<Project, Sample>> samples = sampleService.getSamplesForProject(project);
 
+		//for each sample
 		for (Join<Project, Sample> join : samples) {
 			Sample s = join.getObject();
 
+			//get the metadata for that sample
 			Set<MetadataEntry> metadataForSample = sampleService.getMetadataForSample(s);
 
+			//build the response
 			SampleMetadataResponse response = buildSampleMetadataResponse(s, metadataForSample);
-
 			resources.add(response);
 		}
 
+		//add a link back to this collection
 		resources.add(
 				linkTo(methodOn(RESTSampleMetadataController.class).getProjectSampleMetadata(projectId)).withSelfRel());
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -4,6 +4,7 @@ import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,6 +26,7 @@ import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
+import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResourceCollection;
 import ca.corefacility.bioinformatics.irida.web.controller.api.RESTGenericController;
 import ca.corefacility.bioinformatics.irida.web.controller.api.projects.RESTProjectSamplesController;
 
@@ -66,6 +68,36 @@ public class RESTSampleMetadataController {
 		SampleMetadataResponse response = buildSampleMetadataResponse(s, metadataForSample);
 
 		modelMap.addAttribute(RESTGenericController.RESOURCE_NAME, response);
+		return modelMap;
+	}
+
+	/**
+	 * Get multiple sample metadata collections
+	 * @param sampleIds the ids of the samples to get metadata for
+	 * @return A collection of sample metadata for the given IDs
+	 */
+	@RequestMapping(value = "/api/samples/metadata", method = RequestMethod.POST, consumes = "application/idcollection+json")
+	public ModelMap getMultipleSampleMetadata(final @RequestBody List<Long> sampleIds) {
+		ModelMap modelMap = new ModelMap();
+
+		ResourceCollection<SampleMetadataResponse> resources = new ResourceCollection<>();
+
+		Iterable<Sample> samples = sampleService.readMultiple(sampleIds);
+
+		for (Sample s : samples) {
+
+			Set<MetadataEntry> metadataForSample = sampleService.getMetadataForSample(s);
+
+			SampleMetadataResponse response = buildSampleMetadataResponse(s, metadataForSample);
+
+			resources.add(response);
+		}
+
+		resources.add(
+				linkTo(methodOn(RESTSampleMetadataController.class).getMultipleSampleMetadata(null)).withSelfRel());
+
+		modelMap.addAttribute(RESTGenericController.RESOURCE_NAME, resources);
+
 		return modelMap;
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -38,6 +38,8 @@ public class RESTSampleMetadataController {
 	private static final Logger logger = LoggerFactory.getLogger(RESTSampleMetadataController.class);
 
 	public static final String METADATA_REL = "sample/metadata";
+	public static final String ALL_METADATA_REL = "samples/metadata";
+
 	public static final String SAMPLE_REL = "sample";
 
 	private SampleService sampleService;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -27,6 +27,7 @@ import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResourceCollection;
+import ca.corefacility.bioinformatics.irida.web.assembler.resource.sample.SampleMetadataResponse;
 import ca.corefacility.bioinformatics.irida.web.controller.api.RESTGenericController;
 import ca.corefacility.bioinformatics.irida.web.controller.api.projects.RESTProjectSamplesController;
 
@@ -52,9 +53,8 @@ public class RESTSampleMetadataController {
 
 	/**
 	 * Get the metadata for a given {@link Sample}
-	 * 
-	 * @param sampleId
-	 *            the id of the {@link Sample} to get metadata for
+	 *
+	 * @param sampleId the id of the {@link Sample} to get metadata for
 	 * @return the metadata for the sample
 	 */
 	@RequestMapping(value = "/api/samples/{sampleId}/metadata", method = RequestMethod.GET)
@@ -73,6 +73,7 @@ public class RESTSampleMetadataController {
 
 	/**
 	 * Get multiple sample metadata collections
+	 *
 	 * @param sampleIds the ids of the samples to get metadata for
 	 * @return A collection of sample metadata for the given IDs
 	 */
@@ -104,11 +105,9 @@ public class RESTSampleMetadataController {
 	/**
 	 * Save new metadata for a {@link Sample}. Note this will overwrite the
 	 * existing metadata
-	 * 
-	 * @param sampleId
-	 *            the id of the {@link Sample} to save new metadata
-	 * @param metadataMap
-	 *            the metadata to save to the {@link Sample}
+	 *
+	 * @param sampleId    the id of the {@link Sample} to save new metadata
+	 * @param metadataMap the metadata to save to the {@link Sample}
 	 * @return the updated {@link Sample}
 	 */
 	@RequestMapping(value = "/api/samples/{sampleId}/metadata", method = RequestMethod.POST)
@@ -118,7 +117,7 @@ public class RESTSampleMetadataController {
 
 		Set<MetadataEntry> metadata = metadataTemplateService.convertMetadataStringsToSet(metadataMap);
 
-		sampleService.updateSampleMetadata(s,metadata);
+		sampleService.updateSampleMetadata(s, metadata);
 
 		return getSampleMetadata(sampleId);
 	}
@@ -126,11 +125,9 @@ public class RESTSampleMetadataController {
 	/**
 	 * Add select new metadata fields to the {@link Sample}. Note this will only
 	 * overwrite duplicate terms. Existing metadata will not be affected.
-	 * 
-	 * @param sampleId
-	 *            the {@link Sample} to add metadata to
-	 * @param metadataMap
-	 *            the new metadata
+	 *
+	 * @param sampleId    the {@link Sample} to add metadata to
+	 * @param metadataMap the new metadata
 	 * @return the updated {@link Sample}
 	 */
 	@RequestMapping(value = "/api/samples/{sampleId}/metadata", method = RequestMethod.PUT)
@@ -139,7 +136,7 @@ public class RESTSampleMetadataController {
 		Sample s = sampleService.read(sampleId);
 
 		Set<MetadataEntry> metadata = metadataTemplateService.convertMetadataStringsToSet(metadataMap);
-		
+
 		sampleService.mergeSampleMetadata(s, metadata);
 
 		return getSampleMetadata(sampleId);
@@ -147,9 +144,8 @@ public class RESTSampleMetadataController {
 
 	/**
 	 * Build a {@link SampleMetadataResponse} object
-	 * 
-	 * @param s
-	 *            the {@link Sample} to build the object from
+	 *
+	 * @param s the {@link Sample} to build the object from
 	 * @return a constructed {@link SampleMetadataResponse}
 	 */
 	private SampleMetadataResponse buildSampleMetadataResponse(final Sample s, Set<MetadataEntry> metadataEntries) {
@@ -157,34 +153,5 @@ public class RESTSampleMetadataController {
 		response.add(linkTo(methodOn(RESTSampleMetadataController.class).getSampleMetadata(s.getId())).withSelfRel());
 		response.add(linkTo(methodOn(RESTProjectSamplesController.class).getSample(s.getId())).withRel(SAMPLE_REL));
 		return response;
-	}
-
-	/**
-	 * Response class so we can add links to sample metadata
-	 */
-	private class SampleMetadataResponse extends IridaResourceSupport {
-		Map<MetadataTemplateField, MetadataEntry> metadata;
-
-		@Deprecated
-		public SampleMetadataResponse(Map<MetadataTemplateField, MetadataEntry> metadata) {
-			this.metadata = metadata;
-		}
-
-		public SampleMetadataResponse(Set<MetadataEntry> metadataEntrySet) {
-			metadata = new HashMap<>();
-			for (MetadataEntry entry : metadataEntrySet) {
-				metadata.put(entry.getField(), entry);
-			}
-		}
-
-		@JsonProperty
-		public Map<MetadataTemplateField, MetadataEntry> getMetadata() {
-			return metadata;
-		}
-
-		@JsonProperty
-		public void setMetadata(Map<MetadataTemplateField, MetadataEntry> metadata) {
-			this.metadata = metadata;
-		}
 	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
@@ -1,0 +1,61 @@
+package ca.corefacility.bioinformatics.irida.web.controller.test.integration.sample;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import ca.corefacility.bioinformatics.irida.config.data.IridaApiJdbcDataSourceConfig;
+import ca.corefacility.bioinformatics.irida.config.services.IridaApiPropertyPlaceholderConfig;
+
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
+
+import static ca.corefacility.bioinformatics.irida.web.controller.test.integration.util.ITestAuthUtils.asUser;
+import static com.jayway.restassured.path.json.JsonPath.from;
+import static org.hamcrest.Matchers.hasItem;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = { IridaApiJdbcDataSourceConfig.class,
+		IridaApiPropertyPlaceholderConfig.class })
+@TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
+@ActiveProfiles("it")
+@DatabaseSetup("/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.xml")
+//@DatabaseTearDown("classpath:/ca/corefacility/bioinformatics/irida/test/integration/TableReset.xml")
+public class RESTSampleMetadataControllerIT {
+
+	@Test
+	public void testGetMetadataForProject() {
+		Long projectId = 5L;
+
+		final String projectUri = "/api/projects/" + projectId;
+		final String projectJson = asUser().expect()
+				.statusCode(HttpStatus.OK.value())
+				.get(projectUri)
+				.asString();
+
+		final String samplesUri = from(projectJson).get("resource.links.find{it.rel == 'project/samples'}.href");
+
+		String samplesJson = asUser().get(samplesUri)
+				.asString();
+
+		final String metadataUri = from(samplesJson).get("resource.links.find{it.rel == 'samples/metadata'}.href");
+
+		asUser().expect()
+				.statusCode(HttpStatus.OK.value())
+				.and()
+				.body("resource.resources.metadata", hasItem("field1"))
+				.and()
+				.body("resource.resources.metadata", hasItem("field2"))
+				.when()
+				.get(metadataUri)
+				.asString();
+
+	}
+}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
@@ -20,6 +20,7 @@ import com.github.springtestdbunit.annotation.DatabaseTearDown;
 import static ca.corefacility.bioinformatics.irida.web.controller.test.integration.util.ITestAuthUtils.asUser;
 import static com.jayway.restassured.path.json.JsonPath.from;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = { IridaApiJdbcDataSourceConfig.class,
@@ -50,9 +51,11 @@ public class RESTSampleMetadataControllerIT {
 		asUser().expect()
 				.statusCode(HttpStatus.OK.value())
 				.and()
-				.body("resource.resources.metadata", hasKey("field1"))
+				.body("resource.resources.metadata", hasSize(2))
 				.and()
-				.body("resource.resources.metadata", hasKey("field2"))
+				.body("resource.resources.metadata[0]", hasKey("field1"))
+				.and()
+				.body("resource.resources.metadata[0]", hasKey("field2"))
 				.when()
 				.get(metadataUri)
 				.asString();

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
@@ -15,11 +15,10 @@ import ca.corefacility.bioinformatics.irida.config.services.IridaApiPropertyPlac
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
-import com.github.springtestdbunit.annotation.DatabaseTearDown;
 
 import static ca.corefacility.bioinformatics.irida.web.controller.test.integration.util.ITestAuthUtils.asUser;
 import static com.jayway.restassured.path.json.JsonPath.from;
-import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class, classes = { IridaApiJdbcDataSourceConfig.class,
@@ -27,7 +26,7 @@ import static org.hamcrest.Matchers.hasItem;
 @TestExecutionListeners({ DependencyInjectionTestExecutionListener.class, DbUnitTestExecutionListener.class })
 @ActiveProfiles("it")
 @DatabaseSetup("/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.xml")
-//@DatabaseTearDown("classpath:/ca/corefacility/bioinformatics/irida/test/integration/TableReset.xml")
+@DatabaseTearDown("classpath:/ca/corefacility/bioinformatics/irida/test/integration/TableReset.xml")
 public class RESTSampleMetadataControllerIT {
 
 	@Test
@@ -50,9 +49,9 @@ public class RESTSampleMetadataControllerIT {
 		asUser().expect()
 				.statusCode(HttpStatus.OK.value())
 				.and()
-				.body("resource.resources.metadata", hasItem("field1"))
+				.body("resource.resources.metadata", hasKey("field1"))
 				.and()
-				.body("resource.resources.metadata", hasItem("field2"))
+				.body("resource.resources.metadata", hasKey("field2"))
 				.when()
 				.get(metadataUri)
 				.asString();

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.java
@@ -15,6 +15,7 @@ import ca.corefacility.bioinformatics.irida.config.services.IridaApiPropertyPlac
 
 import com.github.springtestdbunit.DbUnitTestExecutionListener;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
+import com.github.springtestdbunit.annotation.DatabaseTearDown;
 
 import static ca.corefacility.bioinformatics.irida.web.controller.test.integration.util.ITestAuthUtils.asUser;
 import static com.jayway.restassured.path.json.JsonPath.from;

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
@@ -142,7 +142,7 @@ public class RESTProjectSamplesControllerTest {
 		@SuppressWarnings("unchecked") ResourceCollection<Sample> samples = (ResourceCollection<Sample>) o;
 		assertEquals(1, samples.size());
 		List<Link> resourceLinks = samples.getLinks();
-		assertEquals(1, resourceLinks.size());
+		assertEquals(2, resourceLinks.size());
 		Link self = resourceLinks.iterator()
 				.next();
 		assertEquals("self", self.getRel());

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
@@ -1,6 +1,5 @@
 package ca.corefacility.bioinformatics.irida.web.controller.test.unit.samples;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Before;
@@ -45,7 +44,7 @@ public class RESTSampleMetadataControllerTest {
 	}
 
 	@Test
-	public void testReadMultipleMetadata() {
+	public void testReadProjectSampleMetadata() {
 		Sample s1 = new Sample("s1");
 		s1.setId(1L);
 		Sample s2 = new Sample("s2");
@@ -65,7 +64,7 @@ public class RESTSampleMetadataControllerTest {
 		when(sampleService.getMetadataForSample(s1)).thenReturn(Sets.newHashSet(entry1));
 		when(sampleService.getMetadataForSample(s2)).thenReturn(Sets.newHashSet(entry2));
 
-		ModelMap modelMap = metadataController.getProjectMetadata(p1.getId());
+		ModelMap modelMap = metadataController.getProjectSampleMetadata(p1.getId());
 
 		ResourceCollection<SampleMetadataResponse> responses = (ResourceCollection) modelMap.get(
 				RESTGenericController.RESOURCE_NAME);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.ui.ModelMap;
 import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
+import ca.corefacility.bioinformatics.irida.service.ProjectService;
 import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResourceCollection;
@@ -28,13 +29,15 @@ public class RESTSampleMetadataControllerTest {
 	private RESTSampleMetadataController metadataController;
 	private SampleService sampleService;
 	private MetadataTemplateService metadataTemplateService;
+	private ProjectService projectService;
 
 	@Before
 	public void setUp() {
 		sampleService = mock(SampleService.class);
 		metadataTemplateService = mock(MetadataTemplateService.class);
 
-		metadataController = new RESTSampleMetadataController(sampleService, metadataTemplateService);
+
+		metadataController = new RESTSampleMetadataController(sampleService, metadataTemplateService, projectService);
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
@@ -1,0 +1,76 @@
+package ca.corefacility.bioinformatics.irida.web.controller.test.unit.samples;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.ui.ModelMap;
+
+import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
+import ca.corefacility.bioinformatics.irida.model.sample.Sample;
+import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
+import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
+import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
+import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResourceCollection;
+import ca.corefacility.bioinformatics.irida.web.assembler.resource.sample.SampleMetadataResponse;
+import ca.corefacility.bioinformatics.irida.web.controller.api.RESTGenericController;
+import ca.corefacility.bioinformatics.irida.web.controller.api.samples.RESTSampleMetadataController;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class RESTSampleMetadataControllerTest {
+
+	private RESTSampleMetadataController metadataController;
+	private SampleService sampleService;
+	private MetadataTemplateService metadataTemplateService;
+
+	@Before
+	public void setUp() {
+		sampleService = mock(SampleService.class);
+		metadataTemplateService = mock(MetadataTemplateService.class);
+
+		metadataController = new RESTSampleMetadataController(sampleService, metadataTemplateService);
+	}
+
+	@Test
+	public void testReadMultipleMetadata() {
+		Sample s1 = new Sample("s1");
+		s1.setId(1L);
+		Sample s2 = new Sample("s2");
+		s2.setId(2L);
+
+		MetadataTemplateField f1 = new MetadataTemplateField("f1", "text");
+		MetadataEntry entry1 = new MetadataEntry("val1", "text", f1);
+		MetadataEntry entry2 = new MetadataEntry("val1", "text", f1);
+
+		ArrayList<Long> ids = Lists.newArrayList(s1.getId(), s2.getId());
+
+		when(sampleService.readMultiple(ids)).thenReturn(Lists.newArrayList(s1, s2));
+		when(sampleService.getMetadataForSample(s1)).thenReturn(Sets.newHashSet(entry1));
+		when(sampleService.getMetadataForSample(s2)).thenReturn(Sets.newHashSet(entry2));
+
+		ModelMap modelMap = metadataController.getMultipleSampleMetadata(ids);
+
+		ResourceCollection<SampleMetadataResponse> responses = (ResourceCollection) modelMap.get(
+				RESTGenericController.RESOURCE_NAME);
+
+		assertEquals(2, responses.size());
+		for (SampleMetadataResponse response : responses) {
+			assertEquals(1, response.getMetadata()
+					.size());
+			assertTrue(response.getMetadata()
+					.keySet()
+					.contains(f1));
+		}
+
+		verify(sampleService).readMultiple(ids);
+		verify(sampleService).getMetadataForSample(s1);
+		verify(sampleService).getMetadataForSample(s2);
+	}
+
+}

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/web/controller/test/integration/sample/RESTSampleMetadataControllerIT.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+    <user id="1" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0"
+          email="manager@nowhere.com" firstName="Mr." lastName="Manager"
+          password="$2a$10$yvzFLxWA9m2wNQmHpJtWT.MRZv8qV8Mo3EMB6HTkDnUbi9aBrbWWW"
+          phoneNumber="867-5309" username="manager" enabled="true" system_role="ROLE_MANAGER"
+          credentialsNonExpired="true"/>
+    <user id="2" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0"
+          email="admin@nowhere.com" firstName="Admin" lastName="Admin"
+          password="$2a$10$yvzFLxWA9m2wNQmHpJtWT.MRZv8qV8Mo3EMB6HTkDnUbi9aBrbWWW"
+          phoneNumber="0000" username="admin" enabled="true" system_role="ROLE_ADMIN"
+          credentialsNonExpired="true"/>
+    <user id="3" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0"
+          email="user@nowhere.com" firstName="User" lastName="User"
+          password="$2a$10$yvzFLxWA9m2wNQmHpJtWT.MRZv8qV8Mo3EMB6HTkDnUbi9aBrbWWW"
+          phoneNumber="0000" username="fbristow" enabled="true" system_role="ROLE_USER"
+          credentialsNonExpired="true"/>
+
+    <project id="5" createdDate="2013-07-18 14:22:19.0" name="project22"/>
+
+    <sample id="1" sampleName="sample" createdDate="2013-07-18 14:20:19.0"/>
+    <sample id="2" sampleName="sample2" createdDate="2013-07-18 14:20:19.0"/>
+
+    <project_sample id="1" project_id="5" sample_id="1"
+                    createdDate="2013-07-18 14:20:19.0" owner="true"/>
+    <project_sample id="2" project_id="5" sample_id="2"
+                    createdDate="2013-07-18 14:20:19.0" owner="true"/>
+
+    <project_user id="1" project_id="5" user_id="3"
+                  projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0"
+                  email_subscription="false"/>
+
+    <metadata_field id="1" label="field1" type="text" DTYPE="MetadataTemplateField"/>
+    <metadata_field id="2" label="field2" type="text" DTYPE="MetadataTemplateField"/>
+
+    <metadata_entry id="1" value="data1" type="text" field_id="1" sample_id="1"/>
+    <metadata_entry id="2" value="data2" type="text" field_id="2" sample_id="1"/>
+
+    <metadata_entry id="3" value="data3" type="text" field_id="1" sample_id="2"/>
+    <metadata_entry id="4" value="data4" type="text" field_id="2" sample_id="2"/>
+
+    <client_details id="1" clientId="testClient"
+                    clientSecret="testClientSecret" token_validity="43200" createdDate="2013-07-18 14:20:19.0" />
+    <client_role name="ROLE_CLIENT" description="A basic OAuth2 client." />
+    <client_details_authorities
+            client_details_id="1" authority_name="ROLE_CLIENT" />
+    <client_details_scope client_details_id="1" scope="read" />
+    <client_details_scope client_details_id="1" scope="write" />
+    <client_details_grant_types
+            client_details_id="1" grant_value="password" />
+    <client_details_resource_ids
+            client_details_id="1" resource_id="NmlIrida" />
+</dataset>


### PR DESCRIPTION
## Description of changes
Added a REST endpoint to request a full project's sample metadata at the same time.  This should help with performance issues when reading large amounts of metadata at the same time.  This endpoint may be slow for large projects, but if you need to read a full project anyway should be faster than requesting for each individual sample.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
