### PR TITLE
HOTFIX: Enable sync now button on project synchronization settings page if in UNSYNCHRONIZED state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+21.05 to 21.05.1
+----------------
+* [UI]: Fixed bug where a remote project in `UNSYNCHRONIZED` state would have the Sync buttons disabled on the Project Synchronization Settings page.
+
 21.01 to 21.05
 --------------
 * [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.05</version>
+	<version>21.05.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIRemoteAPIService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIRemoteAPIService.java
@@ -12,6 +12,7 @@ import ca.corefacility.bioinformatics.irida.exceptions.IridaOAuthException;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPIToken;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
+import ca.corefacility.bioinformatics.irida.model.project.ProjectSyncFrequency;
 import ca.corefacility.bioinformatics.irida.model.remote.RemoteStatus;
 import ca.corefacility.bioinformatics.irida.ria.web.ajax.dto.ajax.AjaxCreateItemSuccessResponse;
 import ca.corefacility.bioinformatics.irida.ria.web.ajax.dto.remote.CreateRemoteProjectRequest;
@@ -116,8 +117,14 @@ public class UIRemoteAPIService {
     public AjaxCreateItemSuccessResponse createSynchronizedProject(CreateRemoteProjectRequest request) {
         Project project = projectRemoteService.read(request.getUrl());
         project.setId(null);
-        project.getRemoteStatus()
-                .setSyncStatus(RemoteStatus.SyncStatus.MARKED);
+        if (request.getFrequency()
+                .equals(ProjectSyncFrequency.NEVER)) {
+            project.getRemoteStatus()
+                    .setSyncStatus(RemoteStatus.SyncStatus.UNSYNCHRONIZED);
+        } else {
+            project.getRemoteStatus()
+                    .setSyncStatus(RemoteStatus.SyncStatus.MARKED);
+        }
         project.setSyncFrequency(request.getFrequency());
         project = projectService.create(project);
         return new AjaxCreateItemSuccessResponse(project.getId());

--- a/src/main/webapp/resources/js/pages/projects/settings/components/ProjectSynchronizationSettings.jsx
+++ b/src/main/webapp/resources/js/pages/projects/settings/components/ProjectSynchronizationSettings.jsx
@@ -18,7 +18,12 @@ const { Title } = Typography;
  * @constructor
  */
 export default function ProjectSynchronizationSettings({ projectId }) {
-  const syncNowEnabledStates = ["SYNCHRONIZED", "ERROR", "UNAUTHORIZED"];
+  const syncNowEnabledStates = [
+    "ERROR",
+    "SYNCHRONIZED",
+    "UNAUTHORIZED",
+    "UNSYNCHRONIZED",
+  ];
   const [remoteProjectData, setRemoteProjectData] = useState(null);
   const [disableSyncNow, setDisableSyncNow] = useState(false);
 


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Updated creating of remote project to be set sync status as `UNSYNCHRONIZED` if the frequency is set to `NEVER`. Updated UI to enable sync buttons if a project is in `UNSYNCHRONIZED` state.

**To Test:**

1) Create a project
2) Synchronize Remote Project with a frequency of `NEVER`
3) Go into the remote project -> settings -> remote page
4) The `Force Sync` and `Sync Now` buttons should both be enabled even though the project is in `UNSYNCHRONIZED` state

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
