### PR TITLE
HOTFIX: Remote project manager members/groups permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changes
 --------------
 * [UI]: Fixed bug where a remote project in `UNSYNCHRONIZED` state would have the Sync buttons disabled on the Project Synchronization Settings page. (21.05.1)
 * [UI]: Added back `Users` option for managers in main navigation. (21.05.1)
+* [UI]: Fixed bug which prevented a manager on a remote project from adding/removing members and groups. (21.05.2)
 
 21.01 to 21.05
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.05.1</version>
+	<version>21.05.2</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
+++ b/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
@@ -69,7 +69,7 @@ export function ProjectMembersTable({ projectId }) {
     },
   ];
 
-  if (project.canManage || project.canManageRemote) {
+  if (project.canManageRemote) {
     columns.push({
       align: "right",
       render(text, user) {
@@ -109,7 +109,7 @@ export function ProjectMembersTable({ projectId }) {
   return (
     <PagedTable
       buttons={[
-        project.canManage || project.canManageRemote ? (
+        project.canManageRemote ? (
           <AddMemberButton
             key="add-members-btn"
             label={i18n("AddMemberButton.label")}

--- a/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
+++ b/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
@@ -69,7 +69,7 @@ export function ProjectMembersTable({ projectId }) {
     },
   ];
 
-  if (project.canManage) {
+  if (project.canManage || project.canManageRemote) {
     columns.push({
       align: "right",
       render(text, user) {
@@ -109,7 +109,7 @@ export function ProjectMembersTable({ projectId }) {
   return (
     <PagedTable
       buttons={[
-        project.canManage ? (
+        project.canManage || project.canManageRemote ? (
           <AddMemberButton
             key="add-members-btn"
             label={i18n("AddMemberButton.label")}

--- a/src/main/webapp/resources/js/components/project-user-groups/ProjectUserGroupsTable.jsx
+++ b/src/main/webapp/resources/js/components/project-user-groups/ProjectUserGroupsTable.jsx
@@ -56,7 +56,7 @@ export function ProjectUserGroupsTable({ projectId }) {
     },
   ];
 
-  if (project.canManage) {
+  if (project.canManage || project.canManageRemote) {
     columns.push({
       align: "right",
       render(text, group) {
@@ -77,7 +77,7 @@ export function ProjectUserGroupsTable({ projectId }) {
   return (
     <PagedTable
       buttons={[
-        project.canManage ? (
+        project.canManage || project.canManageRemote ? (
           <AddGroupButton
             key="add-group-btn"
             defaultRole="PROJECT_USER"

--- a/src/main/webapp/resources/js/components/project-user-groups/ProjectUserGroupsTable.jsx
+++ b/src/main/webapp/resources/js/components/project-user-groups/ProjectUserGroupsTable.jsx
@@ -56,7 +56,7 @@ export function ProjectUserGroupsTable({ projectId }) {
     },
   ];
 
-  if (project.canManage || project.canManageRemote) {
+  if (project.canManageRemote) {
     columns.push({
       align: "right",
       render(text, group) {
@@ -77,7 +77,7 @@ export function ProjectUserGroupsTable({ projectId }) {
   return (
     <PagedTable
       buttons={[
-        project.canManage || project.canManageRemote ? (
+        project.canManageRemote ? (
           <AddGroupButton
             key="add-group-btn"
             defaultRole="PROJECT_USER"

--- a/src/main/webapp/resources/js/components/roles/ProjectRole.jsx
+++ b/src/main/webapp/resources/js/components/roles/ProjectRole.jsx
@@ -40,7 +40,7 @@ export function ProjectRole({ projectId, item, updateRoleFn }) {
       .finally(() => setLoading(false));
   };
 
-  return project.canManage ? (
+  return project.canManageRemote ? (
     <Select
       className="t-role-select"
       value={role}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectMembersPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectMembersPage.java
@@ -48,6 +48,13 @@ public class ProjectMembersPage extends AbstractPage {
 		return PageFactory.initElements(driver, ProjectMembersPage.class);
 	}
 
+	public static ProjectMembersPage goToRemoteProject(WebDriver driver, Long projectId) {
+		get(driver, "projects/"+ projectId +"/settings/members");
+		table = AntTable.getTable(driver);
+		addMemberButton = AddMemberButton.getAddMemberButton(driver);
+		return PageFactory.initElements(driver, ProjectMembersPage.class);
+	}
+
 	public String getPageHeaderTitle() {
 		return title.getText();
 	}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSyncPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSyncPage.java
@@ -73,6 +73,7 @@ public class ProjectSyncPage extends AbstractPage {
 		WebDriverWait wait = new WebDriverWait(driver, 10);
 		wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
 		submitBtn.click();
+		waitForTime(500);
 	}
 
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectMembersPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectMembersPageIT.java
@@ -9,6 +9,11 @@ import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.ProjectMembersPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.clients.ClientDetailsPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.clients.CreateClientPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectDetailsPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectSyncPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.utilities.RemoteApiUtilities;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import com.google.common.collect.ImmutableList;
@@ -64,4 +69,58 @@ public class ProjectMembersPageIT extends AbstractIridaUIITChromeDriver {
 		ProjectMembersPage page = ProjectMembersPage.goTo(driver());
 		assertFalse("Add Members button should not be visible", page.isAddMemberBtnVisible());
 	}
+
+	@Test
+	public void testRemoteProjectManagerPageSetup() {
+		LoginPage.loginAsAdmin(driver());
+
+		CreateClientPage createClientPage;
+		ProjectSyncPage page;
+
+		String clientId = "myClient";
+		String clientSecret;
+
+		//create the oauth client
+		String redirectLocation = RemoteApiUtilities.getRedirectLocation();
+		createClientPage = new CreateClientPage(driver());
+		createClientPage.goTo();
+		createClientPage.createClientWithDetails(clientId, "authorization_code", redirectLocation, true, false);
+		ClientDetailsPage detailsPage = new ClientDetailsPage(driver());
+		clientSecret = detailsPage.getClientSecret();
+
+		RemoteApiUtilities.addRemoteApi(driver(), clientId, clientSecret);
+		page = ProjectSyncPage.goTo(driver());
+		page.selectApi(0);
+		final String name = "project";
+
+		page.selectProjectInListing(name);
+
+		String url = page.getProjectUrl();
+		assertFalse("URL should not be empty", url.isEmpty());
+		page.submitProject();
+
+		String pathTokens[] = driver().getCurrentUrl().split("/");
+		Long projectId = Long.valueOf(pathTokens[pathTokens.length-1]);
+
+		ProjectMembersPage remoteProjectMembersPage = ProjectMembersPage.goToRemoteProject(driver(), projectId);
+		assertEquals("Should be 1 members in the project", 1, remoteProjectMembersPage.getNumberOfMembers());
+		remoteProjectMembersPage.addUserToProject("Mr. Manager");
+		remoteProjectMembersPage.updateUserRole(0, ProjectRole.PROJECT_OWNER.toString());
+		assertEquals("Should be 2 members in the project", 2, remoteProjectMembersPage.getNumberOfMembers());
+
+		LoginPage.loginAsManager(driver());
+
+		ProjectDetailsPage remoteProjectDetailsPage = ProjectDetailsPage.goTo(driver(), projectId);
+		String dataProjectName = remoteProjectDetailsPage.getProjectName();
+		assertEquals("Should be on the remote project", dataProjectName, name);
+
+		ProjectMembersPage managerRemoteProjectMembersPage = ProjectMembersPage.goToRemoteProject(driver(), projectId);
+		assertTrue("Add member button should be visible", managerRemoteProjectMembersPage.isAddMemberBtnVisible());
+
+		managerRemoteProjectMembersPage.addUserToProject("testUser");
+		assertEquals("Should be 3 members in the project", 3, remoteProjectMembersPage.getNumberOfMembers());
+		managerRemoteProjectMembersPage.removeUser(0);
+		assertEquals("Should be 2 members in the project", 2, remoteProjectMembersPage.getNumberOfMembers());
+	}
+
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectUserGroupsPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectUserGroupsPageIT.java
@@ -2,9 +2,15 @@ package ca.corefacility.bioinformatics.irida.ria.integration.projects;
 
 import org.junit.Test;
 
+import ca.corefacility.bioinformatics.irida.model.enums.ProjectRole;
 import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.ProjectMembersPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.clients.ClientDetailsPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.clients.CreateClientPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectSyncPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectUserGroupsPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.utilities.RemoteApiUtilities;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 
@@ -32,5 +38,54 @@ public class ProjectUserGroupsPageIT extends AbstractIridaUIITChromeDriver {
 
 		page.removeUserGroups(0);
 		assertEquals("Should be no user groups", 0, page.getNumberOfUserGroups());
+	}
+
+	@Test
+	public void testRemoteProjectPageAsAManager() {
+		LoginPage.loginAsAdmin(driver());
+
+		CreateClientPage createClientPage;
+		ProjectSyncPage page;
+
+		String clientId = "myClient";
+		String clientSecret;
+
+		//create the oauth client
+		String redirectLocation = RemoteApiUtilities.getRedirectLocation();
+		createClientPage = new CreateClientPage(driver());
+		createClientPage.goTo();
+		createClientPage.createClientWithDetails(clientId, "authorization_code", redirectLocation, true, false);
+		ClientDetailsPage detailsPage = new ClientDetailsPage(driver());
+		clientSecret = detailsPage.getClientSecret();
+
+		RemoteApiUtilities.addRemoteApi(driver(), clientId, clientSecret);
+		page = ProjectSyncPage.goTo(driver());
+		page.selectApi(0);
+		final String name = "project";
+
+		page.selectProjectInListing(name);
+
+		String url = page.getProjectUrl();
+		assertFalse("URL should not be empty", url.isEmpty());
+		page.submitProject();
+
+		String pathTokens[] = driver().getCurrentUrl().split("/");
+		Long projectId = Long.valueOf(pathTokens[pathTokens.length-1]);
+
+		ProjectMembersPage remoteProjectMembersPage = ProjectMembersPage.goToRemoteProject(driver(), projectId);
+		assertEquals("Should be 1 members in the project", 1, remoteProjectMembersPage.getNumberOfMembers());
+		remoteProjectMembersPage.addUserToProject("Mr. Manager");
+		remoteProjectMembersPage.updateUserRole(0, ProjectRole.PROJECT_OWNER.toString());
+		assertEquals("Should be 2 members in the project", 2, remoteProjectMembersPage.getNumberOfMembers());
+
+		LoginPage.loginAsManager(driver());
+		ProjectUserGroupsPage projectUserGroupsPage = ProjectUserGroupsPage.goToPage(driver(), projectId);
+		assertTrue("Managers can see the add user groups button.", projectUserGroupsPage.isAddUserGroupButtonVisible());
+		assertEquals("Should be no user groups", 0, projectUserGroupsPage.getNumberOfUserGroups());
+		projectUserGroupsPage.addUserGroup("group 1");
+		assertEquals("Should be one user groups", 1, projectUserGroupsPage.getNumberOfUserGroups());
+
+		projectUserGroupsPage.removeUserGroups(0);
+		assertEquals("Should be no user groups", 0, projectUserGroupsPage.getNumberOfUserGroups());
 	}
 }


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

This hotfix fixes bug preventing a manager on a remote project from adding and removing members/groups.

**To test:**

1) Create a synchronized project
2) Add a user to the sync'd project and give them a `Manager` role
3) Login as the manager user from above
4) In the remote `Project -> Settings -> Members` you should be able to see the `Add Project Member` button and be able to add a user to the project.
5) In the remote `Project -> Settings -> Groups` you should be able to see the `Add User Group` button and be able to add a user group to the project.
6) You should also be able to remove the users and groups added above

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

Fixes #1043 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [X] Tests added (or description of how to test) for any new features.
~* [] User documentation updated for UI or technical changes.~
