### PR TITLE
Hiding template fields when user is not allowed to read

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIMetadataService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIMetadataService.java
@@ -118,7 +118,7 @@ public class UIMetadataService {
 	 */
 	public List<ProjectMetadataField> getMetadataFieldsForProject(Long projectId) {
 		Project project = projectService.read(projectId);
-		List<MetadataTemplateField> fields = templateService.getPermittedFieldsForCurrentUser(project);
+		List<MetadataTemplateField> fields = templateService.getPermittedFieldsForCurrentUser(project, true);
 		return addRestrictionsToMetadataFields(project, fields);
 	}
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/MetadataTemplateService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/sample/MetadataTemplateService.java
@@ -146,17 +146,20 @@ public interface MetadataTemplateService extends CRUDService<Long, MetadataTempl
 	/**
 	 * Get all {@link MetadataTemplateField} that are permitted to be read by a given {@link ProjectRole}
 	 *
-	 * @param project the {@link Project} to get fields for
-	 * @param role    the {@link ProjectRole} to request
+	 * @param project               the {@link Project} to get fields for
+	 * @param role                  the {@link ProjectRole} to request
+	 * @param includeTemplateFields whether to include metadata template fields in the allowed fields
 	 * @return the {@link MetadataTemplateField} the given role can read
 	 */
-	public List<MetadataTemplateField> getPermittedFieldsForRole(Project project, ProjectRole role);
+	public List<MetadataTemplateField> getPermittedFieldsForRole(Project project, ProjectRole role,
+			boolean includeTemplateFields);
 
 	/**
 	 * Get all {@link MetadataTemplateField} that the currently logged in user is allowed to read
 	 *
-	 * @param project the {@link Project} to request fields from
+	 * @param project               the {@link Project} to request fields from
+	 * @param includeTemplateFields whether to include metadata template fields in the allowed fields
 	 * @return a list of {@link MetadataTemplateField} collecting the allowed {@link MetadataTemplateField}
 	 */
-	public List<MetadataTemplateField> getPermittedFieldsForCurrentUser(Project project);
+	public List<MetadataTemplateField> getPermittedFieldsForCurrentUser(Project project, boolean includeTemplateFields);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/samples/RESTSampleMetadataController.java
@@ -94,7 +94,7 @@ public class RESTSampleMetadataController {
 		Project project = projectService.read(projectId);
 
 		List<MetadataTemplateField> metadataTemplateFields = metadataTemplateService.getPermittedFieldsForCurrentUser(
-				project);
+				project, true);
 
 		List<Sample> samples = sampleService.getSamplesForProjectShallow(project);
 		ProjectMetadataResponse metadataResponse = sampleService.getMetadataForProject(project,

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/LineListControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/LineListControllerTest.java
@@ -54,7 +54,7 @@ public class LineListControllerTest {
 		long projectId = 1L;
 		lineListController.getProjectMetadataTemplateFields(projectId, Locale.ENGLISH);
 		verify(projectService, times(1)).read(projectId);
-		verify(metadataTemplateService, times(1)).getPermittedFieldsForCurrentUser(any(Project.class));
+		verify(metadataTemplateService, times(1)).getPermittedFieldsForCurrentUser(any(Project.class), true);
 	}
 
 	@Test
@@ -77,7 +77,7 @@ public class LineListControllerTest {
 		when(projectService.read(projectId)).thenReturn(project);
 		when(sampleService.getMetadataForProject(project, fieldList)).thenReturn(new ProjectMetadataResponse(project,metadata));
 		when(sampleService.getSamplesForProjectShallow(project)).thenReturn(Lists.newArrayList(s1, s2));
-		when(metadataTemplateService.getPermittedFieldsForCurrentUser(project)).thenReturn(fieldList);
+		when(metadataTemplateService.getPermittedFieldsForCurrentUser(project, true)).thenReturn(fieldList);
 		List<UISampleMetadata> projectSamplesMetadataEntries = lineListController.getProjectSamplesMetadataEntries(
 				projectId);
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/sample/SampleServiceImplIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/integration/sample/SampleServiceImplIT.java
@@ -484,7 +484,7 @@ public class SampleServiceImplIT {
 		Project project = projectService.read(1L);
 
 		List<MetadataTemplateField> permittedFieldsForCurrentUser = metadataTemplateService.getPermittedFieldsForCurrentUser(
-				project);
+				project, true);
 
 		ProjectMetadataResponse metadataForProject = sampleService.getMetadataForProject(project,
 				permittedFieldsForCurrentUser);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/samples/RESTSampleMetadataControllerTest.java
@@ -61,7 +61,7 @@ public class RESTSampleMetadataControllerTest {
 
 		when(projectService.read(p1.getId())).thenReturn(p1);
 		when(sampleService.getSamplesForProjectShallow(p1)).thenReturn(Lists.newArrayList(s1, s2));
-		when(metadataTemplateService.getPermittedFieldsForCurrentUser(p1)).thenReturn(fieldList);
+		when(metadataTemplateService.getPermittedFieldsForCurrentUser(p1, true)).thenReturn(fieldList);
 		when(sampleService.getMetadataForProject(p1, fieldList)).thenReturn(new ProjectMetadataResponse(p1,metadata));
 
 		ModelMap modelMap = metadataController.getProjectSampleMetadata(p1.getId());


### PR DESCRIPTION
## Description of changes
Added code to hide metadata template fields from the line list when a user does not have permissions to read those fields.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
