### PR TITLE
Fix create first metadata template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes
 * [Test]: Updated chromedriver to version 92.0.0.
 * [UI]: Updated Project Single Sample Analyses Outputs pages to use Ant Design.
 * [UI]: Updated Your Single Sample Analysis Outputs page to use Ant Design.
+* [UI] Fixed bug which prevented the first created metadata template from being displayed after creation.
 
 21.01 to 21.05
 --------------

--- a/src/main/webapp/resources/js/pages/projects/settings/components/metadata/MetadataTemplateCreate.jsx
+++ b/src/main/webapp/resources/js/pages/projects/settings/components/metadata/MetadataTemplateCreate.jsx
@@ -26,7 +26,10 @@ export function MetadataTemplateCreate({ children, projectId, fields = [] }) {
   const [visible, setVisible] = React.useState(false);
   const [fieldsState, setFieldsState] = React.useState([]);
   const [form] = Form.useForm();
-  const { data: templates } = useGetTemplatesForProjectQuery(projectId);
+  const {
+    data: templates,
+    refetch: refetchTemplates,
+  } = useGetTemplatesForProjectQuery(projectId);
 
   React.useEffect(() => {
     if (fields.length) {
@@ -59,6 +62,7 @@ export function MetadataTemplateCreate({ children, projectId, fields = [] }) {
       .then((template) => {
         form.resetFields(Object.keys(values));
         setVisible(false);
+        refetchTemplates();
         navigate(`templates/${template.identifier}`);
       })
       .catch(({ data }) => notification.info({ message: data.error }));


### PR DESCRIPTION
## Description of changes
Force the refresh of the metadata templates list allows for the first template to be created to be displayed nicely.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] ~~Tests added (or description of how to test) for any new features.~~
* [ ] ~~User documentation updated for UI or technical changes.~~
