### PR TITLE
Fix add new sample modal not resetting fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Changes
 * [Developer]: Removed unused DataTables code.
 * [UI]: Sorted columns for advanced charts and added labels to tiny charts on admin statistics page.
 * [UI]: Fixed: Allow organism name not included in the current taxonomy.
+* [UI]: Fixed: Add new sample modal fields now reset after sample was created or if the modal was closed.
 
 22.01 to 22.03
 --------------

--- a/src/main/webapp/resources/js/pages/projects/samples/add-sample/AddSampleButton.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/add-sample/AddSampleButton.jsx
@@ -100,10 +100,16 @@ function AddSampleForm({ onSubmit, visible = false }) {
           term={organism}
           ontology={TAXONOMY}
           onTermSelected={(value) => setOrganism(value)}
+          className="t-organism"
         />
       </Form.Item>
       <Form.Item>
-        <Button type={"primary"} htmlType={"submit"} disabled={!isValid}>
+        <Button
+          type={"primary"}
+          htmlType={"submit"}
+          disabled={!isValid}
+          className="t-add-new-sample-create-btn"
+        >
           {i18n("AddSample.submit")}
         </Button>
       </Form.Item>

--- a/src/main/webapp/resources/js/pages/projects/samples/add-sample/AddSampleButton.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/add-sample/AddSampleButton.jsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import { render } from "react-dom";
 import { Button, Form, Input, Modal } from "antd";
 import { IconPlusCircle } from "../../../../components/icons/Icons";
 import { grey6, grey9 } from "../../../../styles/colors";
-import { OntologyInput } from "../../../../components/ontology";
-import { TAXONOMY } from "../../../../apis/ontology/taxonomy";
 import {
   createNewSample,
   validateSampleName,
 } from "../../../../apis/projects/samples";
+import { OntologyInput } from "../../../../components/ontology";
+import { TAXONOMY } from "../../../../apis/ontology/taxonomy";
 
 /**
  * React Ant Design form to create a new sample within a project.
@@ -19,17 +19,19 @@ import {
  */
 function AddSampleForm({ onSubmit, visible = false }) {
   const [form] = Form.useForm();
-  const [name, setName] = useState("");
-  const [isValid, setIsValid] = useState(false);
-  const [organism, setOrganism] = useState("");
-  const nameRef = useRef();
+  const [name, setName] = React.useState("");
+  const [isValid, setIsValid] = React.useState(false);
+  const [organism, setOrganism] = React.useState("");
+  const nameRef = React.useRef();
+
+  React.useEffect(() => {}, [visible]);
 
   /**
    * Watch for changes in the modal visibilty. When it changes update the form to reflect.
    * If it opens, focus on the name input
    * If it closes, clear fields
    */
-  useEffect(() => {
+  React.useEffect(() => {
     if (visible) {
       nameRef.current.focus();
     } else {
@@ -116,7 +118,12 @@ function AddSampleForm({ onSubmit, visible = false }) {
  * @constructor
  */
 function AddSampleButton() {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = React.useState(false);
+  const [modalFormVisible, setModalFormVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    setModalFormVisible(visible);
+  }, [visible]);
 
   /**
    * Open the modal to create a new sample.
@@ -156,7 +163,10 @@ function AddSampleButton() {
         title={i18n("AddSample.title")}
         footer={null}
       >
-        <AddSampleForm onSubmit={closeNewSampleModal} visible={visible} />
+        <AddSampleForm
+          onSubmit={closeNewSampleModal}
+          visible={modalFormVisible}
+        />
       </Modal>
     </>
   );

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
@@ -183,6 +183,12 @@ public class ProjectSamplesPage extends ProjectPageBase {
 	@FindBy(className = "t-linker-cmd")
 	private WebElement linkerCmd;
 
+	@FindBy(className = "t-add-new-sample-create-btn")
+	private WebElement createSampleSubmitButton;
+
+	@FindBy(className = "ant-modal-close")
+	private WebElement createNewSampleModalCloseButton;
+
 	public ProjectSamplesPage(WebDriver driver) {
 		super(driver);
 	}
@@ -503,6 +509,20 @@ public class ProjectSamplesPage extends ProjectPageBase {
 
 	public boolean isSampleNameErrorDisplayed() {
 		return driver.findElements(By.cssSelector(".t-sample-name-wrapper .ant-form-item-explain")).size() > 0;
+	}
+
+	public boolean isSampleNameClear() {
+		return sampleNameInput.getText().equals("");
+	}
+
+	public void clickCreateSampleSubmitButton() {
+		createSampleSubmitButton.click();
+		waitForTime(1000);
+	}
+
+	public void closeCreateNewSampleModal() {
+		createNewSampleModalCloseButton.click();
+		waitForTime(500);
 	}
 
 	/**

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -339,4 +339,25 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 		page.enterSampleName("GOOD_NAME");
 		assertFalse(page.isSampleNameErrorDisplayed(), "Sample name error should not be displayed");
 	}
+
+	@Test
+	public void testAddNewSampleModalResetting() {
+		LoginPage.loginAsManager(driver());
+		ProjectSamplesPage page = ProjectSamplesPage.gotToPage(driver(), 1);
+
+		page.openCreateNewSampleModal();
+		page.enterSampleName("GOOD_NAME");
+		page.closeCreateNewSampleModal();
+
+		page.openCreateNewSampleModal();
+		assertTrue(page.isSampleNameClear(), "Sample name input should be empty");
+		page.closeCreateNewSampleModal();
+
+		page.openCreateNewSampleModal();
+		page.enterSampleName("GOOD_NAME_FIRST");
+		page.clickCreateSampleSubmitButton();
+
+		page.openCreateNewSampleModal();
+		assertTrue(page.isSampleNameClear(), "Sample name input should be empty");
+	}
 }


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed bug where add new sample modal was not cleared after creating a previous sample right before or if text was entered into the modal and then closed

Fixes #973 

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
