### PR TITLE
hotfix/snvphyl 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changes
 
 21.05 to 21.09
 --------------
+* [Workflow]: SNVPhyl has been updated to version `1.2.3` to fix an installation issue (<https://github.com/phac-nml/irida/issues/1018>). Since this updates a pipeline you will have to upgrade the Galaxy tool suite for SNVPhyl as described in our [instllation documentation](https://phac-nml.github.io/irida-documentation/administrator/galaxy/pipelines/phylogenomics/). (21.05.2)
 * [UI]: Fixed bug where a remote project in `UNSYNCHRONIZED` state would have the Sync buttons disabled on the Project Synchronization Settings page. (21.05.1)
 * [UI]: Added back `Users` option for managers in main navigation. (21.05.1)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,11 @@ Upgrading
 This document summarizes the environmental changes that need to be made when
 upgrading IRIDA that cannot be automated.
 
+21.05.1 to 21.05.2
+------------------
+
+* The [SNVPhyl](https://phac-nml.github.io/irida-documentation/administrator/galaxy/pipelines/phylogenomics/) pipeline has been upgraded to version `1.2.3`. Please make sure to install the necessary tools in Galaxy.
+
 21.01.3 to 21.05
 --------------
 * This upgrade makes schema changes to the databases and cannot be parallel deployed.  Servlet container must be stopped before deploying the new `war` file.

--- a/doc/administrator/galaxy/index.md
+++ b/doc/administrator/galaxy/index.md
@@ -28,7 +28,7 @@ The easiest way to get Galaxy up and running for use with IRIDA is to use a cust
 # curl -sSL https://get.docker.com/ | sh
 
 # Run IRIDA/Galaxy docker
-docker run -d -p 48888:80 -v /path/to/irida/data:/path/to/irida/data phacnml/galaxy-irida-20.05
+docker run -d -p 48888:80 -v /path/to/irida/data:/path/to/irida/data phacnml/galaxy-irida-20.09
 ```
 
 Where `48888` is the port on your local system where Galaxy should be accessible, and `/path/to/irida/data` should point to the location where the sequencing data for IRIDA is stored (i.e., the parent directory of `{sequence,reference,output,assembly}.file.base.directory` in [/etc/irida/irida.conf][irida-conf]). Note: You may have to create these directories manually the first time you set up IRIDA.

--- a/doc/administrator/galaxy/pipelines/phylogenomics/index.md
+++ b/doc/administrator/galaxy/pipelines/phylogenomics/index.md
@@ -12,6 +12,7 @@ IRIDA uses the software [SNVPhyl][] for constructing whole genome phylogenies.  
 | Tool Name               | Tool Revision   | Toolshed Installable Revision | Toolshed              |
 |:-----------------------:|:---------------:|:-----------------------------:|:---------------------:|
 | **suite_snvphyl_1_2_3** | [bc72925159fc]  | 0                             | [Galaxy Main Shed][]  |
+| **bcftools_view**       | [98d5499ead46]  | 13 (2021-04-13)               | [Galaxy Main Shed][]  |
 
 To install these tools, please proceed through the following steps.
 
@@ -20,6 +21,15 @@ To install these tools, please proceed through the following steps.
 Please install all the Galaxy tools in the table above by logging into Galaxy, navigating to **Admin > Search and browse tool sheds**, searching for the appropriate **Tool Name** and installing the appropriate **Toolshed Installable Revision**.
 
 The install progress can be monitored in the Galaxy log files `galaxy/*.log`.  On completion you should see a message of `Installed` next to the tool when going to **Admin > Manage installed tool shed repositories**.
+
+### Possible issues
+
+If, after installing all the above tools and testing the pipeline in IRIDA you get the error `GalaxyResponseException{status=400, responseBody={"err_msg": {"sec_filter|select_genotype"` as described in <https://github.com/phac-nml/irida/issues/1018> then you may need to take the following steps.
+
+1. Find the existing version of `bcftools_view` installed in Galaxy.
+2. Uninstall the existing version of `bcftools_view`.
+3. Install the new version of `bcftools_view` as described above.
+4. Test out the SNVPhyl pipeline again.
 
 ## Step 2: Testing Pipeline
 
@@ -47,6 +57,7 @@ If everything was successfull then all dependencies for this pipeline have been 
 
 [SNVPhyl]: http://snvphyl.readthedocs.io
 [bc72925159fc]: https://toolshed.g2.bx.psu.edu/view/nml/suite_snvphyl_1_2_3/bc72925159fc
+[bc72925159fc]: https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_view/98d5499ead46
 [Galaxy Main Shed]: http://toolshed.g2.bx.psu.edu/
 [SNVPhyl Galaxy Workflow]: ../test/snvphyl/snvphyl_workflow.ga
 [upload-icon]: ../test/snvphyl/images/upload-icon.jpg

--- a/doc/administrator/galaxy/pipelines/phylogenomics/index.md
+++ b/doc/administrator/galaxy/pipelines/phylogenomics/index.md
@@ -11,7 +11,7 @@ IRIDA uses the software [SNVPhyl][] for constructing whole genome phylogenies.  
 
 | Tool Name               | Tool Revision   | Toolshed Installable Revision | Toolshed              |
 |:-----------------------:|:---------------:|:-----------------------------:|:---------------------:|
-| **suite_snvphyl_1_2_2** | [77a9422303ce]  | 0                             | [Galaxy Main Shed][]  |
+| **suite_snvphyl_1_2_3** | [bc72925159fc]  | 0                             | [Galaxy Main Shed][]  |
 
 To install these tools, please proceed through the following steps.
 
@@ -46,7 +46,7 @@ A Galaxy workflow and some test data has been included with this documentation t
 If everything was successfull then all dependencies for this pipeline have been properly installed.
 
 [SNVPhyl]: http://snvphyl.readthedocs.io
-[77a9422303ce]: https://toolshed.g2.bx.psu.edu/view/nml/suite_snvphyl_1_2_2/77a9422303ce
+[bc72925159fc]: https://toolshed.g2.bx.psu.edu/view/nml/suite_snvphyl_1_2_3/bc72925159fc
 [Galaxy Main Shed]: http://toolshed.g2.bx.psu.edu/
 [SNVPhyl Galaxy Workflow]: ../test/snvphyl/snvphyl_workflow.ga
 [upload-icon]: ../test/snvphyl/images/upload-icon.jpg

--- a/doc/administrator/galaxy/pipelines/phylogenomics/index.md
+++ b/doc/administrator/galaxy/pipelines/phylogenomics/index.md
@@ -24,7 +24,7 @@ The install progress can be monitored in the Galaxy log files `galaxy/*.log`.  O
 
 ### Possible issues
 
-If, after installing all the above tools and testing the pipeline in IRIDA you get the error `GalaxyResponseException{status=400, responseBody={"err_msg": {"sec_filter|select_genotype"` as described in <https://github.com/phac-nml/irida/issues/1018> then you may need to take the following steps.
+If, after installing all the above tools and testing the pipeline in IRIDA you get the error `GalaxyResponseException{status=400, responseBody={"err_msg": {"sec_filter|select_genotype"...` as described in <https://github.com/phac-nml/irida/issues/1018> then you may need to take the following steps.
 
 1. Find the existing version of `bcftools_view` installed in Galaxy.
 2. Uninstall the existing version of `bcftools_view`.
@@ -57,7 +57,7 @@ If everything was successfull then all dependencies for this pipeline have been 
 
 [SNVPhyl]: http://snvphyl.readthedocs.io
 [bc72925159fc]: https://toolshed.g2.bx.psu.edu/view/nml/suite_snvphyl_1_2_3/bc72925159fc
-[bc72925159fc]: https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_view/98d5499ead46
+[98d5499ead46]: https://toolshed.g2.bx.psu.edu/view/iuc/bcftools_view/98d5499ead46
 [Galaxy Main Shed]: http://toolshed.g2.bx.psu.edu/
 [SNVPhyl Galaxy Workflow]: ../test/snvphyl/snvphyl_workflow.ga
 [upload-icon]: ../test/snvphyl/images/upload-icon.jpg

--- a/doc/administrator/galaxy/pipelines/test/snvphyl/snvphyl_workflow.ga
+++ b/doc/administrator/galaxy/pipelines/test/snvphyl/snvphyl_workflow.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true",
     "annotation": "snvphyl",
     "format-version": "0.1",
-    "name": "SNVPhyl v1.2.2 Paired-End",
+    "name": "SNVPhyl v1.2.3 Paired-End",
     "steps": {
         "0": {
             "annotation": "",
@@ -32,7 +32,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "aa5be25d-46d2-47c9-904a-d02403c1061b"
+                    "uuid": "077da4fa-04b4-4d34-b271-e9844d0077c7"
                 }
             ]
         },
@@ -53,7 +53,7 @@
             "outputs": [],
             "position": {
                 "left": 200,
-                "top": 310
+                "top": 309
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -64,7 +64,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "91e3b578-0dfa-4bbd-8131-e4a2fb793be3"
+                    "uuid": "7c4fac08-6e78-4031-b394-696013960c4f"
                 }
             ]
         },
@@ -158,7 +158,7 @@
             ],
             "position": {
                 "left": 486,
-                "top": 321
+                "top": 320
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/smalt/smalt/0.7.6+galaxy1",
@@ -250,7 +250,7 @@
             ],
             "position": {
                 "left": 772,
-                "top": 392
+                "top": 390
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_log": {
@@ -311,12 +311,12 @@
             ],
             "position": {
                 "left": 772,
-                "top": 554
+                "top": 550
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/1.10",
             "tool_shed_repository": {
-                "changeset_revision": "f65383c7ed49",
+                "changeset_revision": "0dbff46d5a1b",
                 "name": "bcftools_mpileup",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -412,7 +412,7 @@
             ],
             "position": {
                 "left": 1058,
-                "top": 321
+                "top": 320
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_file": {
@@ -430,7 +430,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_call/bcftools_call/1.10",
             "tool_shed_repository": {
-                "changeset_revision": "5801eff9ac7e",
+                "changeset_revision": "072f606e2e69",
                 "name": "bcftools_call",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -481,12 +481,12 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_view/bcftools_view/1.10",
             "tool_shed_repository": {
-                "changeset_revision": "c4a9b38b435d",
+                "changeset_revision": "98d5499ead46",
                 "name": "bcftools_view",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"b\", \"sec_filter\": {\"min_ac\": \"\", \"max_ac\": \"\", \"select_genotype\": \"__none__\", \"types\": null, \"exclude_types\": null, \"known_or_novel\": null, \"min_alleles\": \"\", \"max_alleles\": \"\", \"phased\": null, \"min_af\": \"\", \"max_af\": \"\", \"uncalled\": null, \"private\": null}, \"sec_output\": {\"drop_genotypes\": \"false\", \"header\": null, \"compression_level\": \"\", \"invert_targets_file\": \"false\"}, \"sec_restrict\": {\"apply_filters\": \"\", \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}, \"include\": \"\", \"exclude\": \"\"}, \"sec_subset\": {\"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\", \"force_samples\": \"false\", \"no_update\": \"false\", \"trim_alt_alleles\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"b\", \"sec_filter\": {\"min_ac\": \"\", \"max_ac\": \"\", \"select_genotype\": null, \"types\": null, \"exclude_types\": null, \"known_or_novel\": null, \"min_alleles\": \"\", \"max_alleles\": \"\", \"phased\": null, \"min_af\": \"\", \"max_af\": \"\", \"uncalled\": null, \"private\": null}, \"sec_output\": {\"drop_genotypes\": \"false\", \"header\": null, \"compression_level\": \"\", \"invert_targets_file\": \"false\"}, \"sec_restrict\": {\"apply_filters\": \"\", \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}, \"include\": \"\", \"exclude\": \"\"}, \"sec_subset\": {\"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\", \"force_samples\": \"false\", \"no_update\": \"false\", \"trim_alt_alleles\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.10",
             "type": "tool",
             "uuid": "dc7c99fa-255b-4008-a352-422768e2083f",
@@ -754,12 +754,7 @@
                     "output_name": "phylip"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Regex Find And Replace",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Regex Find And Replace",
             "outputs": [
@@ -788,7 +783,7 @@
                 "owner": "galaxyp",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"checks\": [{\"__index__\": 0, \"pattern\": \"'\", \"replacement\": \"\"}], \"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"checks\": [{\"__index__\": 0, \"pattern\": \"'\", \"replacement\": \"\"}], \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.1",
             "type": "tool",
             "uuid": "ef09d1c7-5a20-4817-b81d-0a23d090cade",
@@ -822,7 +817,7 @@
             ],
             "position": {
                 "left": 2774,
-                "top": 342
+                "top": 340
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout": {
@@ -926,8 +921,8 @@
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "output_stats",
-                    "uuid": "eda0df2d-a3bf-48f8-b0f1-14a634842e5e"
+                    "output_name": "output_stdout",
+                    "uuid": "32e10655-c4e2-485e-8157-1b0dd72937ab"
                 },
                 {
                     "label": null,
@@ -936,8 +931,8 @@
                 },
                 {
                     "label": null,
-                    "output_name": "output_stdout",
-                    "uuid": "32e10655-c4e2-485e-8157-1b0dd72937ab"
+                    "output_name": "output_stats",
+                    "uuid": "eda0df2d-a3bf-48f8-b0f1-14a634842e5e"
                 }
             ]
         },
@@ -963,7 +958,7 @@
             ],
             "position": {
                 "left": 3060,
-                "top": 412
+                "top": 410
             },
             "post_job_actions": {
                 "RenameDatasetActionout": {
@@ -995,6 +990,6 @@
         }
     },
     "tags": [],
-    "uuid": "b164bd2b-675f-4b88-9b4c-6b072399baf1",
+    "uuid": "4a7fbdb1-e496-423e-a6a0-637d1f0469a1",
     "version": 1
 }

--- a/docker/base-image/Dockerfile
+++ b/docker/base-image/Dockerfile
@@ -1,10 +1,10 @@
 # Galaxy - IRIDA Base Image
 
-FROM bgruening/galaxy-stable:20.05
+FROM bgruening/galaxy-stable:20.09
 
 LABEL maintainer="Aaron Petkau <aaron.petkau@canada.ca>"
 
-ENV GALAXY_CONFIG_BRAND IRIDA (Galaxy 20.05)
+ENV GALAXY_CONFIG_BRAND IRIDA (Galaxy 20.09)
 
 WORKDIR /galaxy-central
 

--- a/docker/base-image/galaxy/irida-tools.yml
+++ b/docker/base-image/galaxy/irida-tools.yml
@@ -1,9 +1,9 @@
 ---
 tools:
-- name: "suite_snvphyl_1_2_2"
+- name: "suite_snvphyl_1_2_3"
   owner: "nml"
   tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
   revisions:
-  - "77a9422303ce"
+  - "bc72925159fc"
   tool_panel_section_id: "irida"
   install_tool_dependencies: true

--- a/docker/integration-testing/Dockerfile
+++ b/docker/integration-testing/Dockerfile
@@ -1,6 +1,6 @@
 # Galaxy - IRIDA Integration Testing Image
 
-FROM phacnml/galaxy-irida-20.05:base 
+FROM phacnml/galaxy-irida-20.09:base 
 
 # Add test tool configs
 ADD ./galaxy/tool_conf_irida.xml /galaxy-central/config/tool_conf.xml

--- a/docker/virtual-machine/Dockerfile
+++ b/docker/virtual-machine/Dockerfile
@@ -1,6 +1,6 @@
 # Galaxy - IRIDA Galaxy Image
 
-FROM phacnml/galaxy-irida-20.05:base
+FROM phacnml/galaxy-irida-20.09:base
 
 ADD ./data/tools-list.yml $GALAXY_ROOT/irida-tools.yml
 

--- a/docker/virtual-machine/Dockerfile
+++ b/docker/virtual-machine/Dockerfile
@@ -3,25 +3,11 @@
 FROM phacnml/galaxy-irida-20.09:base
 
 ADD ./data/tools-list.yml $GALAXY_ROOT/irida-tools.yml
-ADD ./data/mentalist.env /tmp/mentalist.env
-
-# Install some example mentalist databases
-ADD --chown=galaxy:galaxy ./data/tool-data.tar.gz /galaxy-central/
 
 # Install tools
 RUN install-tools $GALAXY_ROOT/irida-tools.yml \
       && /tool_deps/_conda/bin/conda install --name __sistr_cmd@1.0.2 pandas==1.0.5 -y \
       && chown -R galaxy:galaxy /tool_deps/_conda/envs/__sistr_cmd@1.0.2 \
-      && /tool_deps/_conda/bin/conda remove --name __mentalist@0.1.9 --all -y \
-      && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __mentalist@0.1.9 --file /tmp/mentalist.env -y \
-      && echo -e "@\nATCG\n+\nIIII" > /tmp/file_1.fastq \
-      && echo -e "@\nATCG\n+\nIIII" > /tmp/file_2.fastq \
-      && bash -c "source /tool_deps/_conda/bin/activate /tool_deps/_conda/envs/__mentalist\@0.1.9/ && mentalist call -o /tmp/mentalist-test -s x --db /galaxy-central/tool-data/mentalist_databases/salmonella_enterica_pubmlst_k31_2018-04-04/salmonella_enterica_pubmlst_k31_2018-04-04.jld /tmp/file_1.fastq /tmp/file_2.fastq" \
-      && chown -R galaxy:galaxy /tool_deps/_conda/envs/__mentalist@0.1.9 \
-      && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __r-base@3.4.1 r-base==3.4.1 libiconv -y \
-      && chown -R galaxy:galaxy /tool_deps/_conda/envs/__r-base@3.4.1 \
-      && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __biopython@1.70 biopython==1.70 -y \
-      && chown -R galaxy:galaxy /tool_deps/_conda/envs/__biopython@1.70 \
       && /tool_deps/_conda/bin/conda clean --packages -t -i \
       && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
 
@@ -32,6 +18,27 @@ RUN sed -i -e 's@\(<destination .*\)@\1\n\t<env id="SHOVILL_RAM">4</env>@' /etc/
 RUN apt-get update -y && apt-get install less libidn11 \
       && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ \
       && rm -rf /tmp/* /root/.cache/ /var/cache/*
+
+# Install some example mentalist databases
+ADD --chown=galaxy:galaxy ./data/tool-data.tar.gz /galaxy-central/
+
+# Update mentalist environment
+ADD ./data/mentalist.env /tmp/mentalist.env
+RUN /tool_deps/_conda/bin/conda remove --name __mentalist@0.1.9 --all -y \
+      && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __mentalist@0.1.9 --file /tmp/mentalist.env -y \
+      && echo -e "@\nATCG\n+\nIIII" > /tmp/file_1.fastq \
+      && echo -e "@\nATCG\n+\nIIII" > /tmp/file_2.fastq \
+      && bash -c "source /tool_deps/_conda/bin/activate /tool_deps/_conda/envs/__mentalist\@0.1.9/ && mentalist call -o /tmp/mentalist-test -s x --db /galaxy-central/tool-data/mentalist_databases/salmonella_enterica_pubmlst_k31_2018-04-04/salmonella_enterica_pubmlst_k31_2018-04-04.jld /tmp/file_1.fastq /tmp/file_2.fastq" \
+      && chown -R galaxy:galaxy /tool_deps/_conda/envs/__mentalist@0.1.9 \
+      && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __r-base@3.4.1 r-base==3.4.1 libiconv -y \
+      && chown -R galaxy:galaxy /tool_deps/_conda/envs/__r-base@3.4.1 \
+      && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __biopython@1.70 biopython==1.70 -y \
+      && chown -R galaxy:galaxy /tool_deps/_conda/envs/__biopython@1.70 \
+      && /tool_deps/_conda/bin/conda clean --packages -t -i \
+      && rm -rf /tmp/file_*.fastq
+
+# I cannot get MentaLiST to install via the command-line like the other tools
+# To get MentaLiST working you will have to install after Docker Galaxy is started.
 
 # Expose port 80 (webserver), 21 (FTP server), 8800 (Proxy)
 EXPOSE :80

--- a/docker/virtual-machine/Dockerfile
+++ b/docker/virtual-machine/Dockerfile
@@ -3,28 +3,16 @@
 FROM phacnml/galaxy-irida-20.09:base
 
 ADD ./data/tools-list.yml $GALAXY_ROOT/irida-tools.yml
+ADD ./data/mentalist.env /tmp/mentalist.env
+
+# Install some example mentalist databases
+ADD --chown=galaxy:galaxy ./data/tool-data.tar.gz /galaxy-central/
 
 # Install tools
 RUN install-tools $GALAXY_ROOT/irida-tools.yml \
       && /tool_deps/_conda/bin/conda install --name __sistr_cmd@1.0.2 pandas==1.0.5 -y \
       && chown -R galaxy:galaxy /tool_deps/_conda/envs/__sistr_cmd@1.0.2 \
-      && /tool_deps/_conda/bin/conda clean --packages -t -i \
-      && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
-
-# Fix up shovill memory
-RUN sed -i -e 's@\(<destination .*\)@\1\n\t<env id="SHOVILL_RAM">4</env>@' /etc/galaxy/job_conf.xml
-
-# Fix up prokka issues (install 'less' and 'libidn11')
-RUN apt-get update -y && apt-get install less libidn11 \
-      && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ \
-      && rm -rf /tmp/* /root/.cache/ /var/cache/*
-
-# Install some example mentalist databases
-ADD --chown=galaxy:galaxy ./data/tool-data.tar.gz /galaxy-central/
-
-# Update mentalist environment
-ADD ./data/mentalist.env /tmp/mentalist.env
-RUN /tool_deps/_conda/bin/conda remove --name __mentalist@0.1.9 --all -y \
+      && /tool_deps/_conda/bin/conda remove --name __mentalist@0.1.9 --all -y \
       && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __mentalist@0.1.9 --file /tmp/mentalist.env -y \
       && echo -e "@\nATCG\n+\nIIII" > /tmp/file_1.fastq \
       && echo -e "@\nATCG\n+\nIIII" > /tmp/file_2.fastq \
@@ -35,10 +23,15 @@ RUN /tool_deps/_conda/bin/conda remove --name __mentalist@0.1.9 --all -y \
       && /tool_deps/_conda/bin/conda create -c defaults -c bioconda -c conda-forge --name __biopython@1.70 biopython==1.70 -y \
       && chown -R galaxy:galaxy /tool_deps/_conda/envs/__biopython@1.70 \
       && /tool_deps/_conda/bin/conda clean --packages -t -i \
-      && rm -rf /tmp/file_*.fastq
+      && rm -rf /tmp/* /root/.cache/ /var/cache/* $GALAXY_ROOT/client/node_modules/ $GALAXY_VIRTUAL_ENV/src/ /home/galaxy/.cache/ /home/galaxy/.npm
 
-# I cannot get MentaLiST to install via the command-line like the other tools
-# To get MentaLiST working you will have to install after Docker Galaxy is started.
+# Fix up shovill memory
+RUN sed -i -e 's@\(<destination .*\)@\1\n\t<env id="SHOVILL_RAM">4</env>@' /etc/galaxy/job_conf.xml
+
+# Fix up prokka issues (install 'less' and 'libidn11')
+RUN apt-get update -y && apt-get install less libidn11 \
+      && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -rf ~/.cache/ \
+      && rm -rf /tmp/* /root/.cache/ /var/cache/*
 
 # Expose port 80 (webserver), 21 (FTP server), 8800 (Proxy)
 EXPOSE :80

--- a/docker/virtual-machine/data/tools-list.yml
+++ b/docker/virtual-machine/data/tools-list.yml
@@ -39,8 +39,13 @@ tools:
 
   ### Tools for MLSTMentalist v0.1.9 ###
 
-# Mentalist tool fails to install so I am removing it from this file
-# And installing it elsewhere
+- name: "mentalist"
+  owner: "dfornika"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "a6cd59f35832"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true
 - name: "combine_tabular_collection"
   owner: "nml"
   tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
@@ -78,11 +83,11 @@ tools:
 
   ### Tools for SNVPhyl v1.2.2 ###
 
-- name: "suite_snvphyl_1_2_2"
+- name: "suite_snvphyl_1_2_3"
   owner: "nml"
   tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
   revisions:
-  - "77a9422303ce"
+  - "bc72925159fc"
   tool_panel_section_id: "irida"
   install_tool_dependencies: true
 
@@ -93,28 +98,5 @@ tools:
   tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
   revisions:
   - "4654c51dae72"
-  tool_panel_section_id: "irida"
-  install_tool_dependencies: true
-
-  ### Extra tools for plugins ###
-- name: "shovill"
-  owner: "iuc"
-  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
-  revisions:
-  - "865119fcb694"
-  tool_panel_section_id: "irida"
-  install_tool_dependencies: true
-- name: "shovill"
-  owner: "iuc"
-  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
-  revisions:
-  - "83ead2be47b2"
-  tool_panel_section_id: "irida"
-  install_tool_dependencies: true
-- name: "sistr_cmd"
-  owner: "nml"
-  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
-  revisions:
-  - "17fcac7ddf54"
   tool_panel_section_id: "irida"
   install_tool_dependencies: true

--- a/docker/virtual-machine/data/tools-list.yml
+++ b/docker/virtual-machine/data/tools-list.yml
@@ -100,3 +100,47 @@ tools:
   - "4654c51dae72"
   tool_panel_section_id: "irida"
   install_tool_dependencies: true
+
+  ### Extra tools for plugins ###
+- name: "shovill"
+  owner: "iuc"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "865119fcb694"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true
+- name: "shovill"
+  owner: "iuc"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "83ead2be47b2"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true
+- name: "sistr_cmd"
+  owner: "nml"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "17fcac7ddf54"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true
+- name: "rgi"
+  owner: "card"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "bfbfc24c5af2"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true
+- name: "staramr"
+  owner: "nml"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "4b9a8031ab74"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true
+- name: "ectyper"
+  owner: "nml"
+  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
+  revisions:
+  - "e79a8dad83b4"
+  tool_panel_section_id: "irida"
+  install_tool_dependencies: true

--- a/docker/virtual-machine/data/tools-list.yml
+++ b/docker/virtual-machine/data/tools-list.yml
@@ -39,13 +39,8 @@ tools:
 
   ### Tools for MLSTMentalist v0.1.9 ###
 
-- name: "mentalist"
-  owner: "dfornika"
-  tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
-  revisions:
-  - "a6cd59f35832"
-  tool_panel_section_id: "irida"
-  install_tool_dependencies: true
+# Mentalist tool fails to install so I am removing it from this file
+# And installing it elsewhere
 - name: "combine_tabular_collection"
   owner: "nml"
   tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
@@ -141,6 +136,6 @@ tools:
   owner: "nml"
   tool_shed_url: "https://toolshed.g2.bx.psu.edu/"
   revisions:
-  - "e79a8dad83b4"
+  - "08d801182fa1"
   tool_panel_section_id: "irida"
   install_tool_dependencies: true

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.05.1</version>
+	<version>21.05.2</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ JDBC_URL=jdbc:mysql://$DATABASE_HOST:$DATABASE_PORT/$DATABASE_NAME
 TMP_DIRECTORY=`mktemp -d /tmp/irida-test-XXXXXXXX`
 chmod 777 $TMP_DIRECTORY # Needs to be world-accessible so that Docker/Galaxy can access
 
-GALAXY_DOCKER=phacnml/galaxy-irida-20.09:21.05-it
+GALAXY_DOCKER=phacnml/galaxy-irida-20.09:21.05.2-it
 GALAXY_DOCKER_NAME=irida-galaxy-test
 GALAXY_PORT=48889
 GALAXY_URL=http://localhost:$GALAXY_PORT

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,7 +11,7 @@ JDBC_URL=jdbc:mysql://$DATABASE_HOST:$DATABASE_PORT/$DATABASE_NAME
 TMP_DIRECTORY=`mktemp -d /tmp/irida-test-XXXXXXXX`
 chmod 777 $TMP_DIRECTORY # Needs to be world-accessible so that Docker/Galaxy can access
 
-GALAXY_DOCKER=phacnml/galaxy-irida-20.05:20.09-it
+GALAXY_DOCKER=phacnml/galaxy-irida-20.09:21.05-it
 GALAXY_DOCKER_NAME=irida-galaxy-test
 GALAXY_PORT=48889
 GALAXY_URL=http://localhost:$GALAXY_PORT

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/config/workflows.properties
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/config/workflows.properties
@@ -1,4 +1,4 @@
-irida.workflow.default.PHYLOGENOMICS=f609c177-c268-4ad0-9d7f-9f9d5187fef7
+irida.workflow.default.PHYLOGENOMICS=0e06d5c7-20ad-404b-8152-e9b9573ba723
 irida.workflow.default.ASSEMBLY_ANNOTATION=60f7d67d-a85d-4cc5-a7bd-b9cb14eea85f
 irida.workflow.default.ASSEMBLY_ANNOTATION_COLLECTION=86649dd9-3bcf-4be8-82d6-be0360de37d9
 irida.workflow.default.SISTR_TYPING=92ecf046-ee09-4271-b849-7a82625d6b60

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<iridaWorkflow>
+	<id>f609c177-c268-4ad0-9d7f-9f9d5187fef7</id>
+	<name>SNVPhyl</name>
+	<version>1.2.2</version>
+	<analysisType>PHYLOGENOMICS</analysisType>
+	<inputs>
+		<sequenceReadsPaired>sequence_reads_paired</sequenceReadsPaired>
+		<reference>reference</reference>
+		<requiresSingleSample>false</requiresSingleSample>
+	</inputs>
+	<parameters>
+		<parameter name="enable-density-filter" required="true">
+			<choices>
+				<choice name="enable" value="true"/>
+				<choice name="disable" value="false"/>
+			</choices>
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1"
+				parameterName="use_density_filter" />
+		</parameter>
+		<parameter name="repeat-minimum-length" defaultValue="150">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/find_repeats/findrepeat/1.8.2+galaxy1"
+				parameterName="length" />
+		</parameter>
+		<parameter name="repeat-minimum-pid" defaultValue="90">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/find_repeats/findrepeat/1.8.2+galaxy1"
+				parameterName="pid" />
+		</parameter>
+		<parameter name="minimum-percent-coverage" defaultValue="80">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/verify_map/verify_map/1.8.2+galaxy1"
+				parameterName="minmap" />
+		</parameter>
+		<parameter name="snv-abundance-ratio" defaultValue="0.75">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1"
+				parameterName="snv_abundance_ratio" />
+		</parameter>
+		<parameter name="minimum-mean-mapping-quality" defaultValue="30">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1"
+				parameterName="mean_mapping" />
+		</parameter>
+		<parameter name="minimum-read-coverage" defaultValue="15">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1"
+				parameterName="coverage" />
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/verify_map/verify_map/1.8.2+galaxy1"
+				parameterName="mindepth" />
+		</parameter>
+		<parameter name="filter-density-window-size" defaultValue="500">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1"
+				parameterName="window_size" />
+		</parameter>
+		<parameter name="filter-density-threshold" defaultValue="2">
+			<toolParameter
+				toolId="toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1"
+				parameterName="threshold" />
+		</parameter>
+	</parameters>
+	<outputs>
+		<output name="filter-stats" fileName="filterStats.txt" />
+		<output name="mapping-quality" fileName="mappingQuality.txt" />
+		<output name="tree" fileName="phylogeneticTree.newick" />
+		<output name="tree-stats" fileName="phylogeneticTreeStats.txt" />
+		<output name="alignment" fileName="snvAlignment.phy" />
+		<output name="matrix" fileName="snvMatrix.tsv" />
+		<output name="table" fileName="snvTable.tsv" />
+		<output name="core" fileName="vcf2core.tsv" />
+	</outputs>
+	<toolRepositories>
+		<repository>
+			<name>suite_snvphyl_1_2_2</name>
+			<owner>nml</owner>
+			<url>https://toolshed.g2.bx.psu.edu</url>
+			<revision>77a9422303ce</revision>
+		</repository>
+	</toolRepositories>
+</iridaWorkflow>

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow.xml
@@ -81,5 +81,11 @@
 			<url>https://toolshed.g2.bx.psu.edu</url>
 			<revision>bc72925159fc</revision>
 		</repository>
+		<repository>
+			<name>bcftools_view</name>
+			<owner>iuc</owner>
+			<url>https://toolshed.g2.bx.psu.edu</url>
+			<revision>98d5499ead46</revision>
+		</repository>
 	</toolRepositories>
 </iridaWorkflow>

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <iridaWorkflow>
-	<id>f609c177-c268-4ad0-9d7f-9f9d5187fef7</id>
+	<id>0e06d5c7-20ad-404b-8152-e9b9573ba723</id>
 	<name>SNVPhyl</name>
-	<version>1.2.2</version>
+	<version>1.2.3</version>
 	<analysisType>PHYLOGENOMICS</analysisType>
 	<inputs>
 		<sequenceReadsPaired>sequence_reads_paired</sequenceReadsPaired>
@@ -76,10 +76,10 @@
 	</outputs>
 	<toolRepositories>
 		<repository>
-			<name>suite_snvphyl_1_2_2</name>
+			<name>suite_snvphyl_1_2_3</name>
 			<owner>nml</owner>
 			<url>https://toolshed.g2.bx.psu.edu</url>
-			<revision>77a9422303ce</revision>
+			<revision>bc72925159fc</revision>
 		</repository>
 	</toolRepositories>
 </iridaWorkflow>

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow_structure.ga
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow_structure.ga
@@ -1,0 +1,1000 @@
+{
+    "a_galaxy_workflow": "true",
+    "annotation": "snvphyl",
+    "format-version": "0.1",
+    "name": "SNVPhyl v1.2.2 Paired-End",
+    "steps": {
+        "0": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 0,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "sequence_reads_paired"
+                }
+            ],
+            "label": "sequence_reads_paired",
+            "name": "Input dataset collection",
+            "outputs": [],
+            "position": {
+                "left": 200,
+                "top": 200
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false, \"collection_type\": \"list:paired\"}",
+            "tool_version": null,
+            "type": "data_collection_input",
+            "uuid": "2cb28cd0-67ca-416a-9b2a-abfa1601a565",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "aa5be25d-46d2-47c9-904a-d02403c1061b"
+                }
+            ]
+        },
+        "1": {
+            "annotation": "",
+            "content_id": null,
+            "errors": null,
+            "id": 1,
+            "input_connections": {},
+            "inputs": [
+                {
+                    "description": "",
+                    "name": "reference"
+                }
+            ],
+            "label": "reference",
+            "name": "Input dataset",
+            "outputs": [],
+            "position": {
+                "left": 200,
+                "top": 310
+            },
+            "tool_id": null,
+            "tool_state": "{\"optional\": false}",
+            "tool_version": null,
+            "type": "data_input",
+            "uuid": "7b5ce881-8726-4a15-afa1-de5971fe39d0",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "91e3b578-0dfa-4bbd-8131-e4a2fb793be3"
+                }
+            ]
+        },
+        "2": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/find_repeats/findrepeat/1.8.2+galaxy1",
+            "errors": null,
+            "id": 2,
+            "input_connections": {
+                "fasta": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Find Repeats",
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 486,
+                "top": 200
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionout": {
+                    "action_arguments": {
+                        "newtype": "bed"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out"
+                },
+                "RenameDatasetActionout": {
+                    "action_arguments": {
+                        "newname": "invalid_positions.bed"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/find_repeats/findrepeat/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "7e6be57de1a0",
+                "name": "find_repeats",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"fasta\": {\"__class__\": \"ConnectedValue\"}, \"length\": \"150\", \"pid\": \"90\", \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "26031bc7-bd60-4356-aef8-0cbc3cb81aef",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out",
+                    "uuid": "fa9b6c17-1c9a-4d8a-bd58-381eff6d0bd6"
+                }
+            ]
+        },
+        "3": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/smalt/smalt/0.7.6+galaxy1",
+            "errors": null,
+            "id": 3,
+            "input_connections": {
+                "reference": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "singlePaired|fastq_collection": {
+                    "id": 0,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool smalt",
+                    "name": "insfil"
+                }
+            ],
+            "label": null,
+            "name": "smalt",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "cigar"
+                }
+            ],
+            "position": {
+                "left": 486,
+                "top": 321
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/smalt/smalt/0.7.6+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "5ba47ab90254",
+                "name": "smalt",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"insertmax\": \"1000\", \"insertmin\": \"20\", \"insfil\": {\"__class__\": \"RuntimeValue\"}, \"k\": \"13\", \"minbasq\": \"\", \"mincover\": \"\", \"minid\": \"0.5\", \"minscor\": \"\", \"oformat\": {\"outformat\": \"bam\", \"__current_case__\": 1, \"bamOptions\": null}, \"reference\": {\"__class__\": \"ConnectedValue\"}, \"s\": \"\", \"scordiff\": \"\", \"search_harder\": \"false\", \"seed\": \"1\", \"singlePaired\": {\"sPaired\": \"collections\", \"__current_case__\": 2, \"fastq_collection\": {\"__class__\": \"ConnectedValue\"}, \"pairtype\": \"pe\"}, \"sw_weighted\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "0.7.6+galaxy1",
+            "type": "tool",
+            "uuid": "38e038c4-14d8-48a3-b644-2752f343d5de",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output",
+                    "uuid": "cc4cb0c4-e0ed-44e9-8a14-6331cbafb65e"
+                }
+            ]
+        },
+        "4": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.3.1",
+            "errors": null,
+            "id": 4,
+            "input_connections": {
+                "reference_source|batchmode|input_bams": {
+                    "id": 3,
+                    "output_name": "output"
+                },
+                "reference_source|ref_file": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "FreeBayes",
+            "outputs": [
+                {
+                    "name": "output_vcf",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 772,
+                "top": 200
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/devteam/freebayes/freebayes/1.3.1",
+            "tool_shed_repository": {
+                "changeset_revision": "ef2c525bd8cd",
+                "name": "freebayes",
+                "owner": "devteam",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"coverage_options\": {\"coverage_options_selector\": \"do_not_set\", \"__current_case__\": 1}, \"options_type\": {\"options_type_selector\": \"full\", \"__current_case__\": 0, \"optional_inputs\": {\"optional_inputs_selector\": \"do_not_set\", \"__current_case__\": 1}, \"reporting\": {\"reporting_selector\": \"do_not_set\", \"__current_case__\": 1}, \"population_model\": {\"population_model_selector\": \"set\", \"__current_case__\": 0, \"T\": \"0.001\", \"P\": \"1\", \"J\": \"false\", \"K\": \"false\"}, \"reference_allele\": {\"reference_allele_selector\": \"do_not_set\", \"__current_case__\": 1}, \"allele_scope\": {\"allele_scope_selector\": \"do_not_set\", \"__current_case__\": 1}, \"O\": \"false\", \"input_filters\": {\"input_filters_selector\": \"do_not_set\", \"__current_case__\": 1}, \"population_mappability_priors\": {\"population_mappability_priors_selector\": \"do_not_set\", \"__current_case__\": 1}, \"genotype_likelihoods\": {\"genotype_likelihoods_selector\": \"do_not_set\", \"__current_case__\": 1}, \"algorithmic_features\": {\"algorithmic_features_selector\": \"do_not_set\", \"__current_case__\": 1}}, \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"batchmode\": {\"processmode\": \"individual\", \"__current_case__\": 0, \"input_bams\": {\"__class__\": \"ConnectedValue\"}}, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"target_limit_type\": {\"target_limit_type_selector\": \"do_not_limit\", \"__current_case__\": 0}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.3.1",
+            "type": "tool",
+            "uuid": "339143e2-e685-41a1-ab0d-bf3d124200fa",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output_vcf",
+                    "uuid": "94edeea2-edcc-48be-8c71-45050a8edfb9"
+                }
+            ]
+        },
+        "5": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/verify_map/verify_map/1.8.2+galaxy1",
+            "errors": null,
+            "id": 5,
+            "input_connections": {
+                "bams": {
+                    "id": 3,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Verify Mapping Quality",
+            "outputs": [
+                {
+                    "name": "output_log",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 772,
+                "top": 392
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput_log": {
+                    "action_arguments": {
+                        "newname": "mappingQuality.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_log"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/verify_map/verify_map/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "80b7566e62ec",
+                "name": "verify_map",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"bams\": {\"__class__\": \"ConnectedValue\"}, \"mindepth\": \"${min_coverage}\", \"minmap\": \"80\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "0dd907ea-1893-45bd-8f88-557ffb31aba7",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output_log",
+                    "uuid": "257a6a9c-7701-4613-aa5c-17fd88772187"
+                }
+            ]
+        },
+        "6": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/1.10",
+            "errors": null,
+            "id": 6,
+            "input_connections": {
+                "input|input_bam": {
+                    "id": 3,
+                    "output_name": "output"
+                },
+                "reference_source|ref_file": {
+                    "id": 1,
+                    "output_name": "output"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool bcftools mpileup",
+                    "name": "sec_subset"
+                }
+            ],
+            "label": null,
+            "name": "bcftools mpileup",
+            "outputs": [
+                {
+                    "name": "output_file",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 772,
+                "top": 554
+            },
+            "post_job_actions": {},
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/1.10",
+            "tool_shed_repository": {
+                "changeset_revision": "f65383c7ed49",
+                "name": "bcftools_mpileup",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input\": {\"input_number\": \"single\", \"__current_case__\": 0, \"input_bam\": {\"__class__\": \"ConnectedValue\"}}, \"output_type\": \"b\", \"reference_source\": {\"reference_source_selector\": \"history\", \"__current_case__\": 1, \"ref_file\": {\"__class__\": \"ConnectedValue\"}}, \"sec_filtering\": {\"max_reads_per_bam\": \"1024\", \"ignore_overlaps\": \"false\", \"skip_anomalous_read_pairs\": \"true\", \"filter_by_flags\": {\"filter_flags\": \"nofilter\", \"__current_case__\": 1}, \"quality\": {\"quality_settings\": \"adjust\", \"__current_case__\": 0, \"baq\": \"\", \"coefficient_for_downgrading\": \"0\", \"minimum_mapping_quality\": \"0\", \"minimum_base_quality\": \"0\"}, \"read_groups\": {\"read_groups_selector\": \"no_limit\", \"__current_case__\": 3}}, \"sec_indel\": {\"perform_indel_calling\": {\"perform_indel_calling_selector\": \"do_not_perform_indel_calling\", \"__current_case__\": 2}}, \"sec_output_options\": {\"output_tags\": null, \"gvcf\": \"\"}, \"sec_restrict\": {\"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}}, \"sec_subset\": {\"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.10",
+            "type": "tool",
+            "uuid": "390ac6c1-6e7d-4a86-9580-005f417928de",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output_file",
+                    "uuid": "6c1d3765-08c8-4900-9634-259bbfee32a1"
+                }
+            ]
+        },
+        "7": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/filter_vcf/filtervcf/1.8.2+galaxy1",
+            "errors": null,
+            "id": 7,
+            "input_connections": {
+                "vcf": {
+                    "id": 4,
+                    "output_name": "output_vcf"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter vcf",
+            "outputs": [
+                {
+                    "name": "vcfout",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 1058,
+                "top": 200
+            },
+            "post_job_actions": {
+                "HideDatasetActionvcfout": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "vcfout"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/filter_vcf/filtervcf/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "48922d9ca355",
+                "name": "filter_vcf",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"vcf\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "bb6b4bdb-6222-40cf-9cc7-17ac698b9af5",
+            "workflow_outputs": []
+        },
+        "8": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_call/bcftools_call/1.10",
+            "errors": null,
+            "id": 8,
+            "input_connections": {
+                "input_file": {
+                    "id": 6,
+                    "output_name": "output_file"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool bcftools call",
+                    "name": "sec_file_format"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools call",
+                    "name": "sec_file_format"
+                },
+                {
+                    "description": "runtime parameter for tool bcftools call",
+                    "name": "sec_restrict"
+                }
+            ],
+            "label": null,
+            "name": "bcftools call",
+            "outputs": [
+                {
+                    "name": "output_file",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 1058,
+                "top": 321
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput_file": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output_file"
+                },
+                "RenameDatasetActionoutput_file": {
+                    "action_arguments": {
+                        "newname": "mpileup_bcf"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_call/bcftools_call/1.10",
+            "tool_shed_repository": {
+                "changeset_revision": "5801eff9ac7e",
+                "name": "bcftools_call",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"b\", \"sec_consensus_variant_calling\": {\"variant_calling\": {\"method\": \"consensus\", \"__current_case__\": 1, \"genotypes\": {\"constrain\": \"none\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}, \"pval_threshold\": \"0.5\"}}, \"sec_file_format\": {\"ploidy\": \"1\", \"ploidy_file\": {\"__class__\": \"RuntimeValue\"}, \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"sec_input_output\": {\"keep_alts\": \"false\", \"format_fields\": \"\", \"keep_masked_ref\": \"false\", \"skip_variants\": null, \"variants_only\": \"false\"}, \"sec_restrict\": {\"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.10",
+            "type": "tool",
+            "uuid": "acdc1d66-6f4a-4aaf-b494-b862aa0563c7",
+            "workflow_outputs": []
+        },
+        "9": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_view/bcftools_view/1.10",
+            "errors": null,
+            "id": 9,
+            "input_connections": {
+                "input_file": {
+                    "id": 7,
+                    "output_name": "vcfout"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool bcftools view",
+                    "name": "sec_subset"
+                }
+            ],
+            "label": null,
+            "name": "bcftools view",
+            "outputs": [
+                {
+                    "name": "output_file",
+                    "type": "vcf"
+                }
+            ],
+            "position": {
+                "left": 1344,
+                "top": 200
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput_file": {
+                    "action_arguments": {
+                        "newname": "filtered_freebayes_bcf"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_file"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_view/bcftools_view/1.10",
+            "tool_shed_repository": {
+                "changeset_revision": "c4a9b38b435d",
+                "name": "bcftools_view",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"b\", \"sec_filter\": {\"min_ac\": \"\", \"max_ac\": \"\", \"select_genotype\": \"__none__\", \"types\": null, \"exclude_types\": null, \"known_or_novel\": null, \"min_alleles\": \"\", \"max_alleles\": \"\", \"phased\": null, \"min_af\": \"\", \"max_af\": \"\", \"uncalled\": null, \"private\": null}, \"sec_output\": {\"drop_genotypes\": \"false\", \"header\": null, \"compression_level\": \"\", \"invert_targets_file\": \"false\"}, \"sec_restrict\": {\"apply_filters\": \"\", \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}, \"include\": \"\", \"exclude\": \"\"}, \"sec_subset\": {\"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\", \"force_samples\": \"false\", \"no_update\": \"false\", \"trim_alt_alleles\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.10",
+            "type": "tool",
+            "uuid": "dc7c99fa-255b-4008-a352-422768e2083f",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output_file",
+                    "uuid": "2634299b-c5d3-47f5-91c3-02369c8cd3a4"
+                }
+            ]
+        },
+        "10": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1",
+            "errors": null,
+            "id": 10,
+            "input_connections": {
+                "freebayes": {
+                    "id": 9,
+                    "output_name": "output_file"
+                },
+                "mpileup": {
+                    "id": 8,
+                    "output_name": "output_file"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Consolidate VCFs",
+            "outputs": [
+                {
+                    "name": "bcf_combined",
+                    "type": "bcf_bgzip"
+                },
+                {
+                    "name": "filtered_density",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 1630,
+                "top": 200
+            },
+            "post_job_actions": {
+                "HideDatasetActionbcf_combined": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "bcf_combined"
+                },
+                "HideDatasetActionfiltered_density": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "filtered_density"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/consolidate_vcfs/consolidate_vcfs/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "4c249c0aebad",
+                "name": "consolidate_vcfs",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"coverage\": \"${min_coverage}\", \"freebayes\": {\"__class__\": \"ConnectedValue\"}, \"mean_mapping\": \"${min_mean_mapping}\", \"mpileup\": {\"__class__\": \"ConnectedValue\"}, \"snv_abundance_ratio\": \"${snv_abundance_ratio}\", \"threshold\": \"2\", \"use_density_filter\": \"true\", \"window_size\": \"500\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "6f1c83d4-6890-4504-b81e-c8f4d4eef10d",
+            "workflow_outputs": []
+        },
+        "11": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "errors": null,
+            "id": 11,
+            "input_connections": {
+                "input_list": {
+                    "id": 10,
+                    "output_name": "filtered_density"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Collapse Collection",
+            "outputs": [
+                {
+                    "name": "output",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 1916,
+                "top": 200
+            },
+            "post_job_actions": {
+                "HideDatasetActionoutput": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "output"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/collapse_collections/collapse_dataset/5.1.0",
+            "tool_shed_repository": {
+                "changeset_revision": "90981f86000f",
+                "name": "collapse_collections",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"filename\": {\"add_name\": \"false\", \"__current_case__\": 1}, \"input_list\": {\"__class__\": \"ConnectedValue\"}, \"one_header\": \"false\", \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "5.1.0",
+            "type": "tool",
+            "uuid": "07b39887-c5a8-4097-a1f1-f046012aa7bf",
+            "workflow_outputs": []
+        },
+        "12": {
+            "annotation": "",
+            "content_id": "cat1",
+            "errors": null,
+            "id": 12,
+            "input_connections": {
+                "input1": {
+                    "id": 11,
+                    "output_name": "output"
+                },
+                "queries_0|input2": {
+                    "id": 2,
+                    "output_name": "out"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Concatenate datasets",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2202,
+                "top": 200
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "combined_invalid_positions"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "cat1",
+            "tool_state": "{\"input1\": {\"__class__\": \"ConnectedValue\"}, \"queries\": [{\"__index__\": 0, \"input2\": {\"__class__\": \"ConnectedValue\"}}], \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.0",
+            "type": "tool",
+            "uuid": "af5e3585-8c37-4bc1-8a35-0d30287ab749",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "e7c5f146-31ac-4fea-807f-f8fdd9b082d5"
+                }
+            ]
+        },
+        "13": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/vcf2snvalignment/vcf2snvalignment/1.8.2+galaxy1",
+            "errors": null,
+            "id": 13,
+            "input_connections": {
+                "invalid": {
+                    "id": 12,
+                    "output_name": "out_file1"
+                },
+                "ref_fasta": {
+                    "id": 1,
+                    "output_name": "output"
+                },
+                "vcf_collection": {
+                    "id": 10,
+                    "output_name": "bcf_combined"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "VCF 2 snvalignment",
+            "outputs": [
+                {
+                    "name": "positions",
+                    "type": "tabular"
+                },
+                {
+                    "name": "fasta",
+                    "type": "fasta"
+                },
+                {
+                    "name": "phylip",
+                    "type": "phylip"
+                },
+                {
+                    "name": "vcf2core",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2488,
+                "top": 200
+            },
+            "post_job_actions": {
+                "HideDatasetActionfasta": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "fasta"
+                },
+                "HideDatasetActionphylip": {
+                    "action_arguments": {},
+                    "action_type": "HideDatasetAction",
+                    "output_name": "phylip"
+                },
+                "RenameDatasetActionpositions": {
+                    "action_arguments": {
+                        "newname": "snvTable.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "positions"
+                },
+                "RenameDatasetActionvcf2core": {
+                    "action_arguments": {
+                        "newname": "vcf2core.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "vcf2core"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/vcf2snvalignment/vcf2snvalignment/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "d2096d0c149e",
+                "name": "vcf2snvalignment",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"invalid\": {\"__class__\": \"ConnectedValue\"}, \"ref_fasta\": {\"__class__\": \"ConnectedValue\"}, \"reference\": \"reference\", \"strain_list\": {\"select_list\": \"all\", \"__current_case__\": 2}, \"vcf_collection\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "e58fb6a4-3387-4f11-bce1-7f91c73d6475",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "positions",
+                    "uuid": "cf10c699-f16e-4557-8535-ddd47389af93"
+                },
+                {
+                    "label": null,
+                    "output_name": "vcf2core",
+                    "uuid": "c7809da5-19f7-494a-bb81-6d5219162222"
+                }
+            ]
+        },
+        "14": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.1",
+            "errors": null,
+            "id": 14,
+            "input_connections": {
+                "input": {
+                    "id": 13,
+                    "output_name": "phylip"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool Regex Find And Replace",
+                    "name": "input"
+                }
+            ],
+            "label": null,
+            "name": "Regex Find And Replace",
+            "outputs": [
+                {
+                    "name": "out_file1",
+                    "type": "input"
+                }
+            ],
+            "position": {
+                "left": 2774,
+                "top": 200
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout_file1": {
+                    "action_arguments": {
+                        "newname": "snvAlignment.phy"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out_file1"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/galaxyp/regex_find_replace/regex1/1.0.1",
+            "tool_shed_repository": {
+                "changeset_revision": "ae8c4b2488e7",
+                "name": "regex_find_replace",
+                "owner": "galaxyp",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"checks\": [{\"__index__\": 0, \"pattern\": \"'\", \"replacement\": \"\"}], \"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.0.1",
+            "type": "tool",
+            "uuid": "ef09d1c7-5a20-4817-b81d-0a23d090cade",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out_file1",
+                    "uuid": "b9df2326-b67c-4387-9d04-5d5bc27a4150"
+                }
+            ]
+        },
+        "15": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/filter_stats/filterstat/1.8.2+galaxy1",
+            "errors": null,
+            "id": 15,
+            "input_connections": {
+                "tabfile": {
+                    "id": 13,
+                    "output_name": "positions"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "Filter Stats",
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 2774,
+                "top": 342
+            },
+            "post_job_actions": {
+                "ChangeDatatypeActionout": {
+                    "action_arguments": {
+                        "newtype": "txt"
+                    },
+                    "action_type": "ChangeDatatypeAction",
+                    "output_name": "out"
+                },
+                "RenameDatasetActionout": {
+                    "action_arguments": {
+                        "newname": "filterStats.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/filter_stats/filterstat/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "2fbea749a1d1",
+                "name": "filter_stats",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"summary\": [\"invalids\"], \"tabfile\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "5758b538-fce0-4c6a-9e9e-95dc683d79fd",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out",
+                    "uuid": "8921eadd-2073-4608-a25e-225f918c3fa3"
+                }
+            ]
+        },
+        "16": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/iuc/phyml/phyml/3.3.20190909",
+            "errors": null,
+            "id": 16,
+            "input_connections": {
+                "input": {
+                    "id": 14,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [
+                {
+                    "description": "runtime parameter for tool PhyML",
+                    "name": "userInputTree"
+                }
+            ],
+            "label": null,
+            "name": "PhyML",
+            "outputs": [
+                {
+                    "name": "output_tree",
+                    "type": "nhx"
+                },
+                {
+                    "name": "output_stats",
+                    "type": "txt"
+                },
+                {
+                    "name": "output_stdout",
+                    "type": "txt"
+                }
+            ],
+            "position": {
+                "left": 3060,
+                "top": 200
+            },
+            "post_job_actions": {
+                "RenameDatasetActionoutput_stats": {
+                    "action_arguments": {
+                        "newname": "phylogeneticTreeStats.txt"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_stats"
+                },
+                "RenameDatasetActionoutput_tree": {
+                    "action_arguments": {
+                        "newname": "phylogeneticTree.newick"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "output_tree"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/phyml/phyml/3.3.20190909",
+            "tool_shed_repository": {
+                "changeset_revision": "2bf47d57ebb5",
+                "name": "phyml",
+                "owner": "iuc",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"equi_freq\": \"m\", \"gamma\": \"e\", \"input\": {\"__class__\": \"ConnectedValue\"}, \"move\": \"BEST\", \"nbSubstCat\": \"4\", \"nb_data_set\": \"1\", \"numStartSeed\": \"0\", \"optimisationTopology\": \"tlr\", \"phylip_format\": \"\", \"prop_invar\": \"e\", \"seq\": {\"type_of_seq\": \"nt\", \"__current_case__\": 0, \"tstv\": \"e\", \"model\": \"GTR\"}, \"support_condition\": {\"branchSupport\": \"-4\", \"__current_case__\": 3}, \"userInputTree\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "3.3.20190909",
+            "type": "tool",
+            "uuid": "f03c5331-c97e-4f65-b3eb-e976ed8c05d3",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "output_stats",
+                    "uuid": "eda0df2d-a3bf-48f8-b0f1-14a634842e5e"
+                },
+                {
+                    "label": null,
+                    "output_name": "output_tree",
+                    "uuid": "3751db48-73fe-462b-8249-399671ef12c6"
+                },
+                {
+                    "label": null,
+                    "output_name": "output_stdout",
+                    "uuid": "32e10655-c4e2-485e-8157-1b0dd72937ab"
+                }
+            ]
+        },
+        "17": {
+            "annotation": "",
+            "content_id": "toolshed.g2.bx.psu.edu/repos/nml/snv_matrix/snvmatrix/1.8.2+galaxy1",
+            "errors": null,
+            "id": 17,
+            "input_connections": {
+                "phylip": {
+                    "id": 14,
+                    "output_name": "out_file1"
+                }
+            },
+            "inputs": [],
+            "label": null,
+            "name": "SNV Matrix",
+            "outputs": [
+                {
+                    "name": "out",
+                    "type": "tabular"
+                }
+            ],
+            "position": {
+                "left": 3060,
+                "top": 412
+            },
+            "post_job_actions": {
+                "RenameDatasetActionout": {
+                    "action_arguments": {
+                        "newname": "snvMatrix.tsv"
+                    },
+                    "action_type": "RenameDatasetAction",
+                    "output_name": "out"
+                }
+            },
+            "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/snv_matrix/snvmatrix/1.8.2+galaxy1",
+            "tool_shed_repository": {
+                "changeset_revision": "4d3e3d7aa0c4",
+                "name": "snv_matrix",
+                "owner": "nml",
+                "tool_shed": "toolshed.g2.bx.psu.edu"
+            },
+            "tool_state": "{\"phylip\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": 0, \"__rerun_remap_job_id__\": null}",
+            "tool_version": "1.8.2+galaxy1",
+            "type": "tool",
+            "uuid": "9a6d04e9-56ba-46a5-99ef-cb987f7aefac",
+            "workflow_outputs": [
+                {
+                    "label": null,
+                    "output_name": "out",
+                    "uuid": "818a6aa9-90ae-4d3f-8dfd-dfe4942413d3"
+                }
+            ]
+        }
+    },
+    "tags": [],
+    "uuid": "b164bd2b-675f-4b88-9b4c-6b072399baf1",
+    "version": 1
+}

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow_structure.ga
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/irida_workflow_structure.ga
@@ -2,7 +2,7 @@
     "a_galaxy_workflow": "true",
     "annotation": "snvphyl",
     "format-version": "0.1",
-    "name": "SNVPhyl v1.2.2 Paired-End",
+    "name": "SNVPhyl v1.2.3 Paired-End",
     "steps": {
         "0": {
             "annotation": "",
@@ -32,7 +32,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "aa5be25d-46d2-47c9-904a-d02403c1061b"
+                    "uuid": "077da4fa-04b4-4d34-b271-e9844d0077c7"
                 }
             ]
         },
@@ -53,7 +53,7 @@
             "outputs": [],
             "position": {
                 "left": 200,
-                "top": 310
+                "top": 309
             },
             "tool_id": null,
             "tool_state": "{\"optional\": false}",
@@ -64,7 +64,7 @@
                 {
                     "label": null,
                     "output_name": "output",
-                    "uuid": "91e3b578-0dfa-4bbd-8131-e4a2fb793be3"
+                    "uuid": "7c4fac08-6e78-4031-b394-696013960c4f"
                 }
             ]
         },
@@ -158,7 +158,7 @@
             ],
             "position": {
                 "left": 486,
-                "top": 321
+                "top": 320
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/nml/smalt/smalt/0.7.6+galaxy1",
@@ -250,7 +250,7 @@
             ],
             "position": {
                 "left": 772,
-                "top": 392
+                "top": 390
             },
             "post_job_actions": {
                 "RenameDatasetActionoutput_log": {
@@ -311,12 +311,12 @@
             ],
             "position": {
                 "left": 772,
-                "top": 554
+                "top": 550
             },
             "post_job_actions": {},
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_mpileup/bcftools_mpileup/1.10",
             "tool_shed_repository": {
-                "changeset_revision": "f65383c7ed49",
+                "changeset_revision": "0dbff46d5a1b",
                 "name": "bcftools_mpileup",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -412,7 +412,7 @@
             ],
             "position": {
                 "left": 1058,
-                "top": 321
+                "top": 320
             },
             "post_job_actions": {
                 "HideDatasetActionoutput_file": {
@@ -430,7 +430,7 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_call/bcftools_call/1.10",
             "tool_shed_repository": {
-                "changeset_revision": "5801eff9ac7e",
+                "changeset_revision": "072f606e2e69",
                 "name": "bcftools_call",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
@@ -481,12 +481,12 @@
             },
             "tool_id": "toolshed.g2.bx.psu.edu/repos/iuc/bcftools_view/bcftools_view/1.10",
             "tool_shed_repository": {
-                "changeset_revision": "c4a9b38b435d",
+                "changeset_revision": "98d5499ead46",
                 "name": "bcftools_view",
                 "owner": "iuc",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"b\", \"sec_filter\": {\"min_ac\": \"\", \"max_ac\": \"\", \"select_genotype\": \"__none__\", \"types\": null, \"exclude_types\": null, \"known_or_novel\": null, \"min_alleles\": \"\", \"max_alleles\": \"\", \"phased\": null, \"min_af\": \"\", \"max_af\": \"\", \"uncalled\": null, \"private\": null}, \"sec_output\": {\"drop_genotypes\": \"false\", \"header\": null, \"compression_level\": \"\", \"invert_targets_file\": \"false\"}, \"sec_restrict\": {\"apply_filters\": \"\", \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}, \"include\": \"\", \"exclude\": \"\"}, \"sec_subset\": {\"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\", \"force_samples\": \"false\", \"no_update\": \"false\", \"trim_alt_alleles\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"input_file\": {\"__class__\": \"ConnectedValue\"}, \"output_type\": \"b\", \"sec_filter\": {\"min_ac\": \"\", \"max_ac\": \"\", \"select_genotype\": null, \"types\": null, \"exclude_types\": null, \"known_or_novel\": null, \"min_alleles\": \"\", \"max_alleles\": \"\", \"phased\": null, \"min_af\": \"\", \"max_af\": \"\", \"uncalled\": null, \"private\": null}, \"sec_output\": {\"drop_genotypes\": \"false\", \"header\": null, \"compression_level\": \"\", \"invert_targets_file\": \"false\"}, \"sec_restrict\": {\"apply_filters\": \"\", \"regions\": {\"regions_src\": \"__none__\", \"__current_case__\": 0}, \"targets\": {\"targets_src\": \"__none__\", \"__current_case__\": 0}, \"include\": \"\", \"exclude\": \"\"}, \"sec_subset\": {\"samples\": \"\", \"invert_samples\": \"false\", \"samples_file\": {\"__class__\": \"RuntimeValue\"}, \"invert_samples_file\": \"false\", \"force_samples\": \"false\", \"no_update\": \"false\", \"trim_alt_alleles\": \"false\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.10",
             "type": "tool",
             "uuid": "dc7c99fa-255b-4008-a352-422768e2083f",
@@ -754,12 +754,7 @@
                     "output_name": "phylip"
                 }
             },
-            "inputs": [
-                {
-                    "description": "runtime parameter for tool Regex Find And Replace",
-                    "name": "input"
-                }
-            ],
+            "inputs": [],
             "label": null,
             "name": "Regex Find And Replace",
             "outputs": [
@@ -788,7 +783,7 @@
                 "owner": "galaxyp",
                 "tool_shed": "toolshed.g2.bx.psu.edu"
             },
-            "tool_state": "{\"checks\": [{\"__index__\": 0, \"pattern\": \"'\", \"replacement\": \"\"}], \"input\": {\"__class__\": \"RuntimeValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
+            "tool_state": "{\"checks\": [{\"__index__\": 0, \"pattern\": \"'\", \"replacement\": \"\"}], \"input\": {\"__class__\": \"ConnectedValue\"}, \"__page__\": null, \"__rerun_remap_job_id__\": null}",
             "tool_version": "1.0.1",
             "type": "tool",
             "uuid": "ef09d1c7-5a20-4817-b81d-0a23d090cade",
@@ -822,7 +817,7 @@
             ],
             "position": {
                 "left": 2774,
-                "top": 342
+                "top": 340
             },
             "post_job_actions": {
                 "ChangeDatatypeActionout": {
@@ -926,8 +921,8 @@
             "workflow_outputs": [
                 {
                     "label": null,
-                    "output_name": "output_stats",
-                    "uuid": "eda0df2d-a3bf-48f8-b0f1-14a634842e5e"
+                    "output_name": "output_stdout",
+                    "uuid": "32e10655-c4e2-485e-8157-1b0dd72937ab"
                 },
                 {
                     "label": null,
@@ -936,8 +931,8 @@
                 },
                 {
                     "label": null,
-                    "output_name": "output_stdout",
-                    "uuid": "32e10655-c4e2-485e-8157-1b0dd72937ab"
+                    "output_name": "output_stats",
+                    "uuid": "eda0df2d-a3bf-48f8-b0f1-14a634842e5e"
                 }
             ]
         },
@@ -963,7 +958,7 @@
             ],
             "position": {
                 "left": 3060,
-                "top": 412
+                "top": 410
             },
             "post_job_actions": {
                 "RenameDatasetActionout": {
@@ -995,6 +990,6 @@
         }
     },
     "tags": [],
-    "uuid": "b164bd2b-675f-4b88-9b4c-6b072399baf1",
+    "uuid": "4a7fbdb1-e496-423e-a6a0-637d1f0469a1",
     "version": 1
 }

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/messages_en.properties
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/model/workflow/analysis/type/workflows/SNVPhyl/1.2.3/messages_en.properties
@@ -1,0 +1,24 @@
+# Workflow Description
+workflow.PHYLOGENOMICS.title=SNVPhyl Phylogenomics Pipeline
+workflow.PHYLOGENOMICS.description=Generate a Whole Genome Phylogeny from a set of samples and a reference genome based on Single Nucleotide Polymorphisms (SNVs) using the SNVPhyl pipeline.  This will provide a dendrogram as well as a table of all SNVs used and a SNV distance matrix between each sample. An example of how to run SNVPhyl and a description of the parameters can be found at https://irida.corefacility.ca/documentation/user/tutorials/snvphyl/.
+
+# Pipeline Submission
+pipeline.title.SNVPhyl=Pipelines - Phylogenomics
+pipeline.h1.SNVPhyl=SNVPhyl Phylogenomics Pipeline
+pipeline.parameters.modal-title.snvphyl=SNVPhyl Pipeline Parameters
+
+# Pipeline parameters
+pipeline.parameters.snvphyl.enable-density-filter=Enable SNV Density Filtering
+pipeline.parameters.snvphyl.enable-density-filter.enable=Enable
+pipeline.parameters.snvphyl.enable-density-filter.disable=Disable
+pipeline.parameters.snvphyl.minimum-percent-coverage=Minimum percent coverage of mapped reads
+pipeline.parameters.snvphyl.snv-abundance-ratio=SNV Abundance Ratio (Alternative Allele Fraction)
+pipeline.parameters.snvphyl.repeat-minimum-length=Minimum length for a repeat region
+pipeline.parameters.snvphyl.minimum-mapping-quality=Minimum mapping quality for inclusion of a read in a variant call
+pipeline.parameters.snvphyl.minimum-base-quality=Minimum base quality for including a read in a variant call
+pipeline.parameters.snvphyl.repeat-minimum-pid=Minimum percent identity for a repeat region
+pipeline.parameters.snvphyl.minimum-mean-mapping-quality=Minimum mean mapping quality of reads for inclusion of a variant call
+pipeline.parameters.snvphyl.minimum-read-coverage=Minimum read coverage for identification of variants
+pipeline.parameters.snvphyl.filter-density-window-size=The window size used for searching for high-density SNV regions.
+pipeline.parameters.snvphyl.filter-density-threshold=The threshold of SNVs within the defined window size to flag high-density SNV regions.
+


### PR DESCRIPTION
## Description of changes
* Updates SNVPhyl to version `1.2.3` (from `1.2.2`) which includes all updated tools which can all be properly installed in Galaxy.
* Updates the IRIDA/Galaxy Docker image to include this new version of SNVPhyl and also updates from Galaxy 20.05 to 20.09 (the latest Galaxy Docker image).
    * Updates the integration test suite to use this newer Docker image with the latest SNVPhyl pipeline.

In order to test this out, you can install the newest IRIDA/Galaxy Docker by the command:

```bash
docker run -d -p 48888:80 -v /path/to/irida/data:/path/to/irida/data phacnml/galaxy-irida-20.09
```

Where `/path/to/irida/data` is the location of your IRIDA data directories and `48888` is the port that Galaxy should run on.

Once the IRIDA/Galaxy Docker container is running you can connect IRIDA to this Galaxy version and test out the pipelines.

Tested with the following versions of Galaxy:
* Galaxy `21.01` (latest stable release)
* Galaxy `20.09` (version in Docker)
* Galaxy `18.05` (version used by our IRIDA)
    * For this version of Galaxy it looks like you need to remove `bcftools_view` and re-install the newer version. This has been documented in our SNVPhyl install instructions.

*Note: this is a **hotfix** and so it must be merged into `master` and `development`.*

## Related issue
Fix for issue #1018 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
