### PR TITLE
Fixing updates to sample collectionDate through REST API

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -1,13 +1,11 @@
 package ca.corefacility.bioinformatics.irida.web.controller.api.projects;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
-
-import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResponseResource;
-
-import io.swagger.v3.oas.annotations.Operation;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,12 +31,14 @@ import ca.corefacility.bioinformatics.irida.service.ProjectService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.LabelledRelationshipResource;
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResourceCollection;
+import ca.corefacility.bioinformatics.irida.web.assembler.resource.ResponseResource;
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.RootResource;
 import ca.corefacility.bioinformatics.irida.web.controller.api.samples.RESTSampleAssemblyController;
 import ca.corefacility.bioinformatics.irida.web.controller.api.samples.RESTSampleMetadataController;
 import ca.corefacility.bioinformatics.irida.web.controller.api.samples.RESTSampleSequenceFilesController;
 
 import com.google.common.net.HttpHeaders;
+import io.swagger.v3.oas.annotations.Operation;
 
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
 import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
@@ -384,8 +384,28 @@ public class RESTProjectSamplesController {
 			MediaType.APPLICATION_JSON_VALUE })
 	public ResponseResource<Sample> updateSample(@PathVariable Long sampleId,
 			@RequestBody Map<String, Object> updatedFields) {
+
+		//collectionDate is a Date object, but will come in here as a String
+		String collectionDateProperty = "collectionDate";
+		String dateFormat = "yyyy-MM-dd";
+		if (updatedFields.containsKey(collectionDateProperty)) {
+			String dateTime = (String) updatedFields.get(collectionDateProperty);
+
+			SimpleDateFormat format = new SimpleDateFormat(dateFormat);
+			try {
+				Date parsed = format.parse(dateTime);
+
+				updatedFields.put(collectionDateProperty, parsed);
+			} catch (ParseException e) {
+				logger.error("Failed to parse collectionDate into date object", e);
+
+				throw new IllegalArgumentException("'collectionDate' must be in the format " + dateFormat);
+			}
+		}
 		// issue an update request
-		final Sample s = sampleService.updateFields(sampleId, updatedFields);
+		sampleService.updateFields(sampleId, updatedFields);
+		Sample s = sampleService.read(sampleId);
+
 		addLinksForSample(Optional.empty(), s);
 
 		ResponseResource<Sample> responseObject = new ResponseResource<>(s);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
@@ -304,6 +304,43 @@ public class ProjectSamplesIT {
 	}
 
 	@Test
+	public void testUpdateProjectSampleCollectionDate() {
+		String projectSampleUri = ITestSystemProperties.BASE_URL + "/api/samples/1";
+		Map<String, String> updatedFields = new HashMap<>();
+		String badDate = "x-y-z";
+		updatedFields.put("collectionDate", badDate);
+
+		//ensure updating date fails with bad date format
+		asUser().and()
+				.body(updatedFields)
+				.expect()
+				.body("resource.links.rel", hasItems("self", "sample/sequenceFiles"))
+				.expect()
+				.response()
+				.statusCode(HttpStatus.BAD_REQUEST.value())
+				.when()
+				.patch(projectSampleUri);
+
+		String goodDate = "2021-10-12";
+		updatedFields.put("collectionDate", goodDate);
+		asUser().and()
+				.body(updatedFields)
+				.expect()
+				.body("resource.links.rel", hasItems("self", "sample/sequenceFiles"))
+				.expect()
+				.response()
+				.statusCode(HttpStatus.OK.value())
+				.when()
+				.patch(projectSampleUri);
+
+		// now confirm that the collectionDate was updated
+		asUser().expect()
+				.body("resource.collectionDate", is(goodDate))
+				.when()
+				.get(projectSampleUri);
+	}
+
+	@Test
 	public void testReadSampleAsAdmin() {
 		String projectUri = ITestSystemProperties.BASE_URL + "/api/projects/5";
 		String projectSampleUri = projectUri + "/samples/1";

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
@@ -314,8 +314,6 @@ public class ProjectSamplesIT {
 		asUser().and()
 				.body(updatedFields)
 				.expect()
-				.body("resource.links.rel", hasItems("self", "sample/sequenceFiles"))
-				.expect()
 				.response()
 				.statusCode(HttpStatus.BAD_REQUEST.value())
 				.when()
@@ -325,8 +323,6 @@ public class ProjectSamplesIT {
 		updatedFields.put("collectionDate", goodDate);
 		asUser().and()
 				.body(updatedFields)
-				.expect()
-				.body("resource.links.rel", hasItems("self", "sample/sequenceFiles"))
 				.expect()
 				.response()
 				.statusCode(HttpStatus.OK.value())

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/project/RESTProjectSamplesControllerTest.java
@@ -194,6 +194,7 @@ public class RESTProjectSamplesControllerTest {
 		Map<String, Object> updatedFields = ImmutableMap.of("sampleName", (Object) "some new name");
 
 		when(sampleService.updateFields(s.getId(), updatedFields)).thenReturn(s);
+		when(sampleService.read(s.getId())).thenReturn(s);
 
 		ResponseResource<Sample> responseObject = controller.updateSample(s.getId(), updatedFields);
 


### PR DESCRIPTION
## Description of changes
Fixed an issue where Sample `collectionDate` property couldn't be updated through the REST API.  This is because the `update` function was taking a collection of properties, and the `collectionDate` wasn't being converted to a `Date` before sending to the update method, and instead was passed as a `String`.

## Related issue
Fixes #283 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
