### PR TITLE
Hotfix - add user list link for manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+21.05 to 21.09
+--------------
+* [UI]: Added back `Users` option for managers in main navigation. (21.05.1)
+
 21.01 to 21.05
 --------------
 * [UI]: Fixed bug which was preventing a user from viewing more than 5 rows of a tabular result file. (21.01.1)

--- a/src/main/webapp/resources/js/components/Header/MainNavigation.jsx
+++ b/src/main/webapp/resources/js/components/Header/MainNavigation.jsx
@@ -11,6 +11,7 @@ import "./main-navigation/style.css";
 
 export function MainNavigation() {
   const isAdmin = window.TL._USER.systemRole === "ROLE_ADMIN";
+  const isManager = window.TL._USER.systemRole === "ROLE_MANAGER";
 
   return (
     <Row
@@ -84,6 +85,13 @@ export function MainNavigation() {
           <Menu.Item icon={<CartLink />} key="cart" />
           {!isAdmin && (
             <Menu.SubMenu title={<IconCog />}>
+              {isManager && (
+              <Menu.Item key="user:users">
+                <a href={setBaseUrl("/users")}>
+                  {i18n("nav.main.users-list")}
+                </a>
+              </Menu.Item>
+              )}
               <Menu.Item key="user:groups">
                 <a href={setBaseUrl("/groups")}>
                   {i18n("nav.main.groups-list")}


### PR DESCRIPTION
## Description of changes
Added a link to the users list for IRIDA managers.  Managers need to be able to create users, and the link to the list and creation pages were accidentally removed in the refactor of the main navigation.

## Related issue
Fixes #1024 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
