### PR TITLE
Fixed remote project sync for unsynchronized projects

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIRemoteAPIService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIRemoteAPIService.java
@@ -12,6 +12,7 @@ import ca.corefacility.bioinformatics.irida.exceptions.IridaOAuthException;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPIToken;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
+import ca.corefacility.bioinformatics.irida.model.project.ProjectSyncFrequency;
 import ca.corefacility.bioinformatics.irida.model.remote.RemoteStatus;
 import ca.corefacility.bioinformatics.irida.ria.web.ajax.dto.ajax.AjaxCreateItemSuccessResponse;
 import ca.corefacility.bioinformatics.irida.ria.web.ajax.dto.remote.CreateRemoteProjectRequest;
@@ -116,8 +117,14 @@ public class UIRemoteAPIService {
     public AjaxCreateItemSuccessResponse createSynchronizedProject(CreateRemoteProjectRequest request) {
         Project project = projectRemoteService.read(request.getUrl());
         project.setId(null);
-        project.getRemoteStatus()
-                .setSyncStatus(RemoteStatus.SyncStatus.MARKED);
+        if (request.getFrequency()
+                .equals(ProjectSyncFrequency.NEVER)) {
+            project.getRemoteStatus()
+                    .setSyncStatus(RemoteStatus.SyncStatus.UNSYNCHRONIZED);
+        } else {
+            project.getRemoteStatus()
+                    .setSyncStatus(RemoteStatus.SyncStatus.MARKED);
+        }
         project.setSyncFrequency(request.getFrequency());
         project = projectService.create(project);
         return new AjaxCreateItemSuccessResponse(project.getId());

--- a/src/main/webapp/resources/js/pages/projects/settings/components/ProjectSynchronizationSettings.jsx
+++ b/src/main/webapp/resources/js/pages/projects/settings/components/ProjectSynchronizationSettings.jsx
@@ -18,7 +18,12 @@ const { Title } = Typography;
  * @constructor
  */
 export default function ProjectSynchronizationSettings({ projectId }) {
-  const syncNowEnabledStates = ["SYNCHRONIZED", "ERROR", "UNAUTHORIZED"];
+  const syncNowEnabledStates = [
+    "ERROR",
+    "SYNCHRONIZED",
+    "UNAUTHORIZED",
+    "UNSYNCHRONIZED",
+  ];
   const [remoteProjectData, setRemoteProjectData] = useState(null);
   const [disableSyncNow, setDisableSyncNow] = useState(false);
 


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed bug where a remote project in `UNSYNCHRONIZED` state would have the Sync buttons disabled on the Project Synchronization Settings page within project settings. Updated creating of a synchronized project to set a project to `UNSYNCHRONIZED` state if a frequency of `NEVER` is selected.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
