### PR TITLE
HOTFIX: CVE-2022-22965

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes
 =======
 
+22.03 to 22.05
+--------------
+* [ALL]: Upgraded to Spring Boot 2.6.6 which fixes CVE-2022-22965. (22.03.1)
+
 22.01 to 22.03
 --------------
 * [REST]: Corrected behaviour of date fields in REST API to return epoch instead of textual string. (22.01.1)

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>ca.corefacility.bioinformatics</groupId>
   <artifactId>irida</artifactId>
   <packaging>war</packaging>
-  <version>22.03</version>
+  <version>22.03.1</version>
   <name>irida</name>
   <url>http://www.irida.ca</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.3</version>
+    <version>2.6.6</version>
     <relativePath />
   </parent>
   <groupId>ca.corefacility.bioinformatics</groupId>


### PR DESCRIPTION
## Description of changes
Upgraded to Spring Boot 2.6.6 which fixes CVE-2022-22965.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
