### PR TITLE
Use forwarding rather than redirect for login page

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaWebSecurityConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/security/IridaWebSecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.web.servlet.LocaleResolver;
 
 import ca.corefacility.bioinformatics.irida.repositories.user.UserRepository;
 import ca.corefacility.bioinformatics.irida.ria.config.filters.SessionFilter;
-import ca.corefacility.bioinformatics.irida.ria.security.CredentialsExpriredAuthenticationFailureHandler;
+import ca.corefacility.bioinformatics.irida.ria.security.CredentialsExpiredAuthenticationFailureHandler;
 import ca.corefacility.bioinformatics.irida.ria.security.LoginSuccessHandler;
 
 /**
@@ -50,7 +50,7 @@ public class IridaWebSecurityConfig extends WebSecurityConfigurerAdapter {
 		}
 
 		@Autowired
-		CredentialsExpriredAuthenticationFailureHandler authFailureHandler;
+        CredentialsExpiredAuthenticationFailureHandler authFailureHandler;
 
 		@Override
 		public void configure(WebSecurity web) throws Exception {

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/security/CredentialsExpiredAuthenticationFailureHandler.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/security/CredentialsExpiredAuthenticationFailureHandler.java
@@ -33,14 +33,14 @@ import com.google.common.collect.ImmutableList;
  *
  */
 @Component
-public class CredentialsExpriredAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
-	private static final Logger logger = LoggerFactory.getLogger(CredentialsExpriredAuthenticationFailureHandler.class);
+public class CredentialsExpiredAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+	private static final Logger logger = LoggerFactory.getLogger(CredentialsExpiredAuthenticationFailureHandler.class);
 
 	private final PasswordResetService resetService;
 	private final UserService userService;
 
 	@Autowired
-	public CredentialsExpriredAuthenticationFailureHandler(PasswordResetService resetService, UserService userService) {
+	public CredentialsExpiredAuthenticationFailureHandler(PasswordResetService resetService, UserService userService) {
 		this.resetService = resetService;
 		this.userService = userService;
 	}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/security/CredentialsExpiredAuthenticationFailureHandler.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/security/CredentialsExpiredAuthenticationFailureHandler.java
@@ -43,6 +43,7 @@ public class CredentialsExpiredAuthenticationFailureHandler extends SimpleUrlAut
 	public CredentialsExpiredAuthenticationFailureHandler(PasswordResetService resetService, UserService userService) {
 		this.resetService = resetService;
 		this.userService = userService;
+		this.setUseForward(true);
 	}
 
 	/**

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/security/CredentialsExpiredAuthenticationFailureHandlerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/security/CredentialsExpiredAuthenticationFailureHandlerTest.java
@@ -22,12 +22,12 @@ import org.springframework.security.core.AuthenticationException;
 
 import ca.corefacility.bioinformatics.irida.model.user.PasswordReset;
 import ca.corefacility.bioinformatics.irida.model.user.User;
-import ca.corefacility.bioinformatics.irida.ria.security.CredentialsExpriredAuthenticationFailureHandler;
+import ca.corefacility.bioinformatics.irida.ria.security.CredentialsExpiredAuthenticationFailureHandler;
 import ca.corefacility.bioinformatics.irida.service.user.PasswordResetService;
 import ca.corefacility.bioinformatics.irida.service.user.UserService;
 
 public class CredentialsExpiredAuthenticationFailureHandlerTest {
-	private CredentialsExpriredAuthenticationFailureHandler handler;
+	private CredentialsExpiredAuthenticationFailureHandler handler;
 	private PasswordResetService resetService;
 	private UserService userService;
 
@@ -35,7 +35,7 @@ public class CredentialsExpiredAuthenticationFailureHandlerTest {
 	public void setUp() {
 		resetService = mock(PasswordResetService.class);
 		userService = mock(UserService.class);
-		handler = new CredentialsExpriredAuthenticationFailureHandler(resetService, userService);
+		handler = new CredentialsExpiredAuthenticationFailureHandler(resetService, userService);
 
 	}
 


### PR DESCRIPTION
## Description of changes
This sends unauthenticated users the login page in the response rather than sending a redirect.
Spring appears to ignore the tomcat configuration that handles headers from upstream proxies doing SSL offloading.
This causes a cross scheme redirect to be returned forcing users to use http over https.

Enabling relative redirects is the next best option over this PR:
https://github.com/OpenLiberty/open-liberty/issues/10000

I think I narrowed down where the cross scheme root redirect is occurring, but I need someone more familiar with tomcat and the spring framework to have a look at it and the information in this post:
https://stackoverflow.com/questions/3401113/spring-mvc-redirect-prefix-always-redirects-to-http-how-do-i-make-it-stay

Including the following in tomcats `server.xml:/Server/Service/Engine` does not resolve the issue:
```
<Valve className="org.apache.catalina.valves.RemoteIpValve"
    remoteIpHeader="x-forwarded-for"
    remoteIpProxiesHeader="x-forwarded-by"
    protocolHeader="x-forwarded-proto"
    protocolHeaderHttpsValue="https"
/>
```

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
