### PR TITLE
Fixes filter by file exports all samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ Changes
 * [UI]: Updated Your Single Sample Analysis Outputs page to use Ant Design.
 * [Developer]: Fix dependabot warning for `path-parse`, set resolution of `path-parse` to 1.0.7.
 * [UI]: Fixed bug where the length of the project name was not checked on project creation.
-* [UI] Fixed bug which prevented the first created metadata template from being displayed after creation.
+* [UI]: Fixed bug which prevented the first created metadata template from being displayed after creation.
+* [UI]: Fixed bug when exporting samples from project > samples page while using filter by file, all sample were exported.
 
 21.01 to 21.05
 --------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/specification/ProjectSampleSpecification.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/specification/ProjectSampleSpecification.java
@@ -9,11 +9,11 @@ import javax.persistence.criteria.Predicate;
 
 import org.springframework.data.jpa.domain.Specification;
 
-import com.google.common.base.Strings;
-
 import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectSampleJoin;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
+
+import com.google.common.base.Strings;
 
 /**
  * Specification for searching and filtering {@link ProjectSampleJoin} properties
@@ -71,11 +71,7 @@ public class ProjectSampleSpecification {
 				predicates.add(criteriaBuilder
 						.lessThanOrEqualTo(root.get("sample").get("modifiedDate"), maxDate));
 			}
-			if (predicates.size() > 0) {
-				return criteriaBuilder.and(predicates.toArray(new Predicate[predicates.size()]));
-			} else {
-				return null;
-			}
+			return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
 		};
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
@@ -799,6 +799,7 @@ public class ProjectSamplesController {
 	 * @param params      DataTable parameters.
 	 * @param sampleNames List of {@link Sample} names the {@link Project} is filtered on
 	 * @param associated  List of acitve associated {@link Project} identifiers.
+	 * @param sampleIds   List of {@link Sample} identifiers that are selected in the project
 	 * @param filter      {@link Sample} attribute filters applied.
 	 * @param request     {@link HttpServletRequest}
 	 * @param response    {@link HttpServletResponse}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -796,13 +795,7 @@ public class ProjectSamplesController {
 	 * Export {@link Sample} from a {@link Project} as either Excel or CSV formatted.
 	 *
 	 * @param projectId   identifier for the current {@link Project}
-	 * @param type        of file to export (.csv or .xlsx)
-	 * @param params      DataTable parameters.
-	 * @param sampleNames List of {@link Sample} names the {@link Project} is filtered on
-	 * @param associated  List of acitve associated {@link Project} identifiers.
-	 * @param sampleIds   List of {@link Sample} identifiers that are selected in the project
-	 * @param filter      {@link Sample} attribute filters applied.
-	 * @param request     {@link HttpServletRequest}
+	 * @param exportModel {@link ExportToFileModel} details of which samples to export
 	 * @param response    {@link HttpServletResponse}
 	 * @param locale      of the current user.
 	 * @throws IOException if the exported file cannot be written

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesController.java
@@ -822,7 +822,7 @@ public class ProjectSamplesController {
 		final Page<ProjectSampleJoin> page;
 		page = sampleService.getFilteredSamplesForProjects(projects, exportModel.getSampleNames(),
 				exportModel.getName(), exportModel.getSearch(), exportModel.getOrganism(), exportModel.getStartDate(),
-				exportModel.getEndDate(), 0, Integer.MAX_VALUE, Sort.by(new Sort.Order(Direction.ASC, "sampleName")));
+				exportModel.getEndDate(), 0, Integer.MAX_VALUE, Sort.by(new Sort.Order(Direction.ASC, "sample.sampleName")));
 
 		// Create DataTables representation of the page.
 		List<DTProjectSamples> models = page.getContent()

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/dto/ExportToFileModel.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/dto/ExportToFileModel.java
@@ -1,0 +1,94 @@
+package ca.corefacility.bioinformatics.irida.ria.web.projects.dto;
+
+import java.util.Date;
+import java.util.List;
+
+public class ExportToFileModel {
+	private List<String> sampleNames;
+	private List<Long> associated;
+	private String search;
+	private Date startDate;
+	private Date endDate;
+	private String type;
+	private String name;
+	private String organism;
+
+	public ExportToFileModel() {
+	}
+
+	public ExportToFileModel(List<String> sampleNames, List<Long> associated, String search, Date startDate,
+			Date endDate, String type, String name, String organism) {
+		this.sampleNames = sampleNames;
+		this.associated = associated;
+		this.search = search;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.type = type;
+		this.name = name;
+		this.organism = organism;
+	}
+
+	public List<String> getSampleNames() {
+		return sampleNames;
+	}
+
+	public void setSampleNames(List<String> sampleNames) {
+		this.sampleNames = sampleNames;
+	}
+
+	public List<Long> getAssociated() {
+		return associated;
+	}
+
+	public void setAssociated(List<Long> associated) {
+		this.associated = associated;
+	}
+
+	public String getSearch() {
+		return search;
+	}
+
+	public void setSearch(String search) {
+		this.search = search;
+	}
+
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	public Date getEndDate() {
+		return endDate;
+	}
+
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getOrganism() {
+		return organism;
+	}
+
+	public void setOrganism(String organism) {
+		this.organism = organism;
+	}
+}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/dto/ExportToFileModel.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/dto/ExportToFileModel.java
@@ -3,6 +3,8 @@ package ca.corefacility.bioinformatics.irida.ria.web.projects.dto;
 import java.util.Date;
 import java.util.List;
 
+import com.google.common.base.Strings;
+
 public class ExportToFileModel {
 	private List<String> sampleNames;
 	private List<Long> associated;
@@ -77,7 +79,7 @@ public class ExportToFileModel {
 	}
 
 	public String getName() {
-		return name;
+		return Strings.isNullOrEmpty(name) ? "" : name;
 	}
 
 	public void setName(String name) {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/dto/ExportToFileModel.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/projects/dto/ExportToFileModel.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 import com.google.common.base.Strings;
 
+/**
+ * Used the get the form details submitted via a post to export samples to a CSV.
+ */
 public class ExportToFileModel {
 	private List<String> sampleNames;
 	private List<Long> associated;

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -1,29 +1,28 @@
-import $ from "jquery";
-
 import chroma from "chroma-js";
+import $ from "jquery";
+import "../../../../css/pages/project-samples.css";
+import { putSampleInCart } from "../../../apis/cart/cart";
 import {
   createItemLink,
   generateColumnOrderInfo,
   tableConfig,
 } from "../../../utilities/datatables-utilities";
 import { formatInternationalizedDateTime } from "../../../utilities/date-utilities";
+import { download } from "../../../utilities/file-utilities";
+import { setBaseUrl } from "../../../utilities/url-utilities";
 import "./../../../vendor/datatables/datatables";
 import "./../../../vendor/datatables/datatables-buttons";
 import "./../../../vendor/datatables/datatables-rowSelection";
+import "./add-sample/AddSampleButton";
+import { FILTERS, SAMPLE_EVENTS } from "./constants";
+
+import "./linker/Linker";
 import {
   SampleCartButton,
   SampleDropdownButton,
   SampleExportButton,
   SampleProjectDropdownButton,
 } from "./SampleButtons";
-import { FILTERS, SAMPLE_EVENTS } from "./constants";
-import { download } from "../../../utilities/file-utilities";
-import "../../../../css/pages/project-samples.css";
-import { putSampleInCart } from "../../../apis/cart/cart";
-import { setBaseUrl } from "../../../utilities/url-utilities";
-
-import "./linker/Linker";
-import "./add-sample/AddSampleButton";
 
 /*
 This is required to use select2 inside a modal.
@@ -99,7 +98,7 @@ const EXPORT_HANDLERS = {
     const url = this.data("url");
     const params = $dt.ajax.params();
     params.type = this.data("file");
-    download(`${url}?${$.param(params)}`);
+    download(`${url}?${$.param({ ...params, ids: getSelectedIds() })}`);
   },
   ncbi() {
     const ids = getSelectedIds();

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -96,6 +96,10 @@ const EXPORT_HANDLERS = {
   file() {
     // this is set by the object calling (i.e. download btn)
     const url = this.data("url");
+
+    /*
+    Get the default datatable params
+     */
     const {
       sampleNames,
       associated,
@@ -106,8 +110,9 @@ const EXPORT_HANDLERS = {
       endDate,
     } = $dt.ajax.params();
 
-    console.log($dt.ajax.params());
-
+    /*
+    These are default params must be included.
+     */
     const data = {
       sampleNames: sampleNames || [],
       search: search.value,
@@ -115,6 +120,9 @@ const EXPORT_HANDLERS = {
       type: this.data("file"),
     };
 
+    /*
+    Only add the following if they are needed,
+     */
     if (associated) {
       data.associated = associated;
     }

--- a/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
+++ b/src/main/webapp/resources/js/pages/projects/samples/project-samples.js
@@ -8,7 +8,7 @@ import {
   tableConfig,
 } from "../../../utilities/datatables-utilities";
 import { formatInternationalizedDateTime } from "../../../utilities/date-utilities";
-import { download } from "../../../utilities/file-utilities";
+import { download, downloadPost } from "../../../utilities/file-utilities";
 import { setBaseUrl } from "../../../utilities/url-utilities";
 import "./../../../vendor/datatables/datatables";
 import "./../../../vendor/datatables/datatables-buttons";
@@ -96,9 +96,39 @@ const EXPORT_HANDLERS = {
   file() {
     // this is set by the object calling (i.e. download btn)
     const url = this.data("url");
-    const params = $dt.ajax.params();
-    params.type = this.data("file");
-    download(`${url}?${$.param({ ...params, ids: getSelectedIds() })}`);
+    const {
+      sampleNames,
+      associated,
+      search,
+      name,
+      organism,
+      startDate,
+      endDate,
+    } = $dt.ajax.params();
+
+    console.log($dt.ajax.params());
+
+    const data = {
+      sampleNames: sampleNames || [],
+      search: search.value,
+      name: name || "",
+      type: this.data("file"),
+    };
+
+    if (associated) {
+      data.associated = associated;
+    }
+
+    if (organism) {
+      data.organism = organism;
+    }
+
+    if (startDate && endDate) {
+      data.startDate = startDate;
+      data.endDate = endDate;
+    }
+
+    downloadPost(`${url}`, data);
   },
   ncbi() {
     const ids = getSelectedIds();

--- a/src/main/webapp/resources/js/utilities/file-utilities.js
+++ b/src/main/webapp/resources/js/utilities/file-utilities.js
@@ -11,6 +11,12 @@ export function download(url) {
   document.body.appendChild(iframe);
 }
 
+/**
+ * Download a file using a post request.
+ * This is good for when large amounts of data are required ot create the download
+ * @param {string} url - Url to send the info to.
+ * @param {object} contents - Any details that need to be including in the request.
+ */
 export function downloadPost(url, contents) {
   const form =
     document.querySelector("#submit-download") ||

--- a/src/main/webapp/resources/js/utilities/file-utilities.js
+++ b/src/main/webapp/resources/js/utilities/file-utilities.js
@@ -11,6 +11,29 @@ export function download(url) {
   document.body.appendChild(iframe);
 }
 
+export function downloadPost(url, contents) {
+  const form =
+    document.querySelector("#submit-download") ||
+    document.createElement("form");
+
+  form.setAttribute("id", "submit-download");
+  form.setAttribute("method", "POST");
+  form.setAttribute("action", url);
+  form.setAttribute("target", "_self");
+  form.setAttribute("style", "display: none");
+
+  for (const [name, value] of Object.entries(contents)) {
+    const field = document.createElement("input");
+    field.setAttribute("name", name);
+    field.setAttribute("value", value);
+    form.appendChild(field);
+  }
+
+  document.body.appendChild(form);
+  form.submit();
+  document.body.removeChild(form);
+}
+
 /**
  * Convert file size from bytes to larger unit.
  * @param {number} bytes size of file.


### PR DESCRIPTION
## Description of changes
**Previously**: When filter by file was applied and the user tried to export the samples to excel or csv, the download would contain all the samples in the project.

**Fix**:  By default when filter by file is applied the filtered samples are selected. I am using this system to send the selected sample ids to the server and filtering the samples based on this list.

## Related issue
Fixes #985 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] ~~Tests added (or description of how to test) for any new features.~~
* [ ] ~~User documentation updated for UI or technical changes.~~
