### PR TITLE
Hotfix/correct rest api date fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+22.01 to 22.05
+--------------
+* [REST]: Corrected behaviour of date fields in REST API to return epoch instead of textual string. (22.01.1)
+
 21.09 to 22.01
 --------------
 * [REST]: Fixed bug where analysis output file bytes were being included in responses when only JSON should have been sent. (21.09.1)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -7,6 +7,12 @@ upgrading IRIDA that cannot be automated.
 21.09 to 22.01
 --------------
 * This upgrade converted the project from bare Spring to Spring Boot, which deprecated a number of properties relating to database connection and setup. These deprecated properties are mentioned in [/etc/irida/irida.conf](https://phac-nml.github.io/irida-documentation/administrator/web/#core-configuration).
+* Due to an update in Spring you will need to revoke tokens for all OAuth clients, you can perform this through the UI or with the following sql:
+```sql
+USE IRIDA_DB_NAME;
+truncate oauth_access_token;
+truncate oauth_refresh_token;
+```
 
 21.09.1 to 21.09.2
 ------------------

--- a/pom.xml
+++ b/pom.xml
@@ -1,16 +1,15 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
 		<version>2.6.3</version>
-		<relativePath/>
+		<relativePath />
 	</parent>
 	<groupId>ca.corefacility.bioinformatics</groupId>
 	<artifactId>irida</artifactId>
 	<packaging>war</packaging>
-	<version>22.01</version>
+	<version>22.01.1</version>
 	<name>irida</name>
 	<url>http://www.irida.ca</url>
 
@@ -953,7 +952,9 @@
 		<profile>
 			<id>ui_testing</id>
 			<properties>
-				<include.tags><![CDATA[IntegrationTest & UI]]></include.tags>
+				<include.tags>
+					<![CDATA[IntegrationTest & UI]]>
+				</include.tags>
 				<tomcat.skip>true</tomcat.skip>
 				<exclude.test.listeners>
 					ca.corefacility.bioinformatics.irida.junit5.listeners.UnitTestListener,
@@ -963,7 +964,9 @@
 		<profile>
 			<id>service_testing</id>
 			<properties>
-				<include.tags><![CDATA[IntegrationTest & Service]]></include.tags>
+				<include.tags>
+					<![CDATA[IntegrationTest & Service]]>
+				</include.tags>
 				<tomcat.skip>true</tomcat.skip>
 				<exclude.test.listeners>
 					ca.corefacility.bioinformatics.irida.junit5.listeners.UnitTestListener,
@@ -974,7 +977,9 @@
 		<profile>
 			<id>rest_testing</id>
 			<properties>
-				<include.tags><![CDATA[IntegrationTest & Rest]]></include.tags>
+				<include.tags>
+					<![CDATA[IntegrationTest & Rest]]>
+				</include.tags>
 				<tomcat.skip>true</tomcat.skip>
 				<exclude.test.listeners>
 					ca.corefacility.bioinformatics.irida.junit5.listeners.UnitTestListener,
@@ -985,7 +990,9 @@
 		<profile>
 			<id>galaxy_testing</id>
 			<properties>
-				<include.tags><![CDATA[IntegrationTest & Galaxy & !Pipeline]]></include.tags>
+				<include.tags>
+					<![CDATA[IntegrationTest & Galaxy & !Pipeline]]>
+				</include.tags>
 				<tomcat.skip>true</tomcat.skip>
 				<exclude.test.listeners>
 					ca.corefacility.bioinformatics.irida.junit5.listeners.UnitTestListener,
@@ -996,7 +1003,9 @@
 		<profile>
 			<id>galaxy_pipeline_testing</id>
 			<properties>
-				<include.tags><![CDATA[IntegrationTest & Galaxy & Pipeline]]></include.tags>
+				<include.tags>
+					<![CDATA[IntegrationTest & Galaxy & Pipeline]]>
+				</include.tags>
 				<tomcat.skip>true</tomcat.skip>
 				<exclude.test.listeners>
 					ca.corefacility.bioinformatics.irida.junit5.listeners.UnitTestListener,

--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/web/IridaRestApiWebConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/web/IridaRestApiWebConfig.java
@@ -1,8 +1,8 @@
 package ca.corefacility.bioinformatics.irida.config.web;
 
 import java.nio.file.Path;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -22,6 +22,7 @@ import org.springframework.web.servlet.view.ContentNegotiatingViewResolver;
 import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
 
 import ca.corefacility.bioinformatics.irida.web.controller.api.json.PathJson;
+import ca.corefacility.bioinformatics.irida.web.controller.api.json.TimestampJson;
 import ca.corefacility.bioinformatics.irida.web.spring.view.*;
 
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -79,14 +80,18 @@ public class IridaRestApiWebConfig implements WebMvcConfigurer {
 		// add support for serializing Path data
 		SimpleModule module = new SimpleModule();
 		module.addSerializer(Path.class, new PathJson.PathSerializer());
-		jsonView.getObjectMapper()
-				.registerModule(module);
+		jsonView.getObjectMapper().registerModule(module);
 
-		// java.util.date fields (i.e. createdDate, modifiedDate, etc) are stored in the database with
-		// seconds precision, but are generated at higher precision. To combat this, previously the entity
-		// was re-read from the database. Now we are just formatting the date with 0s for milliseconds
+		// java.util.date fields (i.e. createdDate, modifiedDate, etc) are
+		// stored in the database with
+		// seconds precision, but are generated at higher precision. To combat
+		// this, previously the entity
+		// was re-read from the database. Now we are just formatting the date
+		// with 0s for milliseconds
 		// portion.
-		jsonView.getObjectMapper().setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.'000Z'"));
+		SimpleModule timestampModule = new SimpleModule();
+		timestampModule.addSerializer(Date.class, new TimestampJson.TimestampSerializer());
+		jsonView.getObjectMapper().registerModule(timestampModule);
 
 		views.add(jsonView);
 
@@ -103,8 +108,6 @@ public class IridaRestApiWebConfig implements WebMvcConfigurer {
 		Map<String, MediaType> mediaTypes = ImmutableMap.of("json", MediaType.APPLICATION_JSON, "fasta",
 				MediaType.valueOf("application/fasta"), "fastq", MediaType.valueOf("application/fastq"), "gbk",
 				MediaType.valueOf("application/genbank"));
-		configurer.ignoreAcceptHeader(false)
-				.defaultContentType(MediaType.APPLICATION_JSON)
-				.mediaTypes(mediaTypes);
+		configurer.ignoreAcceptHeader(false).defaultContentType(MediaType.APPLICATION_JSON).mediaTypes(mediaTypes);
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/json/TimestampJson.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/json/TimestampJson.java
@@ -1,0 +1,38 @@
+package ca.corefacility.bioinformatics.irida.web.controller.api.json;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Date;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import org.apache.commons.lang3.time.DateUtils;
+
+/**
+ * Serialization class for java Date objects. We use DATETIME types for storing
+ * our timestamps in mysql. DATETIME only stores at seconds precision by
+ * default. In the REST api when we create an object the timestamps will have
+ * milliseconds precision but on subsequent fetchs the timestamps will only have
+ * seconds precision. This enforces the timestamp fields to only ever have
+ * seconds precision.
+ */
+public class TimestampJson {
+
+	/**
+	 * Default serializer for {@link Date} objects.
+	 */
+	public static class TimestampSerializer extends StdSerializer<Date> {
+
+		public TimestampSerializer() {
+			super(Date.class);
+		}
+
+		@Override
+		public void serialize(Date value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+			gen.writeNumber(DateUtils.truncate(value, Calendar.SECOND).getTime());
+		}
+
+	}
+}


### PR DESCRIPTION
## Description of changes
In 22.01 I incorrectly changed the response format of the REST API date fields to textual string instead of epoch ms. This reverts back to the old behavior and updates the UPGRADING.md to mention issues we faced when deploying 22.01.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
