### PR TITLE
Disable built-in SISTR and Mentalist pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Changes
 * [Developer]: Updated redux API within the cart page to use Redux Toolkit.
 * [All]: Added functionality for project managers to restrict metadata fields depending on the Collaborator's metadata role on the project.
 * [Developer]: Removed IRIDA virtual appliance build scripts and references in documentation.
+* [Workflow]: Disable the built-in SISTR and the MentaLiST pipelines by default as they are deprecated. They can be re-enabled in `/etc/irida/irida.conf`.
 
 22.01 to 22.03
 --------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Changes
 * [All]: Added functionality for project managers to restrict metadata fields depending on the Collaborator's metadata role on the project.
 * [Developer]: Removed IRIDA virtual appliance build scripts and references in documentation.
 * [Workflow]: Disable the built-in SISTR and the MentaLiST pipelines by default as they are deprecated. They can be re-enabled in `/etc/irida/irida.conf`.
+* [Workflow]: Automated pipelines which become marked as disabled will now be prevented from running, similar to out-of-date automated pipelines.
 
 22.01 to 22.03
 --------------

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,15 @@ Upgrading
 This document summarizes the environmental changes that need to be made when
 upgrading IRIDA that cannot be automated.
 
+22.03 to 22.05
+--------------
+* This upgrade deprecates two pipelines, SISTR_TYPING and MLST_MENTALIST, and disables them from being executed. Any previously-run analysis results will still function as normal. If you wish to re-enable these pipelines you can set `irida.workflow.types.disabled=` (i.e., set the value to empty) in the `/etc/irida/irida.conf` file and restart IRIDA. If you wish to keep these pipelines disabled but include your own additional disabled pipelines you can set `irida.workflow.types.disabled=SISTR_TYPING,MLST_MENTALIST` and add your own pipelines to disable after this list.
+   * For SISTR_TYPING, it is recommended to switch to using the version implemented as a plugin <https://github.com/phac-nml/irida-plugin-sistr>. For MLST_MENTALIST, we can no longer provide support for the installation of this software in IRIDA and Galaxy and have chosen to deprecate it.
+
+22.01 to 22.03
+--------------
+* It is recommended to stop the servlet container before deploying the new `war` file.
+
 21.09 to 22.01
 --------------
 * This upgrade converted the project from bare Spring to Spring Boot, which deprecated a number of properties relating to database connection and setup. These deprecated properties are mentioned in [/etc/irida/irida.conf](https://phac-nml.github.io/irida-documentation/administrator/web/#core-configuration).

--- a/doc/administrator/web/config/irida.conf
+++ b/doc/administrator/web/config/irida.conf
@@ -178,4 +178,6 @@ ncbi.upload.namespace=IRIDA
 
 # A list of workflow types to disable from display in the web interface
 # For example `irida.workflow.types.disabled=ASSEMBLY_ANNOTATION,ASSEMBLY_ANNOTATION_COLLECTION,BIO_HANSEL,MLST_MENTALIST,REFSEQ_MASHER,SISTR_TYPING,PHYLOGENOMICS`
+# If you wish to re-enable any default disabled pipelines, you can set this to an empty value (i.e., irida.workflow.types.disabled=)
+# If you wish to keep the default disabled pipelines but include additional pipelines, you can set to (irida.workflow.types.disabled=SISTR_TYPING,MLST_MENTALIST) and include your own after this list.
 #irida.workflow.types.disabled=

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/config/workflows.properties
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/config/workflows.properties
@@ -6,7 +6,7 @@ irida.workflow.default.BIO_HANSEL=0e8738e6-2aeb-4627-9d6e-15ae32f21c44
 irida.workflow.default.REFSEQ_MASHER=1317f2dc-191f-48d0-a54c-2fccd3f9ab53
 irida.workflow.default.MLST_MENTALIST=cdcbdf7b-7276-4845-b225-9ea41159e791
 
-irida.workflow.types.disabled=SISTR_TYPING
+irida.workflow.types.disabled=SISTR_TYPING,MLST_MENTALIST
 
 irida.workflow.max-running=4
 irida.workflow.analysis.threads=4

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/config/workflows.properties
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/config/workflows.properties
@@ -6,7 +6,7 @@ irida.workflow.default.BIO_HANSEL=0e8738e6-2aeb-4627-9d6e-15ae32f21c44
 irida.workflow.default.REFSEQ_MASHER=1317f2dc-191f-48d0-a54c-2fccd3f9ab53
 irida.workflow.default.MLST_MENTALIST=cdcbdf7b-7276-4845-b225-9ea41159e791
 
-irida.workflow.types.disabled=
+irida.workflow.types.disabled=SISTR_TYPING
 
 irida.workflow.max-running=4
 irida.workflow.analysis.threads=4

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -1603,6 +1603,7 @@ analysis.html.file.not.found= Unable to read output of {0}.
 analysis.template.status.outdated=The selected pipeline has been updated since this automated analysis was created, so this analysis has been disabled.  You must remove this analysis and create a new one to select any new parameters or options.
 analysis.template.status.nodefault=No pipeline is set as default for this analysis type.
 analysis.template.status.notexists=No pipeline is installed for this analysis type.
+analysis.template.status.disabled=The selected pipeline has been disabled (via the IRIDA 'irida.workflow.types.disabled' configuration property). This automated analysis will no longer work.
 analysis.template.status.lastlaunched=Last launched {0}
 analysis.template.status.new=New automated analysis.  Upload sequencing data to automatically launch this pipeline.
 


### PR DESCRIPTION
## Description of changes

This sets the default status of the built-in `SISTR_TYPING` and `MLST_MENTALIST` pipelines to disabled. A disabled pipeline still exists in IRIDA, but it is not possible to run it. For SISTR, we are switching to the plugin version of the pipeline. For Mentalist we are deprecating the pipeline.

The code for disabling pipelines already existed. This mainly changes the default pipelines which are disabled (above). These can be overridden with the configuration property `irida.workflow.types.disabled` (i.e., to re-enable these pipelines, you can set this property to blank in the `/etc/irida/irida.conf` file).

One small bit of code change that was required was with automated pipelines for a project. Previously, we were disabling automated pipelines if a new version of a pipeline was released. I modified this code to also disable these automated pipelines for anything that is disabled in IRIDA. This will write a message to users informing them that the particular pipeline got disabled:

![image](https://user-images.githubusercontent.com/200517/168175009-802e9f91-1aed-422b-8f09-75b3b21432c5.png)

### Testing

If you wished to test the code for disabling automated pipelines, you can test with RefSeq Masher (or any pipeline really). First setup an automated pipeline that runs RefSeq Masher. Then set `irida.workflow.types.disabled=REFSEQ_MASHER` in `/etc/irida/irida.conf` and restart IRIDA. When you next upload data to the project, the automated pipeline for RefSeq Masher should automatically be disabled and display an appropriate message.

## Related issue

Fix for issue #1022 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [x] User documentation updated for UI or technical changes.
