### PR TITLE
Upgrade react router v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changes
 * [REST]: Fixed bug prevending REST API clients from updating the `collectedDate` on samples.
 * [Developer]: Updated `antd` to version 4.16.13
 * [Developer/UI]: Refreshed the metadata uploader.
-* [Developer/UI]: Updated to latest release of `react-router-dom`
+* [Developer/UI]: Updated to the latest release of `react-router-dom` v6.0.2.
 
 21.05 to 21.09
 --------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changes
 * [REST]: Fixed bug prevending REST API clients from updating the `collectedDate` on samples.
 * [Developer]: Updated `antd` to version 4.16.13
 * [Developer/UI]: Refreshed the metadata uploader.
+* [Developer/UI]: Updated to latest release of `react-router-dom`
 
 21.05 to 21.09
 --------------

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -79,7 +79,7 @@
     "react-markdown": "^4.3.1",
     "react-mde": "^8.0.2",
     "react-redux": "^7.1.0",
-    "react-router-dom": "^5.3.0",
+    "react-router-dom": "^6.0.2",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.1",
     "reactour": "^1.9.1",

--- a/src/main/webapp/resources/js/pages/projects/linelist/components/Toolbar/Toolbar.jsx
+++ b/src/main/webapp/resources/js/pages/projects/linelist/components/Toolbar/Toolbar.jsx
@@ -1,6 +1,5 @@
 import React, { Component, Suspense } from "react";
 import { connect } from "react-redux";
-import { useParams } from "react-router-dom";
 
 import PropTypes from "prop-types";
 import { actions as entryActions } from "../../reducers/entries";

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportComplete.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportComplete.jsx
@@ -8,7 +8,7 @@ import { setBaseUrl } from "../../../../utilities/url-utilities";
  * React component that displays Step #4 of the Sample Metadata Uploader.
  * This page is where the user receives confirmation that the metadata was uploaded successfully.
  * @returns {*}
- * @constructore
+ * @constructor
  */
 export function SampleMetadataImportComplete() {
   const location = useLocation();

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportComplete.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportComplete.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useParams, useLocation } from "react-router-dom";
 import { Button, Result } from "antd";
 import { SampleMetadataImportWizard } from "./SampleMetadataImportWizard";
 import { setBaseUrl } from "../../../../utilities/url-utilities";
@@ -8,18 +8,19 @@ import { setBaseUrl } from "../../../../utilities/url-utilities";
  * React component that displays Step #4 of the Sample Metadata Uploader.
  * This page is where the user receives confirmation that the metadata was uploaded successfully.
  * @returns {*}
- * @constructor
+ * @constructore
  */
 export function SampleMetadataImportComplete() {
+  const location = useLocation();
+
   const { projectId } = useParams();
-  const history = useHistory();
 
   return (
     <SampleMetadataImportWizard currentStep={3}>
       <Result
         status="success"
         title={i18n("SampleMetadataImportComplete.result.title")}
-        subTitle={history.location.state.statusMessage}
+        subTitle={location.state.statusMessage}
         extra={
           <Button
             type="primary"

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportMapHeaders.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportMapHeaders.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useSelector } from "react-redux";
-import { useHistory, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Button, Radio, Typography } from "antd";
 import { SampleMetadataImportWizard } from "./SampleMetadataImportWizard";
 import { BlockRadioInput } from "../../../../components/ant.design/forms/BlockRadioInput";
@@ -20,7 +20,7 @@ const { Text } = Typography;
  */
 export function SampleMetadataImportMapHeaders() {
   const { projectId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [column, setColumn] = React.useState();
   const { headers, sampleNameColumn } = useSelector((state) => state.reducer);
   const [updateColumn] = useSetColumnProjectSampleMetadataMutation();
@@ -33,7 +33,7 @@ export function SampleMetadataImportMapHeaders() {
     updateColumn({ projectId, sampleNameColumn: column })
       .unwrap()
       .then((payload) => {
-        history.push("review");
+        navigate(`/${projectId}/sample-metadata/upload/review`);
       });
   };
 
@@ -60,7 +60,7 @@ export function SampleMetadataImportMapHeaders() {
         <Button
           className="t-metadata-uploader-file-button"
           icon={<IconArrowLeft />}
-          onClick={() => history.goBack()}
+          onClick={() => navigate(-1)}
         >
           {i18n("SampleMetadataImportMapHeaders.button.back")}
         </Button>

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportReview.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportReview.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useHistory, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { Alert, Button, Table, Tag, Tooltip, Typography } from "antd";
 import { SampleMetadataImportWizard } from "./SampleMetadataImportWizard";
 import {
@@ -45,15 +45,13 @@ const MetadataTable = styled(Table)`
  */
 export function SampleMetadataImportReview() {
   const { projectId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const [columns, setColumns] = React.useState([]);
   const [selected, setSelected] = React.useState([]);
   const [valid, setValid] = React.useState(true);
-  const {
-    data = {},
-    isFetching,
-    isSuccess,
-  } = useGetProjectSampleMetadataQuery(projectId);
+  const { data = {}, isFetching, isSuccess } = useGetProjectSampleMetadataQuery(
+    projectId
+  );
   const [saveMetadata] = useSaveProjectSampleMetadataMutation();
 
   const tagColumn = {
@@ -172,8 +170,7 @@ export function SampleMetadataImportReview() {
     saveMetadata({ projectId, sampleNames })
       .unwrap()
       .then((payload) => {
-        history.push({
-          pathname: "complete",
+        navigate(`/${projectId}/sample-metadata/upload/complete`, {
           state: { statusMessage: payload.message },
         });
       });
@@ -217,7 +214,7 @@ export function SampleMetadataImportReview() {
         <Button
           className="t-metadata-uploader-column-button"
           icon={<IconArrowLeft />}
-          onClick={() => history.goBack()}
+          onClick={() => navigate(-1)}
         >
           {i18n("SampleMetadataImportReview.button.back")}
         </Button>

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportUploadFile.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/components/SampleMetadataImportUploadFile.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useDispatch } from "react-redux";
-import { useHistory, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { setHeaders } from "../services/importReducer";
 import { notification, Typography } from "antd";
 import { DragUpload } from "../../../../components/files/DragUpload";
@@ -18,7 +18,7 @@ const { Text } = Typography;
  */
 export function SampleMetadataImportUploadFile() {
   const { projectId } = useParams();
-  const history = useHistory();
+  const navigate = useNavigate();
   const dispatch = useDispatch();
   const [status, setStatus] = React.useState("process");
   const [clearStorage] = useClearProjectSampleMetadataMutation();
@@ -49,7 +49,7 @@ export function SampleMetadataImportUploadFile() {
             info.file.response.sampleNameColumn
           )
         );
-        history.push("headers");
+        navigate(`/${projectId}/sample-metadata/upload/headers`);
       } else if (status === "error") {
         setStatus("error");
         notification.error({

--- a/src/main/webapp/resources/js/pages/projects/samples-metadata-import/index.js
+++ b/src/main/webapp/resources/js/pages/projects/samples-metadata-import/index.js
@@ -1,11 +1,11 @@
 import React from "react";
-import { BrowserRouter, Route, Switch } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Provider } from "react-redux";
 import { render } from "react-dom";
-import { SampleMetadataImportUploadFile } from "./components/SampleMetadataImportUploadFile";
+import { SampleMetadataImportComplete } from "./components/SampleMetadataImportComplete";
 import { SampleMetadataImportMapHeaders } from "./components/SampleMetadataImportMapHeaders";
 import { SampleMetadataImportReview } from "./components/SampleMetadataImportReview";
-import { SampleMetadataImportComplete } from "./components/SampleMetadataImportComplete";
+import { SampleMetadataImportUploadFile } from "./components/SampleMetadataImportUploadFile";
 import { setBaseUrl } from "../../../utilities/url-utilities";
 import store from "./store";
 
@@ -17,20 +17,24 @@ For more information on the browser router see: https://reactrouter.com/web/api/
 render(
   <Provider store={store}>
     <BrowserRouter basename={setBaseUrl("/projects")}>
-      <Switch>
-        <Route path="/:projectId/sample-metadata/upload/file">
-          <SampleMetadataImportUploadFile />
-        </Route>
-        <Route path="/:projectId/sample-metadata/upload/headers">
-          <SampleMetadataImportMapHeaders />
-        </Route>
-        <Route path="/:projectId/sample-metadata/upload/review">
-          <SampleMetadataImportReview />
-        </Route>
-        <Route path="/:projectId/sample-metadata/upload/complete">
-          <SampleMetadataImportComplete />
-        </Route>
-      </Switch>
+      <Routes>
+        <Route
+          path="/:projectId/sample-metadata/upload/file"
+          element={<SampleMetadataImportUploadFile />}
+        />
+        <Route
+          path="/:projectId/sample-metadata/upload/headers"
+          element={<SampleMetadataImportMapHeaders />}
+        />
+        <Route
+          path="/:projectId/sample-metadata/upload/review"
+          element={<SampleMetadataImportReview />}
+        />
+        <Route
+          path="/:projectId/sample-metadata/upload/complete"
+          element={<SampleMetadataImportComplete />}
+        />
+      </Routes>
     </BrowserRouter>
   </Provider>,
   document.querySelector("#samples-metadata-import-root")

--- a/src/main/webapp/yarn.lock
+++ b/src/main/webapp/yarn.lock
@@ -1764,12 +1764,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2":
-  version: 7.15.4
-  resolution: "@babel/runtime@npm:7.15.4"
+"@babel/runtime@npm:^7.7.6":
+  version: 7.16.3
+  resolution: "@babel/runtime@npm:7.16.3"
   dependencies:
     regenerator-runtime: ^0.13.4
-  checksum: 64b6c250fd02a664f40835b7bfc3ec0b473d251bf4881b06b689b60662bf2ae17adc6fa32fb0e0de308de5d4bc383738c6030ad93d823066fb9fd7c18f552b56
+  checksum: ee47a2b6edf56ec25437b34407a98439eb0b71149675e7b2781e5d1b2b6d858772120f590349fd9adbb0f2a186d2eb584b2b3a1819ca673b60dd5959bb02839f
   languageName: node
   linkType: hard
 
@@ -6829,21 +6829,16 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
+"history@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "history@npm:5.1.0"
   dependencies:
-    "@babel/runtime": ^7.1.2
-    loose-envify: ^1.2.0
-    resolve-pathname: ^3.0.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
-    value-equal: ^1.0.1
-  checksum: 3b302b54c08f61f040a265ae9608c6dba88260179b9ddfe542042465ccf79e2ff19e792cb70c6e0240e80bc00b29aad5308d1f277815b1e95662bd5b819c625b
+    "@babel/runtime": ^7.7.6
+  checksum: be7587c614078b6bc39bb3b8ae4da92f9d5d175bf1480c12119d056135eeb88c73589894451536be3d6a3ae250822cc5bf95a2cf5dca26d10b736ac70da0c56f
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.0.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -7284,7 +7279,7 @@ fsevents@^2.1.2:
     react-markdown: ^4.3.1
     react-mde: ^8.0.2
     react-redux: ^7.1.0
-    react-router-dom: ^5.3.0
+    react-router-dom: ^6.0.2
     react-virtualized-auto-sizer: ^1.0.2
     react-window: ^1.8.1
     reactour: ^1.9.1
@@ -7763,13 +7758,6 @@ fsevents@^2.1.2:
   version: 3.3.0
   resolution: "is@npm:3.3.0"
   checksum: 191293ded7b1906b8839201dc027087fc738e04af8e58e3fd477855b8926481ffd7873fd9bc88d91efc9448c313a8f474bfd1667e3f27e8b20c8be7f1c6b991f
-  languageName: node
-  linkType: hard
-
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: daeda3c23646200b0b464b7a9030d10008d7701fc6b7a1b45cafe42b4f4d2dde20835b56f19a49e04bb218245b7f7a2bcc6d0f696cff3711e4eddaa2031c611f
   languageName: node
   linkType: hard
 
@@ -8869,7 +8857,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -9083,19 +9071,6 @@ fsevents@^2.1.2:
   version: 3.1.0
   resolution: "mimic-response@npm:3.1.0"
   checksum: cfbf19f66de6ad46df7481d9e8c1a7f30b6fa77dd771ad4a72a0443265041a39768182bde6d1de39001c2774168635bc74f42902e401c8ba33db55d69b773004
-  languageName: node
-  linkType: hard
-
-"mini-create-react-context@npm:^0.4.0":
-  version: 0.4.1
-  resolution: "mini-create-react-context@npm:0.4.1"
-  dependencies:
-    "@babel/runtime": ^7.12.1
-    tiny-warning: ^1.0.3
-  peerDependencies:
-    prop-types: ^15.0.0
-    react: ^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 26de37b293ecf37c3f858e7dfe545e652a0c177373985ec6059a54b22f1083c28b0c5b3a13910ad4bd61636a603db6f4c085752b56e007907799c9df9767f754
   languageName: node
   linkType: hard
 
@@ -9887,15 +9862,6 @@ fsevents@^2.1.2:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 6de0bfa37b4f09af465ff3900fb4104ca9cb1e1fa5cbe869c40cedd10d5d625d04c284afc34967830eee780bf83fd69c017d72a23ffd35718ec861192ec91dd9
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: 0.0.1
-  checksum: 4c0d9aaf3fc55db0b2d9aab379856acbf4e437f2252bbc2a178aec9f707c8457f8084ea6243a80e0b37c8c1c20d23e918cd43e772a7e71142a8ad67af699686b
   languageName: node
   linkType: hard
 
@@ -11775,7 +11741,7 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.12.0, react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0, react-is@npm:^16.8.1, react-is@npm:^16.8.6":
+"react-is@npm:^16.12.0, react-is@npm:^16.13.1, react-is@npm:^16.7.0, react-is@npm:^16.8.1, react-is@npm:^16.8.6":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 11bcf1267a314a522615f626f3ce3727a3a24cdbf61c4d452add3550a7875326669631326cfb1ba3e92b6f72244c32ffecf93ad21c0cad8455d3e169d0e3f060
@@ -11846,40 +11812,27 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "react-router-dom@npm:5.3.0"
+"react-router-dom@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "react-router-dom@npm:6.0.2"
   dependencies:
-    "@babel/runtime": ^7.12.13
-    history: ^4.9.0
-    loose-envify: ^1.3.1
-    prop-types: ^15.6.2
-    react-router: 5.2.1
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
+    history: ^5.1.0
+    react-router: 6.0.2
   peerDependencies:
-    react: ">=15"
-  checksum: 921c7f08354c6d7a64682d6015b46aec4d7cd89d5d3b0b9e478330630cf1c5de4adc8e5a28b871246bb91c86dc679790c76cccfefad4d4bfd3860655b0778fb3
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: eb45fca71161ec5b8cb014fd2c3fb8b6d8347baef841353be75d16d1c9518897d2e9fede26f9c2bbd6b068dab8a941ff7e3df3cf22ab2557846c1e404c551e54
   languageName: node
   linkType: hard
 
-"react-router@npm:5.2.1":
-  version: 5.2.1
-  resolution: "react-router@npm:5.2.1"
+"react-router@npm:6.0.2":
+  version: 6.0.2
+  resolution: "react-router@npm:6.0.2"
   dependencies:
-    "@babel/runtime": ^7.12.13
-    history: ^4.9.0
-    hoist-non-react-statics: ^3.1.0
-    loose-envify: ^1.3.1
-    mini-create-react-context: ^0.4.0
-    path-to-regexp: ^1.7.0
-    prop-types: ^15.6.2
-    react-is: ^16.6.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
+    history: ^5.1.0
   peerDependencies:
-    react: ">=15"
-  checksum: fd2fb21a46caabd4cc8ebaeb54c1e74733658e90eee50fd585c52e37110576ac479072d919b8a422586c361f7939c2d43dbf6d072700f6c8342808839948088a
+    react: ">=16.8"
+  checksum: 4da03e3348038252ca5c68b567b1926a0470ae1429427ff835af23d8dfab801d780058288d974691d984b58d3adef005112297e298b1145f663b26cf74fa8e6f
   languageName: node
   linkType: hard
 
@@ -12327,13 +12280,6 @@ fsevents@^2.1.2:
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
   checksum: 0d29fc7012eb21f34d2637fa0602694f60e64c14bf5fbd5395b72f6ea5540a6906cbeef062edefc34c22fd802bfe8ae46ef936e6c4a3f1b1047390f9738dd76f
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 88ed8b3dd2b5cec68d35c319dc831cd879155da153208bb9c035f263cd9220fcf0af49158456871f64a181511f8e95c483c3700a958f4110f36e513b78cfd9f0
   languageName: node
   linkType: hard
 
@@ -13436,20 +13382,6 @@ fsevents@^2.1.2:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.1.0
-  resolution: "tiny-invariant@npm:1.1.0"
-  checksum: 64318fbd77c451cfff23b57b9f3aef56594d9cea051a87dc538c9b371f97e8d474eaa2a7cbd60b8aa23f852393152495e8651b197607465fdf9c8ff134043b1b
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: 6cf9f66cb765b893976b8cd1c1310338861f30fb04d02ef2c8e0a748cbc2ed5acd8bb1954b78c15f640ad4116def67134d7d705f2a0c9bf27e6e2eb3e92bff29
-  languageName: node
-  linkType: hard
-
 "tinycolor2@npm:^1.4.1":
   version: 1.4.2
   resolution: "tinycolor2@npm:1.4.2"
@@ -14002,13 +13934,6 @@ fsevents@^2.1.2:
     spdx-correct: ^3.0.0
     spdx-expression-parse: ^3.0.0
   checksum: 940899bd4eacfa012ceecb10a5814ba0e8103da5243aa74d0d62f1f8a405efcd23e034fb7193e2d05b392870c53aabcb1f66439b062075cdcb28bc5d562a8ff6
-  languageName: node
-  linkType: hard
-
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: ae8cc7bbb2bebcaf78ecbf7669944cfc6e23f50361d0d97dc903abbfb9ce5111ce1dc5cb2575646db69636a84b2a3b224e2191088edc3442fb4669c2365af874
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description of changes
This is an start of a full update from `reach-router` to `react-router`.  Since `react-router-dom` was already used on the new metadata uploader page, I updated to use the new v6 API.

## Related issue
Related to #1108 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.

