### PR TITLE
Fixed metadata query error when project had no metadata

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataEntryRepositoryImpl.java
@@ -1,9 +1,6 @@
 package ca.corefacility.bioinformatics.irida.repositories.sample;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
@@ -50,11 +47,17 @@ public class MetadataEntryRepositoryImpl implements MetadataEntryRepositoryCusto
 		parameters.addValue("project", project.getId());
 		List<Long> fieldIds = tmpl.queryForList(fieldIdQueryString, parameters, Long.class);
 
-		//next load the full fields
-		String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
-		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
-		nativeQuery.setParameter("fields", fieldIds);
-		List<MetadataTemplateField> fields = nativeQuery.getResultList();
+		List<MetadataTemplateField> fields;
+		if (!fieldIds.isEmpty()) {
+			//next load the full fields
+			String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
+			Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
+			nativeQuery.setParameter("fields", fieldIds);
+			fields = nativeQuery.getResultList();
+		} else {
+			//if there's no metadata, at least return the empty list
+			fields = new ArrayList<>();
+		}
 
 		//Collect the fields into a map from ID to field for use later
 		Map<Long, MetadataTemplateField> fieldMap = fields.stream()

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataFieldRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/MetadataFieldRepositoryImpl.java
@@ -1,5 +1,6 @@
 package ca.corefacility.bioinformatics.irida.repositories.sample;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -47,11 +48,17 @@ public class MetadataFieldRepositoryImpl implements MetadataFieldRepositoryCusto
 		parameters.addValue("project", p.getId());
 		List<Long> fieldIds = tmpl.queryForList(fieldIdQueryString, parameters, Long.class);
 
-		//next load all the full fields with those ids
-		String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
-		Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
-		nativeQuery.setParameter("fields", fieldIds);
+		List<MetadataTemplateField> resultList;
+		if (!fieldIds.isEmpty()) {
+			//next load all the full fields with those ids
+			String queryString = "SELECT * from metadata_field f WHERE f.id IN :fields";
+			Query nativeQuery = entityManager.createNativeQuery(queryString, MetadataTemplateField.class);
+			nativeQuery.setParameter("fields", fieldIds);
+			resultList = nativeQuery.getResultList();
+		} else {
+			resultList = new ArrayList<>();
+		}
 
-		return nativeQuery.getResultList();
+		return resultList;
 	}
 }


### PR DESCRIPTION
## Description of changes
With the last query update the query failed when loading a line list for a project with no metadata:
```
MySQLSyntaxErrorException: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')'
```

This was because if there was no metadata fields in the first new query, the `IN` clause in the second would be empty.  This PR adds a check to ensure that query is skipped if it'll end up returning no results.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
