### PR TITLE
Fix for verifying the project name length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changes
 * [Test]: Updated chromedriver to version 92.0.0.
 * [UI]: Updated Project Single Sample Analyses Outputs pages to use Ant Design.
 * [UI]: Updated Your Single Sample Analysis Outputs page to use Ant Design.
+* [UI]: Fixed bug where the length of the project name was not checked on project creation.
 
 21.01 to 21.05
 --------------

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -252,7 +252,7 @@ CreateProject.title=Create New Project
 CreateProjectDetails.name=Project Name
 CreateProjectDetails.name-required=A name is required for every project
 CreateProjectDetails.name-characters=A project name can only have letters, numbers, spaces, _ and -.
-CreateProjectDetails.length=The ${label} must be at least ${min} characters long
+CreateProjectDetails.length=The project name must be at least 4 characters long
 CreateProjectDetails.url=Expected format of url is https://wikiname.org
 
 CreateProjectSamples.locked=Some samples in the cart are locked and cannot be copied to other projects.

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -252,7 +252,7 @@ CreateProject.title=Create New Project
 CreateProjectDetails.name=Project Name
 CreateProjectDetails.name-required=A name is required for every project
 CreateProjectDetails.name-characters=A project name can only have letters, numbers, spaces, _ and -.
-CreateProjectDetails.length=The project name must be at least 4 characters long
+CreateProjectDetails.length=The project name must be at least 5 characters long
 CreateProjectDetails.url=Expected format of url is https://wikiname.org
 
 CreateProjectSamples.locked=Some samples in the cart are locked and cannot be copied to other projects.

--- a/src/main/webapp/resources/js/pages/projects/create/CreateProjectDetails.jsx
+++ b/src/main/webapp/resources/js/pages/projects/create/CreateProjectDetails.jsx
@@ -40,6 +40,7 @@ export function CreateProjectDetails({ form }) {
       <Form.Item
         name="name"
         label={i18n("CreateProjectDetails.name")}
+        required
         rules={[
           {
             required: true,
@@ -48,6 +49,11 @@ export function CreateProjectDetails({ form }) {
           {
             pattern: /^[a-zA-Z0-9\s_-]+$/,
             message: i18n("CreateProjectDetails.name-characters"),
+          },
+          {
+            type: "string",
+            min: 4,
+            message: i18n("CreateProjectDetails.length"),
           },
         ]}
       >

--- a/src/main/webapp/resources/js/pages/projects/create/CreateProjectDetails.jsx
+++ b/src/main/webapp/resources/js/pages/projects/create/CreateProjectDetails.jsx
@@ -52,7 +52,7 @@ export function CreateProjectDetails({ form }) {
           },
           {
             type: "string",
-            min: 4,
+            min: 5,
             message: i18n("CreateProjectDetails.length"),
           },
         ]}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/CreateProjectComponent.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/CreateProjectComponent.java
@@ -1,5 +1,6 @@
 package ca.corefacility.bioinformatics.irida.ria.integration.pages;
 
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -41,6 +42,9 @@ public class CreateProjectComponent extends AbstractPage {
 	@FindBy(css = ".t-samples th .ant-checkbox")
 	private WebElement selectAllSamples;
 
+	@FindBy(css = ".ant-form-item-explain div")
+	WebElement nameError;
+
 	public CreateProjectComponent(WebDriver driver) {
 		super(driver);
 	}
@@ -56,6 +60,8 @@ public class CreateProjectComponent extends AbstractPage {
 	}
 
 	public void enterProjectName(String name) {
+		nameInput.sendKeys(Keys.CONTROL + "a");
+		nameInput.sendKeys(Keys.DELETE);
 		nameInput.sendKeys(name);
 	}
 
@@ -83,5 +89,11 @@ public class CreateProjectComponent extends AbstractPage {
 
 	public void selectAllSamples() {
 		selectAllSamples.click();
+	}
+
+	public String getNameWarning() {
+		WebDriverWait wait = new WebDriverWait(driver, 1);
+		wait.until(ExpectedConditions.visibilityOf(nameError));
+		return nameError.getText();
 	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectsPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectsPage.java
@@ -9,8 +9,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
  * <p>

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/CreateProjectIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/CreateProjectIT.java
@@ -33,6 +33,16 @@ public class CreateProjectIT extends AbstractIridaUIITChromeDriver {
 		ProjectsPage.goToProjectsPage(driver(), false);
 		CreateProjectComponent createComponent = CreateProjectComponent.initializeComponent(driver());
 		createComponent.displayForm();
+
+		// Test invalid entries
+		createComponent.enterProjectName("SMA");
+		Assert.assertEquals("Should have a name length error", "The project name must be at least 5 characters long", createComponent.getNameWarning());
+		createComponent.enterProjectName("");
+		Assert.assertEquals("Should display a required error", "A name is required for every project", createComponent.getNameWarning());
+		createComponent.enterProjectName("TE\0*");
+		Assert.assertEquals("Should display a invalid character warning", "A project name can only have letters, numbers, spaces, _ and -.", createComponent.getNameWarning());
+
+		// Test correct
 		createComponent.enterProjectName(name);
 		createComponent.enterProjectDescription(description);
 		createComponent.goToNextStep();


### PR DESCRIPTION
## Description of changes
Fixes an issue where the length of the project name was not checked on creation.
The validation now checks:
* Length
* Restricted characters
* Required

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* ~~[ ] Tests added (or description of how to test) for any new features.~~
* ~~[ ] User documentation updated for UI or technical changes.~~
