### PR TITLE
Add labels to admin statistics

### DIFF
--- a/src/main/webapp/resources/js/pages/admin/chart-config.js
+++ b/src/main/webapp/resources/js/pages/admin/chart-config.js
@@ -67,7 +67,7 @@ export function getTinyChartConfiguration(data) {
     autoFit: true,
     height: 80,
     columnWidthRatio: 1,
-    tooltip: false,
+    tooltip: { showMarkers: false },
   };
 
   return config;

--- a/src/main/webapp/resources/js/pages/admin/chart-config.js
+++ b/src/main/webapp/resources/js/pages/admin/chart-config.js
@@ -68,6 +68,10 @@ export function getTinyChartConfiguration(data) {
     height: 80,
     columnWidthRatio: 1,
     tooltip: { showMarkers: false },
+    label: {
+      position: 'middle',
+      style: { fill: '#FFFFFF', opacity: 0.6 },
+    },
   };
 
   return config;


### PR DESCRIPTION
## Description of changes
As suggested, I  added mouse over values to charts on admin statistic page. 



I tried configuring the x-axis by setting AxisLabelCfg. The charts on this page are tiny column charts and only accept integer arrays. I don't know if it's possible to set the x-axis. I might need to convert it to a column chart. I was able to add labels. If it's not too busy we use these.

![image](https://user-images.githubusercontent.com/325703/126812407-4320980b-8b73-4b77-9f70-91a6b255e6f3.png)

## Related issue
Fixes #953

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] ~Tests added (or description of how to test) for any new features.~
* [ ] ~User documentation updated for UI or technical changes.~
