### PR TITLE
Updating Sample modified date when metadata is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changes
 * [Developer]: Fix dependabot warning for `path-parse`, set resolution of `path-parse` to 1.0.7.
 * [UI]: Fixed bug where the length of the project name was not checked on project creation.
 * [UI] Fixed bug which prevented the first created metadata template from being displayed after creation.
+* [UI]: Sample modified date is now updated when sample metadata is modified.
 
 21.01 to 21.05
 --------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/sample/SampleServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/sample/SampleServiceImpl.java
@@ -231,6 +231,9 @@ public class SampleServiceImpl extends CRUDServiceImpl<Long, Sample> implements 
 		metadataEntryRepository.saveAll(metadataToSet);
 
 		s = read(s.getId());
+		s.setModifiedDate(new Date());
+		//re-saving sample to update modified date
+		s = sampleRepository.save(s);
 
 		return s;
 	}
@@ -274,7 +277,12 @@ public class SampleServiceImpl extends CRUDServiceImpl<Long, Sample> implements 
 
 		metadataEntryRepository.saveAll(currentMetadata);
 
-		return read(s.getId());
+		s = read(s.getId());
+		s.setModifiedDate(new Date());
+		//re-saving sample to update modified date
+		s = sampleRepository.save(s);
+
+		return s;
 	}
 
 	/**

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/sample/SampleServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/sample/SampleServiceImplTest.java
@@ -430,6 +430,7 @@ public class SampleServiceImplTest {
 		ArgumentCaptor<Set> saveCaptor = ArgumentCaptor.forClass(Set.class);
 
 		verify(metadataEntryRepository).saveAll(saveCaptor.capture());
+		verify(sampleRepository).save(s1);
 
 		Set<MetadataEntry> savedValues = saveCaptor.getValue();
 
@@ -499,6 +500,45 @@ public class SampleServiceImplTest {
 				.findAny();
 
 		assertTrue("should be no pipeline entries left", pipelineOpt.isEmpty());
+	}
+
+	@Test
+	public void testUpdateSampleMetadata() {
+		Sample s1 = new Sample();
+		s1.setId(1L);
+
+		when(sampleRepository.findById(s1.getId())).thenReturn(Optional.of(s1));
+
+		MetadataTemplateField field1 = new MetadataTemplateField("field1", "text");
+		MetadataEntry entry1 = new MetadataEntry("entry1", "text", field1);
+		MetadataTemplateField field2 = new MetadataTemplateField("field2", "text");
+		MetadataEntry entry2 = new MetadataEntry("entry2", "text", field2);
+		Set<MetadataEntry> metadataEntries = Sets.newHashSet(entry1, entry2);
+
+		when(metadataEntryRepository.getMetadataForSample(s1)).thenReturn(metadataEntries);
+
+		MetadataEntry entry = new MetadataEntry("entry2", "text", field1);
+
+		Set<MetadataEntry> inputMetadata = Sets.newHashSet(entry);
+
+		sampleService.updateSampleMetadata(s1, inputMetadata);
+
+		verify(metadataEntryRepository).deleteAll(metadataEntries);
+
+		ArgumentCaptor<Set> saveCaptor = ArgumentCaptor.forClass(Set.class);
+
+		verify(metadataEntryRepository).saveAll(saveCaptor.capture());
+		verify(sampleRepository).save(s1);
+
+		Set<MetadataEntry> savedValues = saveCaptor.getValue();
+
+		assertEquals(1, savedValues.size());
+
+		MetadataEntry savedEntry = savedValues.iterator()
+				.next();
+
+		assertEquals(entry.getValue(), savedEntry.getValue());
+		assertEquals(entry.getField(), savedEntry.getField());
 	}
 
 	private Sample s(Long id) {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/sample/SampleServiceImplTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/service/impl/unit/sample/SampleServiceImplTest.java
@@ -44,8 +44,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -411,6 +410,8 @@ public class SampleServiceImplTest {
 		Sample s1 = new Sample();
 		s1.setId(1L);
 
+		Date originalModifiedDate = s1.getModifiedDate();
+
 		when(sampleRepository.findById(s1.getId())).thenReturn(Optional.of(s1));
 
 		MetadataTemplateField field1 = new MetadataTemplateField("field1", "text");
@@ -430,7 +431,15 @@ public class SampleServiceImplTest {
 		ArgumentCaptor<Set> saveCaptor = ArgumentCaptor.forClass(Set.class);
 
 		verify(metadataEntryRepository).saveAll(saveCaptor.capture());
-		verify(sampleRepository).save(s1);
+
+		//ensure modified date got bumped up
+		ArgumentCaptor<Sample> sampleCaptor = ArgumentCaptor.forClass(Sample.class);
+		verify(sampleRepository).save(sampleCaptor.capture());
+
+		Date savedModifiedDate = sampleCaptor.getValue()
+				.getModifiedDate();
+
+		assertNotEquals(originalModifiedDate, savedModifiedDate);
 
 		Set<MetadataEntry> savedValues = saveCaptor.getValue();
 
@@ -507,6 +516,8 @@ public class SampleServiceImplTest {
 		Sample s1 = new Sample();
 		s1.setId(1L);
 
+		Date originalModifiedDate = s1.getModifiedDate();
+
 		when(sampleRepository.findById(s1.getId())).thenReturn(Optional.of(s1));
 
 		MetadataTemplateField field1 = new MetadataTemplateField("field1", "text");
@@ -528,7 +539,15 @@ public class SampleServiceImplTest {
 		ArgumentCaptor<Set> saveCaptor = ArgumentCaptor.forClass(Set.class);
 
 		verify(metadataEntryRepository).saveAll(saveCaptor.capture());
-		verify(sampleRepository).save(s1);
+
+		//ensure modified date got bumped up
+		ArgumentCaptor<Sample> sampleCaptor = ArgumentCaptor.forClass(Sample.class);
+		verify(sampleRepository).save(sampleCaptor.capture());
+
+		Date savedModifiedDate = sampleCaptor.getValue()
+				.getModifiedDate();
+
+		assertNotEquals(originalModifiedDate, savedModifiedDate);
 
 		Set<MetadataEntry> savedValues = saveCaptor.getValue();
 


### PR DESCRIPTION
## Description of changes
Updating the Sample modified date whenever metadata is updated on a sample.  Previously this was always updated because the metadata map was a property of the sample.  Now since its updated separately, the modified date needs to be manually bumped in the update method.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
