### PR TITLE
Fixed user group not displaying

### DIFF
--- a/src/main/webapp/resources/js/contexts/UserGroupsContext.js
+++ b/src/main/webapp/resources/js/contexts/UserGroupsContext.js
@@ -3,16 +3,17 @@
  * required for displaying user groups pages
  */
 
-import React from "react";
-import { deleteUserGroup } from "../apis/users/groups";
-import { navigate } from "@reach/router";
 import { notification } from "antd";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { deleteUserGroup } from "../apis/users/groups";
 
 const initialContext = {};
 
 const UserGroupsContext = React.createContext(initialContext);
 
 function UserGroupsProvider(props) {
+  const navigate = useNavigate();
   /*
    * Deletes User Group and shows confirmation notification.
    */

--- a/src/main/webapp/resources/js/pages/UserGroupsPage/index.js
+++ b/src/main/webapp/resources/js/pages/UserGroupsPage/index.js
@@ -1,6 +1,6 @@
-import { Router } from "@reach/router";
 import React, { lazy, Suspense } from "react";
 import { render } from "react-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { getUserGroupRoles } from "../../apis/users/groups";
 import { ContentLoading } from "../../components/loader";
 import { RolesProvider } from "../../contexts/roles-context";
@@ -54,17 +54,25 @@ export function UserGroups() {
     >
       <UserGroupsProvider>
         <RolesProvider getRolesFn={getUserGroupRoles}>
-          <Router style={{ height: "100%" }}>
-            <UserGroupsPage baseUrl={DEFAULT_URL} path={DEFAULT_URL} />
-            <UserGroupsDetailsPage
-              baseUrl={DEFAULT_URL}
-              path={`${DEFAULT_URL}/:id`}
+          <Routes style={{ height: "100%" }}>
+            <Route
+              path={DEFAULT_URL}
+              element={<UserGroupsPage baseUrl={DEFAULT_URL} />}
             />
-          </Router>
+            <Route
+              path={`${DEFAULT_URL}/:id`}
+              element={<UserGroupsDetailsPage baseUrl={DEFAULT_URL} />}
+            />
+          </Routes>
         </RolesProvider>
       </UserGroupsProvider>
     </Suspense>
   );
 }
 
-render(<UserGroups />, document.querySelector("#groups-root"));
+render(
+  <BrowserRouter>
+    <UserGroups />
+  </BrowserRouter>,
+  document.querySelector("#groups-root")
+);


### PR DESCRIPTION
## Description of changes
Fixes issue where the user groups page does not load for a regular user.  This was caused by an upgrade to react-router-dom from reach-router.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~~
~~* [ ] Tests added (or description of how to test) for any new features.~~
~~* [ ] User documentation updated for UI or technical changes.~~
