### PR TITLE
Fix reference file upload

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectReferenceFileService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectReferenceFileService.java
@@ -65,15 +65,16 @@ public class UIProjectReferenceFileService {
 				Path target = temp.resolve(file.getOriginalFilename());
 				file.transferTo(target.toFile());
 
-				ReferenceFile referenceFile = referenceFileService.create(new ReferenceFile(target));
 				if (projectId != null) {
 					logger.debug("Adding reference file to project " + projectId);
+					ReferenceFile referenceFile = new ReferenceFile(target);
 					Project project = projectService.read(projectId);
 					Join<Project, ReferenceFile> join = projectService.addReferenceFileToProject(project, referenceFile);
 					ReferenceFile refFile = join.getObject();
 					long filesize = Files.size(refFile.getFile());
 					referenceFiles.add(new UIReferenceFile(join, FileUtilities.humanReadableByteCount(filesize, true)));
 				} else {
+					ReferenceFile referenceFile = referenceFileService.create(new ReferenceFile(target));
 					referenceFiles.add(new UIReferenceFile(referenceFile));
 				}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectReferenceFileService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectReferenceFileService.java
@@ -65,16 +65,25 @@ public class UIProjectReferenceFileService {
 				Path target = temp.resolve(file.getOriginalFilename());
 				file.transferTo(target.toFile());
 
+				ReferenceFile referenceFile;
+
 				if (projectId != null) {
 					logger.debug("Adding reference file to project " + projectId);
-					ReferenceFile referenceFile = new ReferenceFile(target);
+					/*
+					Just create the reference file object but don't save to the reference file
+					repository here as the ProjectService -> addReferenceFileToProject takes care of that
+					 */
+					referenceFile = new ReferenceFile(target);
 					Project project = projectService.read(projectId);
 					Join<Project, ReferenceFile> join = projectService.addReferenceFileToProject(project, referenceFile);
 					ReferenceFile refFile = join.getObject();
 					long filesize = Files.size(refFile.getFile());
 					referenceFiles.add(new UIReferenceFile(join, FileUtilities.humanReadableByteCount(filesize, true)));
 				} else {
-					ReferenceFile referenceFile = referenceFileService.create(new ReferenceFile(target));
+					/*
+					Creates the reference file and saves it to the reference file repository
+					 */
+					referenceFile = referenceFileService.create(new ReferenceFile(target));
 					referenceFiles.add(new UIReferenceFile(referenceFile));
 				}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/ProjectServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/ProjectServiceImplTest.java
@@ -5,10 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -28,7 +25,6 @@ import org.junit.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -414,7 +410,7 @@ public class ProjectServiceImplTest {
 
 		projectService.addReferenceFileToProject(p, f);
 
-		verify(referenceFileRepository).save(f);
+		verify(referenceFileRepository, times(1)).save(f);
 		verify(prfjRepository).save(new ProjectReferenceFileJoin(p, f));
 	}
 


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed issue of the referenceFile being saved twice to the referenceFileRepository when adding a reference file to a project.

**To test run either the dev or production profile of IRIDA in Intellij in debug mode:**
1) Set breakpoint on either line 38 or 39 in the `countSequenceFileLengthInBases` method within `BioJavaSequenceFileUtilitiesImpl`.
2) Upload a reference file within a project
3) Stepping through the debugger should only have you land on the breakpoint above 1 time with the file that is created in the /tmp directory

**To test out the double saving to the referenceFileRepository try the above on the `development` branch. Here you will have that breakpoint hit twice (once with the file in the /tmp directory and once with the file in the /opt/irida/data/ directory**

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* [X] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
