### PR TITLE
Single query metadata

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepository.java
@@ -10,7 +10,7 @@ import java.util.Set;
 /**
  * Repository for saving and reading {@link MetadataEntry}
  */
-public interface MetadataEntryRepository extends IridaJpaRepository<MetadataEntry, Long> {
+public interface MetadataEntryRepository extends IridaJpaRepository<MetadataEntry, Long>, MetadataEntryRepositoryCustom {
 
 	/**
 	 * Get all the {@link MetadataEntry} attached to the given {@link Sample}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryCustom.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryCustom.java
@@ -1,0 +1,13 @@
+package ca.corefacility.bioinformatics.irida.repositories.sample;
+
+import java.util.Map;
+import java.util.Set;
+
+import ca.corefacility.bioinformatics.irida.model.project.Project;
+import ca.corefacility.bioinformatics.irida.model.sample.Sample;
+import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
+
+public interface MetadataEntryRepositoryCustom {
+
+	Map<Sample, Set<MetadataEntry>> getMetadataForProject(Project project);
+}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryCustom.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryCustom.java
@@ -9,5 +9,5 @@ import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 
 public interface MetadataEntryRepositoryCustom {
 
-	Map<Sample, Set<MetadataEntry>> getMetadataForProject(Project project);
+	Map<Long, Set<MetadataEntry>> getMetadataForProject(Project project);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryCustom.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryCustom.java
@@ -7,7 +7,16 @@ import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 
+/**
+ * Custom repository methods for retrieving {@link MetadataEntry}s
+ */
 public interface MetadataEntryRepositoryCustom {
 
+	/**
+	 * Get all the {@link MetadataEntry} for a given project.  This will return a Map of the Sample IDs associated with a Set of {@link MetadataEntry}
+	 *
+	 * @param project the {@link Project} to get metadata for
+	 * @return The Map of the Project's metadata
+	 */
 	Map<Long, Set<MetadataEntry>> getMetadataForProject(Project project);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
@@ -80,16 +80,18 @@ public class LineListController {
 
 		final Map<Long, Set<MetadataEntry>> metadataForProject = sampleService.getMetadataForProject(project);
 
-		List<Join<Project, Sample>> projectSamples = sampleService.getSamplesForProject(project);
+		//List<Join<Project, Sample>> projectSamples = sampleService.getSamplesForProject(project);
+
+		List<Sample> projectSamples = sampleService.getSamplesForProjectShallow(project);
 		return projectSamples.stream()
-				.map(join -> {
-					ProjectSampleJoin psj = (ProjectSampleJoin) join;
-					Set<MetadataEntry> metadata = metadataForProject.get(psj.getObject().getId());
+				.map(sample -> {
+					//ProjectSampleJoin psj = (ProjectSampleJoin) sample;
+					Set<MetadataEntry> metadata = metadataForProject.get(sample.getId());
 					if(metadata==null){
 						metadata = new HashSet<>();
 					}
-					return new UISampleMetadata(psj, updateSamplePermission.isAllowed(authentication, psj.getObject()),
-							metadata);
+					return new UISampleMetadata(project, sample,
+							updateSamplePermission.isAllowed(authentication, sample), metadata);
 				})
 				.collect(Collectors.toList());
 	}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
@@ -80,12 +80,9 @@ public class LineListController {
 
 		final Map<Long, Set<MetadataEntry>> metadataForProject = sampleService.getMetadataForProject(project);
 
-		//List<Join<Project, Sample>> projectSamples = sampleService.getSamplesForProject(project);
-
 		List<Sample> projectSamples = sampleService.getSamplesForProjectShallow(project);
 		return projectSamples.stream()
 				.map(sample -> {
-					//ProjectSampleJoin psj = (ProjectSampleJoin) sample;
 					Set<MetadataEntry> metadata = metadataForProject.get(sample.getId());
 					if(metadata==null){
 						metadata = new HashSet<>();

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
@@ -78,14 +78,18 @@ public class LineListController {
 				.getAuthentication();
 		Project project = projectService.read(projectId);
 
-		final Map<Sample, Set<MetadataEntry>> metadataForProject = sampleService.getMetadataForProject(project);
+		final Map<Long, Set<MetadataEntry>> metadataForProject = sampleService.getMetadataForProject(project);
 
 		List<Join<Project, Sample>> projectSamples = sampleService.getSamplesForProject(project);
 		return projectSamples.stream()
 				.map(join -> {
-					ProjectSampleJoin psj = (ProjectSampleJoin)join;
-					Set<MetadataEntry> metadata = metadataForProject.get(psj.getObject());
-					return new UISampleMetadata(psj, updateSamplePermission.isAllowed(authentication, psj.getObject()), metadata);
+					ProjectSampleJoin psj = (ProjectSampleJoin) join;
+					Set<MetadataEntry> metadata = metadataForProject.get(psj.getObject().getId());
+					if(metadata==null){
+						metadata = new HashSet<>();
+					}
+					return new UISampleMetadata(psj, updateSamplePermission.isAllowed(authentication, psj.getObject()),
+							metadata);
 				})
 				.collect(Collectors.toList());
 	}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/LineListController.java
@@ -78,11 +78,13 @@ public class LineListController {
 				.getAuthentication();
 		Project project = projectService.read(projectId);
 
+		final Map<Sample, Set<MetadataEntry>> metadataForProject = sampleService.getMetadataForProject(project);
+
 		List<Join<Project, Sample>> projectSamples = sampleService.getSamplesForProject(project);
 		return projectSamples.stream()
 				.map(join -> {
 					ProjectSampleJoin psj = (ProjectSampleJoin)join;
-					Set<MetadataEntry> metadata = sampleService.getMetadataForSample(psj.getObject());
+					Set<MetadataEntry> metadata = metadataForProject.get(psj.getObject());
 					return new UISampleMetadata(psj, updateSamplePermission.isAllowed(authentication, psj.getObject()), metadata);
 				})
 				.collect(Collectors.toList());

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/dto/UISampleMetadata.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/dto/UISampleMetadata.java
@@ -41,6 +41,21 @@ public class UISampleMetadata extends HashMap<String, String> {
 		this.put(OWNER, String.valueOf(join.isOwner()));
 	}
 
+	public UISampleMetadata(Project project, Sample sample, boolean canModifySample, Set<MetadataEntry> metadata) {
+
+		this.put(SAMPLE_ID, String.valueOf(sample.getId()));
+		this.put(SAMPLE_NAME, sample.getLabel());
+		this.put(PROJECT_ID, String.valueOf(project.getId()));
+		this.put(PROJECT_NAME, project.getLabel());
+		this.put(CREATED_DATE, sample.getCreatedDate()
+				.toString());
+		this.put(MODIFIED_DATE, sample.getModifiedDate()
+				.toString());
+		this.putAll(getAllMetadataForSample(metadata));
+		this.put(EDITABLE, String.valueOf(canModifySample));
+		this.put(OWNER, String.valueOf(true));
+	}
+
 	/**
 	 * Convert the sample metadata into a format that can be consumed by Ag Grid.
 	 *

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/dto/UISampleMetadata.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/linelist/dto/UISampleMetadata.java
@@ -24,6 +24,7 @@ public class UISampleMetadata extends HashMap<String, String> {
 	public static final String EDITABLE = "editable";
 	public static final String OWNER = "owner";
 
+	@Deprecated
 	public UISampleMetadata(ProjectSampleJoin join, boolean canModifySample, Set<MetadataEntry> metadata) {
 		Project project = join.getSubject();
 		Sample sample = join.getObject();
@@ -53,13 +54,15 @@ public class UISampleMetadata extends HashMap<String, String> {
 				.toString());
 		this.putAll(getAllMetadataForSample(metadata));
 		this.put(EDITABLE, String.valueOf(canModifySample));
+
+		//TODO: Remove this and use the canModifySample for access
 		this.put(OWNER, String.valueOf(true));
 	}
 
 	/**
 	 * Convert the sample metadata into a format that can be consumed by Ag Grid.
 	 *
-	 * @param sample {@link Sample}
+	 * @param metadataEntries the Metadata entries
 	 * @return {@link Map} of {@link String} field and {@link String} value
 	 */
 	private Map<String, String> getAllMetadataForSample(Set<MetadataEntry> metadataEntries) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/sample/SampleServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/sample/SampleServiceImpl.java
@@ -197,8 +197,12 @@ public class SampleServiceImpl extends CRUDServiceImpl<Long, Sample> implements 
 		return metadataEntryRepository.getMetadataForSample(sample);
 	}
 
-	@PreAuthorize("permitAll()")
-	public Map<Sample, Set<MetadataEntry>> getMetadataForProject(Project project){
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	@PreAuthorize("hasPermission(#project, 'canReadProject')")
+	public Map<Long, Set<MetadataEntry>> getMetadataForProject(Project project) {
 		return metadataEntryRepository.getMetadataForProject(project);
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/sample/SampleServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/sample/SampleServiceImpl.java
@@ -197,6 +197,11 @@ public class SampleServiceImpl extends CRUDServiceImpl<Long, Sample> implements 
 		return metadataEntryRepository.getMetadataForSample(sample);
 	}
 
+	@PreAuthorize("permitAll()")
+	public Map<Sample, Set<MetadataEntry>> getMetadataForProject(Project project){
+		return metadataEntryRepository.getMetadataForProject(project);
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/SampleService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/SampleService.java
@@ -1,9 +1,6 @@
 package ca.corefacility.bioinformatics.irida.service.sample;
 
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
 import org.springframework.data.domain.Page;
@@ -76,6 +73,8 @@ public interface SampleService extends CRUDService<Long, Sample> {
 	 * @return the metadata associated with the given sample
 	 */
 	public Set<MetadataEntry> getMetadataForSample(Sample sample);
+
+	public Map<Sample, Set<MetadataEntry>> getMetadataForProject(Project project);
 	
 	/**
 	 * Find a {@link Sample} assocaited with a {@link SequencingObject}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/SampleService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/SampleService.java
@@ -74,7 +74,7 @@ public interface SampleService extends CRUDService<Long, Sample> {
 	 */
 	public Set<MetadataEntry> getMetadataForSample(Sample sample);
 
-	public Map<Sample, Set<MetadataEntry>> getMetadataForProject(Project project);
+	public Map<Long, Set<MetadataEntry>> getMetadataForProject(Project project);
 	
 	/**
 	 * Find a {@link Sample} assocaited with a {@link SequencingObject}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/SampleService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/SampleService.java
@@ -74,6 +74,12 @@ public interface SampleService extends CRUDService<Long, Sample> {
 	 */
 	public Set<MetadataEntry> getMetadataForSample(Sample sample);
 
+	/**
+	 * Get the metadata collections for an entire project.  This will return a Map of {@link Sample} ID with a Set of the {@link MetadataEntry}s
+	 *
+	 * @param project the {@link Project} to get metadata for
+	 * @return a map of metadata
+	 */
 	public Map<Long, Set<MetadataEntry>> getMetadataForProject(Project project);
 	
 	/**

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -1,5 +1,6 @@
 package ca.corefacility.bioinformatics.irida.web.controller.api.samples;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -91,14 +92,19 @@ public class RESTSampleMetadataController {
 
 		//get the project and samples for the project
 		Project project = projectService.read(projectId);
-		List<Join<Project, Sample>> samples = sampleService.getSamplesForProject(project);
+
+		List<Sample> samples = sampleService.getSamplesForProjectShallow(project);
+		Map<Long, Set<MetadataEntry>> metadataForProject = sampleService.getMetadataForProject(project);
 
 		//for each sample
-		for (Join<Project, Sample> join : samples) {
-			Sample s = join.getObject();
-
+		for (Sample s : samples) {
 			//get the metadata for that sample
-			Set<MetadataEntry> metadataForSample = sampleService.getMetadataForSample(s);
+			Set<MetadataEntry> metadataForSample = metadataForProject.get(s.getId());
+
+			//if we dont' have any metadata, return an empty collection
+			if (metadataForSample == null) {
+				metadataForSample = new HashSet<>();
+			}
 
 			//build the response
 			SampleMetadataResponse response = buildSampleMetadataResponse(s, metadataForSample);


### PR DESCRIPTION
## Description of changes
Created a custom query for retrieving a full project's metadata for the line list page.  The existing methods using hibernate/JPA were performing a ton of DB queries for retrieving metadata when a project had a high (1000+) number of samples.  This change grabs the metadata in a single(ish) query.

Performance testing reduces rendering time from ~10s for projects with 5k samples to ~1/4s.

## Related issue
Related to #991 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
