### PR TITLE
Excluding unnecessary directories from war file build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes
 * [Developer]: Updated `lodash` to v4.17.21 to fix security vulnerability.
 * [UI/REST]: Improved querying performance of metadata for line list and REST API.
 * [UI]: Complete upgrade of project settings to use Ant Design.
+* [Developer]: Removing many unnecessary files from the `.war` file build to reduce build size.
 
 20.09 to 21.01
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -915,7 +915,12 @@
 				<version>${maven.war.plugin.version}</version>
 				<configuration>
 					<failOnMissingWebXml>false</failOnMissingWebXml>
-					<packagingExcludes>node_modules/**/*</packagingExcludes>
+					<packagingExcludes>
+						node_modules/,
+						.yarn/,
+						resources/css/,
+						resources/js/
+					</packagingExcludes>
 					<attachClasses>true</attachClasses>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
## Description of changes
Excluded a few directories from the war file build as they're unnecessary for deployment.  With a yarn upgrade the war file was building >400MB.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
