### PR TITLE
Hotfix: Throw link error when fast5 not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changes
 * [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)
 * [REST]: Added `ownership` option when copying sample to project in REST API (21.01.2)
 * [Database]: Removed `sample_metadata_entry` table which should have been dropped in 21.01 release. (21.01.3)
+* [REST]: Added handling for synchronizing data from older IRIDA instances.  It was failing for APIs without fast5 functionality (21.01.4)
 
 20.09 to 21.01
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.01.3</version>
+	<version>21.01.4</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/impl/Fast5ObjectRemoteServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/impl/Fast5ObjectRemoteServiceImpl.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Service;
 
+import ca.corefacility.bioinformatics.irida.exceptions.LinkNotFoundException;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sequenceFile.Fast5Object;
@@ -39,6 +40,9 @@ public class Fast5ObjectRemoteServiceImpl extends SequencingObjectRemoteServiceI
 	 */
 	@Override
 	public List<Fast5Object> getFast5FilesForSample(Sample sample) {
+		if (!sample.hasLink(REL_SAMPLE_SEQUENCE_FILE_FAST5)) {
+			throw new LinkNotFoundException("No link for rel: " + REL_SAMPLE_SEQUENCE_FILE_FAST5);
+		}
 		Link link = sample.getLink(REL_SAMPLE_SEQUENCE_FILE_FAST5);
 		String href = link.getHref();
 

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -100,7 +100,7 @@
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-import": "^1.13.1",
-    "chromedriver": "88.0.0",
+    "chromedriver": "90.0.0",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.5.3",
     "cssnano": "^4.1.10",

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/ProjectSynchronizationServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/ProjectSynchronizationServiceTest.java
@@ -264,6 +264,24 @@ public class ProjectSynchronizationServiceTest {
 	}
 
 	@Test
+	public void testSyncSampleNoFast5() {
+		Sample sample = new Sample();
+		RemoteStatus sampleStatus = new RemoteStatus("http://sample", api);
+		sample.setRemoteStatus(sampleStatus);
+
+		when(sampleService.create(sample)).thenReturn(sample);
+		when(sampleService.updateSampleMetadata(eq(sample), any(Set.class))).thenReturn(sample);
+		when(fast5ObjectRemoteService.getFast5FilesForSample(sample)).thenThrow(new LinkNotFoundException("no link"));
+
+		syncService.syncSample(sample, expired, Maps.newHashMap());
+
+		verify(projectService).addSampleToProject(expired, sample, true);
+		verify(assemblyRemoteService, times(0)).mirrorAssembly(any(UploadedAssembly.class));
+
+		assertEquals(SyncStatus.SYNCHRONIZED, sample.getRemoteStatus().getSyncStatus());
+	}
+
+	@Test
 	public void testSyncAssemblies() {
 		Sample sample = new Sample();
 


### PR DESCRIPTION
## Description of changes
Added an error thrown from the fast5 remote repository when the link for fast5 data isn't available.  This would happen if syncing with an older version of IRIDA.

Note this is a hotfix PR and should also be merged to `development`.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
