### PR TITLE
Hotfix - Updated metadata queries for performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes
 * [UI]: Fixed bug which prevented a manager on a remote project from adding/removing members and groups. (21.05.2)
 * [UI]: Fixed bug which caused newly created metadata templates to no be displayed after creation. (21.05.3)
 * [UI]: Fixed bug that would send many emails to users when they request a pipeline completion email. (21.05.3)
+* [Database]: Updated query to improve performance for metadata in REST API and line list. (21.05.4)
 
 21.01 to 21.05
 --------------

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>21.05.3</version>
+	<version>21.05.4</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryImpl.java
@@ -39,15 +39,21 @@ public class MetadataEntryRepositoryImpl implements MetadataEntryRepositoryCusto
 		MapSqlParameterSource parameters = new MapSqlParameterSource();
 		parameters.addValue("project", project.getId());
 
-		//get the metadata fields available in the project
+		/*
+		 * The below code for loading the metadata fields could be simplified into a single query, but the previous
+		 * 3-join query was taking 10s of seconds to load for large projects.  The 2 query process below for loading the
+		 * fields is providing significantly better performance than loading fields in a single 3-join query.
+		 */
+
+		//First get all the field IDs that are associated with this project
 		String fieldIdQueryString = "SELECT DISTINCT e.field_id FROM metadata_entry e INNER JOIN project_sample p ON e.sample_id=p.sample_id WHERE p.project_id=:project";
 		parameters.addValue("project", project.getId());
 		List<Long> fieldIds = tmpl.queryForList(fieldIdQueryString, parameters, Long.class);
 
+		//next load the full fields
 		String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
 		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
 		nativeQuery.setParameter("fields", fieldIds);
-
 		List<MetadataTemplateField> fields = nativeQuery.getResultList();
 
 		//Collect the fields into a map from ID to field for use later

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryImpl.java
@@ -40,9 +40,14 @@ public class MetadataEntryRepositoryImpl implements MetadataEntryRepositoryCusto
 		parameters.addValue("project", project.getId());
 
 		//get the metadata fields available in the project
-		String queryString = "SELECT DISTINCT f.* FROM project_sample p INNER JOIN metadata_entry s ON p.sample_id=s.sample_id INNER JOIN metadata_field f ON s.field_id=f.id WHERE p.project_id=:project";
+		String fieldIdQueryString = "SELECT DISTINCT e.field_id FROM metadata_entry e INNER JOIN project_sample p ON e.sample_id=p.sample_id WHERE p.project_id=:project";
+		parameters.addValue("project", project.getId());
+		List<Long> fieldIds = tmpl.queryForList(fieldIdQueryString, parameters, Long.class);
+
+		String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
 		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
-		nativeQuery.setParameter("project", project.getId());
+		nativeQuery.setParameter("fields", fieldIds);
+
 		List<MetadataTemplateField> fields = nativeQuery.getResultList();
 
 		//Collect the fields into a map from ID to field for use later

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataFieldRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataFieldRepositoryImpl.java
@@ -33,15 +33,21 @@ public class MetadataFieldRepositoryImpl implements MetadataFieldRepositoryCusto
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<MetadataTemplateField> getMetadataFieldsForProject(Project p) {
-
 		NamedParameterJdbcTemplate tmpl = new NamedParameterJdbcTemplate(dataSource);
 		MapSqlParameterSource parameters = new MapSqlParameterSource();
 
-		//get the metadata fields available in the project
+		/*
+		 * The below code for loading the metadata fields could be simplified into a single query, but the previous
+		 * 3-join query was taking 10s of seconds to load for large projects.  The 2 query process below for loading the
+		 * fields is providing significantly better performance than loading fields in a single 3-join query.
+		 */
+
+		//First load all the field IDs related to this project
 		String fieldIdQueryString = "SELECT DISTINCT e.field_id FROM metadata_entry e INNER JOIN project_sample p ON e.sample_id=p.sample_id WHERE p.project_id=:project";
 		parameters.addValue("project", p.getId());
 		List<Long> fieldIds = tmpl.queryForList(fieldIdQueryString, parameters, Long.class);
 
+		//next load all the full fields with those ids
 		String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
 		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
 		nativeQuery.setParameter("fields", fieldIds);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataFieldRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataFieldRepositoryImpl.java
@@ -1,12 +1,17 @@
 package ca.corefacility.bioinformatics.irida.repositories.sample;
 
-import ca.corefacility.bioinformatics.irida.model.project.Project;
-import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.List;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
-import java.util.List;
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import ca.corefacility.bioinformatics.irida.model.project.Project;
+import ca.corefacility.bioinformatics.irida.model.sample.MetadataTemplateField;
 
 /**
  * Custom repository methods for getting {@link MetadataTemplateField}s
@@ -14,10 +19,12 @@ import java.util.List;
 public class MetadataFieldRepositoryImpl implements MetadataFieldRepositoryCustom {
 
 	private final EntityManager entityManager;
+	private DataSource dataSource;
 
 	@Autowired
-	public MetadataFieldRepositoryImpl(EntityManager entityManager) {
+	public MetadataFieldRepositoryImpl(EntityManager entityManager, DataSource dataSource) {
 		this.entityManager = entityManager;
+		this.dataSource = dataSource;
 	}
 
 	/**
@@ -27,10 +34,17 @@ public class MetadataFieldRepositoryImpl implements MetadataFieldRepositoryCusto
 	@Override
 	public List<MetadataTemplateField> getMetadataFieldsForProject(Project p) {
 
-		String queryString = "SELECT DISTINCT f.* FROM project_sample p INNER JOIN metadata_entry s ON p.sample_id=s.sample_id INNER JOIN metadata_field f ON s.field_id=f.id WHERE p.project_id=:project";
-		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
+		NamedParameterJdbcTemplate tmpl = new NamedParameterJdbcTemplate(dataSource);
+		MapSqlParameterSource parameters = new MapSqlParameterSource();
 
-		nativeQuery.setParameter("project", p.getId());
+		//get the metadata fields available in the project
+		String fieldIdQueryString = "SELECT DISTINCT e.field_id FROM metadata_entry e INNER JOIN project_sample p ON e.sample_id=p.sample_id WHERE p.project_id=:project";
+		parameters.addValue("project", p.getId());
+		List<Long> fieldIds = tmpl.queryForList(fieldIdQueryString, parameters, Long.class);
+
+		String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
+		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
+		nativeQuery.setParameter("fields", fieldIds);
 
 		return nativeQuery.getResultList();
 	}

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -106,7 +106,7 @@
     "babel-loader": "^8.2.2",
     "babel-plugin-import": "^1.13.3",
     "browserslist": "^4.16.6",
-    "chromedriver": "90.0.0",
+    "chromedriver": "92.0.1",
     "css-loader": "^5.0.1",
     "css-minimizer-webpack-plugin": "^1.2.0",
     "eslint": "^7.22.0",


### PR DESCRIPTION
## Description of changes
In systems with large amounts of metadata, the queries for retrieving all `metadata_field` for a given project were slowing down.  This appeared to be occurring with the double `INNER JOIN` query between `metadata_entry`, `metadata_field`, and `project_sample`.

This PR breaks that query down into 2 simpler queries:
* First one that gets the field IDs for a project in a query joining `metadata_entry` and `project_sample`
* Second that loads the full `metadata_field` given those ids.

The previous query was sometimes running in the 10s of seconds to query the metadata and fields, this updated code runs in <1s for all projects tested.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
