### PR TITLE
Force using a set-value above 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes
 * [UI]: Updated Your Single Sample Analysis Outputs page to use Ant Design.
 * [Developer]: Fix dependabot warning for `path-parse`, set resolution of `path-parse` to 1.0.7.
 * [UI]: Fixed bug where the length of the project name was not checked on project creation.
+* [Developer]: Fix dependabot warning for `set-value`, force using a set-value above 4.0.1
 
 21.01 to 21.05
 --------------

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -136,6 +136,7 @@
     "fstream": "1.0.12",
     "ini": "1.3.7",
     "resolve": "1.9.0",
-    "path-parse": "1.0.7"
+    "path-parse": "1.0.7",
+    "set-value": "^4.0.1"
   }
 }

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -7535,7 +7535,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
+"is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
   dependencies:
@@ -7548,6 +7548,13 @@ fsevents@^2.1.2:
   version: 1.0.0
   resolution: "is-potential-custom-element-name@npm:1.0.0"
   checksum: 55b1ae44cf9241ea5b08414318d12a4d2eb157cb5722908fc7ef268c6d175894cb59d298092a87f9ed54af5b60fc572fa7f6b34b8633120dbe6edaa6c5169d0b
+  languageName: node
+  linkType: hard
+
+"is-primitive@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "is-primitive@npm:3.0.1"
+  checksum: 401b9a0e2fb758e6a481efa0bec944c3a7f9a3e722be7f6859d8e0303f9680415e7410bd498e71216fd2e453a8e0f30d592c2cc7518aa4158d4682fb79f93ac0
   languageName: node
   linkType: hard
 
@@ -12369,15 +12376,13 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"set-value@npm:^2.0.0, set-value@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "set-value@npm:2.0.1"
+"set-value@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "set-value@npm:4.1.0"
   dependencies:
-    extend-shallow: ^2.0.1
-    is-extendable: ^0.1.1
-    is-plain-object: ^2.0.3
-    split-string: ^3.0.1
-  checksum: a97a99a00cc5ed3034ccd690ff4dde167e4182ec4ef2fd5277637a6e388839292559301408b91405534b44e76450bdd443ac95427fde40e9a1a62102c1262bd1
+    is-plain-object: ^2.0.4
+    is-primitive: ^3.0.1
+  checksum: bdbc3a2e3dd30a02a11f30a29895d10595fa8ff8e0429255801d5e4e768acd2c7006b95ddbbf0310c4731b5ceadbe360dc0fd48a999ad7c055089ededa8b1651
   languageName: node
   linkType: hard
 
@@ -12641,7 +12646,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"split-string@npm:^3.0.1, split-string@npm:^3.0.2":
+"split-string@npm:^3.0.2":
   version: 3.1.0
   resolution: "split-string@npm:3.1.0"
   dependencies:


### PR DESCRIPTION
## Description of changes

Fixes dependabot warning for `set-value` by forcing it in the package.json file.

## Related issue

N/A

## Checklist

Things for the developer to confirm they've done before the PR should be accepted:

*   [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
*   [ ] ~Tests added (or description of how to test) for any new features.~
*   [ ] ~User documentation updated for UI or technical changes.~