### PR TITLE
HOTFIX: Fixed issue with metadate template redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes
 * [UI]: Fixed bug where a remote project in `UNSYNCHRONIZED` state would have the Sync buttons disabled on the Project Synchronization Settings page. (21.05.1)
 * [UI]: Added back `Users` option for managers in main navigation. (21.05.1)
 * [UI]: Fixed bug which prevented a manager on a remote project from adding/removing members and groups. (21.05.2)
+* [UI]: Fixed bug which caused newly created metadata templates to no be displayed after creation. (21.05.3)
 
 21.01 to 21.05
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.05.2</version>
+	<version>21.05.3</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/webapp/resources/js/pages/projects/settings/components/metadata/MetadataTemplateManager.jsx
+++ b/src/main/webapp/resources/js/pages/projects/settings/components/metadata/MetadataTemplateManager.jsx
@@ -44,7 +44,7 @@ const { Paragraph, Text } = Typography;
 export default function MetadataTemplateManager({ id, projectId }) {
   const { data: allFields } = useGetMetadataFieldsForProjectQuery(projectId);
 
-  const { data: templates, isLoading } = useGetTemplatesForProjectQuery(
+  const { data: templates, isFetching } = useGetTemplatesForProjectQuery(
     projectId
   );
   const { data: project = {} } = useGetProjectDetailsQuery(projectId);
@@ -62,7 +62,7 @@ export default function MetadataTemplateManager({ id, projectId }) {
     are found then we redirect to the metadata fields page so the user can
     create one.
      */
-    if (!isLoading) {
+    if (!isFetching) {
       const found = templates.find((template) => template.identifier == id);
 
       if (found) {
@@ -70,16 +70,16 @@ export default function MetadataTemplateManager({ id, projectId }) {
         setTemplate(newTemplate);
         setFields(addKeysToList(fields, "field"));
       } else if (templates.length === 0) {
-        navigate(`../metadata-fields`).then(() =>
+        navigate(`../fields`).then(() =>
           notification.warn({ message: i18n("MetadataTemplate.no-templates") })
         );
       } else {
-        navigate(`../metadata-templates`).then(() =>
+        navigate(`../templates`).then(() =>
           notification.warn({ message: i18n("MetadataTemplate.not-found") })
         );
       }
     }
-  }, [id, isLoading, templates]);
+  }, [id, isFetching, templates]);
 
   React.useEffect(() => {
     if (Array.isArray(fields) && Array.isArray(allFields)) {
@@ -208,7 +208,7 @@ export default function MetadataTemplateManager({ id, projectId }) {
       onBack={() => navigate("./")}
       extra={displayHeaderExtras(template)}
     >
-      <Skeleton loading={isLoading}>
+      <Skeleton loading={isFetching}>
         <List itemLayout="vertical" size="small">
           <List.Item>
             <List.Item.Meta

--- a/src/main/webapp/resources/js/pages/projects/settings/components/metadata/MetadataTemplates.jsx
+++ b/src/main/webapp/resources/js/pages/projects/settings/components/metadata/MetadataTemplates.jsx
@@ -78,7 +78,7 @@ export default function MetadataTemplates({ projectId }) {
   }, [existingTemplates, fields]);
 
   const [BASE_URL] = React.useState(() =>
-    setBaseUrl(`/projects/${projectId}/metadata-templates`)
+    setBaseUrl(`/projects/${projectId}/templates`)
   );
 
   /**


### PR DESCRIPTION
## Description of changes

Fixes bug that resulted from old urls still in the create metadata templates, and an incorrect variable `isLoading` instead of `isFetching`

## Related issue

N/A

## Checklist

Things for the developer to confirm they've done before the PR should be accepted:

*   [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
*   [ ] ~Tests added (or description of how to test) for any new features.~
*   [ ] ~User documentation updated for UI or technical changes.~