### PR TITLE
Casting to ResponseResource in FastaView

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/spring/view/FastaView.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/spring/view/FastaView.java
@@ -1,6 +1,7 @@
 package ca.corefacility.bioinformatics.irida.web.spring.view;
 
 import ca.corefacility.bioinformatics.irida.model.irida.IridaSequenceFile;
+import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResponseResource;
 import ca.corefacility.bioinformatics.irida.web.controller.api.RESTGenericController;
 
 import com.google.common.net.HttpHeaders;
@@ -39,7 +40,8 @@ public class FastaView extends AbstractView {
 	@Override
 	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request,
 			HttpServletResponse response) throws Exception {
-		IridaSequenceFile sfr = (IridaSequenceFile) model.get(RESTGenericController.RESOURCE_NAME);
+		IridaSequenceFile sfr = (IridaSequenceFile) ((ResponseResource) model.get(
+				RESTGenericController.RESOURCE_NAME)).getResource();
 		Path fileContent = sfr.getFile();
 		String filename = fileContent.getFileName()
 				.toString();


### PR DESCRIPTION
## Description of changes
Casting the model `resource` to `ResponseResource` in FastaView.  This is similar to the other view classes, it looks like this one got missed.  Prior to this fix if you requested the content of an assembly you got the error:
```
class ca.corefacility.bioinformatics.irida.web.assembler.resource.ResponseResource cannot be cast to class ca.corefacility.bioinformatics.irida.model.irida.IridaSequenceFile
```

## Related issue
Related to #978 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
