### PR TITLE
Fix GROUP BY error caused by sql_mode=only_full_group_by

### DIFF
--- a/doc/administrator/faq/index.md
+++ b/doc/administrator/faq/index.md
@@ -163,36 +163,3 @@ collation-server = utf8_general_ci
 ```
 
 You will need to drop your databases, restart your mysql service, and then recreate your databases before re-running IRIDA for the changes to take effect.
-
-### only_full_group_by error
-
-You may also run into the following error.
-
-```
-Reason: liquibase.exception.DatabaseException: Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'irida_uploader_test.ss.sample_id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
-```
-
-To fix this on a running sql instance, you can remove the `only_full_group_by` mode from sql
-
-NOTE: This will not persist when restarting mysql/mariadb
-
-```
-mysql -e "SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));"
-```
-
-To make this a permanent setting, check your config file `/etc/mysql/my.cnf` and the config files listed there, for `sql_mode`. If it doesn't exist you can add it to the config file.
-
-In mysql, check what sql_modes are currently enabled, and set your sql_mode to be the same, but with `only_full_group_by` removed.
-
-You can check your sql_mode in mysql with the command `SELECT @@sql_mode;`
-
-Example: if you have `no_auto_create_user`, `no_engine_substitution`, and `only_full_group_by` enabled, you can add/change your mode in a config file to the following.
-
-```
-[mysqld]
-
-sql_mode = "NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
-```
-
-Then restart mysql `sudo service mysql restart`
-

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/3.7.0/sample-sequencingobject.xml
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/database/changesets/3.7.0/sample-sequencingobject.xml
@@ -50,7 +50,7 @@
 			sequencingobject_id, created_date) SELECT DISTINCT ss.sample_id,
 			p.pair_id, MIN(ss.createdDate) FROM sequencefile_sample ss INNER JOIN
 			sequence_file_pair_files p ON p.files_id=ss.sequencefile_id GROUP BY
-			p.pair_id;
+			p.pair_id, ss.sample_id;
 		</sql>
 
 		<!-- Add single files to sample_sequencingobject -->
@@ -80,7 +80,7 @@
 			pf.pair_id=ss.sequencingobject_id INNER
 			JOIN sequencefile_sample_AUD
 			ssa ON ssa.sequencefile_id=pf.files_id
-			GROUP BY ss.id
+			GROUP BY ss.id, ssa.id, ssa.REV
 		</sql>
 
 		<!-- Add single end sample_seqobject_AUD data -->
@@ -97,7 +97,7 @@
 			ON pf.id=ss.sequencingobject_id INNER
 			JOIN sequencefile_sample_AUD ssa
 			ON ssa.sequencefile_id=pf.file_id
-			GROUP BY ss.id
+			GROUP BY ss.id, ssa.id, ssa.REV
 		</sql>
 
 		<!-- Drop sequencefile_sample -->


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fix liquibase changeset so that devs/admins don't have to remove `only_full_group_by` from `sql_mode` as this is default with newer version of mysql and mariadb.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
