### PR TITLE
Fixes issue with full color bleeds on layout pages

### DIFF
--- a/src/main/webapp/pages/index.html
+++ b/src/main/webapp/pages/index.html
@@ -6,15 +6,10 @@
 >
 <head>
     <title th:text="#{dashboard.title}"></title>
-    <webpacker:css entry="dashboard" />
-    <style>
-        body {
-            background-color: hsl(216deg 20% 95%);
-        }
-    </style>
+    <webpacker:css entry="dashboard"/>
 </head>
 <body>
-<div id="root" style="height: 100%;" layout:fragment="page">
+<div id="root" layout:fragment="page">
     <!--
              This is a DOM element for React to render the dashboard into.
              See  src/main/webapp/resources/js/pages/dashboard/Dashboard.jsx
@@ -22,7 +17,7 @@
 </div>
 
 <th:block layout:fragment="scripts">
-    <webpacker:js  entry="dashboard" />
+    <webpacker:js entry="dashboard"/>
 </th:block>
 </body>
 </html>

--- a/src/main/webapp/pages/projects/projects.html
+++ b/src/main/webapp/pages/projects/projects.html
@@ -11,7 +11,6 @@
   <body>
     <div
       id="root"
-      style="height: 100%; min-height: 100%"
       layout:fragment="page"
     ></div>
 

--- a/src/main/webapp/pages/sequencing-runs/index.html
+++ b/src/main/webapp/pages/sequencing-runs/index.html
@@ -5,7 +5,7 @@
   data-layout-decorate="~{template/page}"
 >
   <head>
-    <title>Sequencing Runs</title>
+    <title th:text="#{SequencingRunListPage.title}">Sequencing Runs</title>
     <webpacker:css entry="sequencing-runs" />
   </head>
   <body>

--- a/src/main/webapp/pages/sequencing-runs/index.html
+++ b/src/main/webapp/pages/sequencing-runs/index.html
@@ -1,24 +1,19 @@
 <!DOCTYPE html>
 <html
-        xmlns:th="http://www.thymeleaf.org"
-        xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-        data-layout-decorate="~{template/page}"
+  xmlns:th="http://www.thymeleaf.org"
+  xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+  data-layout-decorate="~{template/page}"
 >
-<head>
+  <head>
     <title>Sequencing Runs</title>
-    <webpacker:css entry="sequencing-runs"/>
-    <style>
-        body {
-            background-color: hsl(216deg 20% 95%);
-        }
-    </style>
-</head>
-<body>
-<div id="root" style="height: 100%" layout:fragment="page">
-    <!-- Contents rendered from SequencingRunListPage.jsx -->
-</div>
-<th:block layout:fragment="scripts">
-    <webpacker:js entry="sequencing-runs"/>
-</th:block>
-</body>
+    <webpacker:css entry="sequencing-runs" />
+  </head>
+  <body>
+    <div id="root" layout:fragment="page">
+      <!-- Contents rendered from SequencingRunListPage.jsx -->
+    </div>
+    <th:block layout:fragment="scripts">
+      <webpacker:js entry="sequencing-runs" />
+    </th:block>
+  </body>
 </html>

--- a/src/main/webapp/pages/template/page.html
+++ b/src/main/webapp/pages/template/page.html
@@ -4,19 +4,13 @@
       data-layout-decorate="~{template/base}">
 <head>
 	<webpacker:css entry="app" />
-  <style>
-    <!-- This is used by angular to prevent page flickering. Remove when done with angular -->
-    .ng-cloak {
-      display: none !important;
-    }
-  </style>
   <script th:inline="javascript">
     window.breadcrumbs = /*[[${breadcrumbs}]]*/ [];
   </script>
 </head>
 <body>
 <th:block layout:fragment="content">
-  <div class="ant-layout" style="height: 100vw; background-color: white;">
+  <div class="ant-layout">
     <header class="js-page-header"></header>
     <div class="ant-layout-content" layout:fragment="page"></div>
   </div>

--- a/src/main/webapp/pages/user/account.html
+++ b/src/main/webapp/pages/user/account.html
@@ -7,14 +7,9 @@
   <head>
     <title th:text="#{user.account}">_USER PAGE_</title>
     <webpacker:css entry="user" />
-    <style>
-      body {
-        background-color: hsl(216deg 20% 95%);
-      }
-    </style>
   </head>
   <body>
-    <div id="user-account-root" style="height: 100%" layout:fragment="page">
+    <div id="user-account-root" style="height: 100%;" layout:fragment="page">
       <!-- Contents rendered from UserDetailsPage.jsx -->
     </div>
     <th:block layout:fragment="scripts">

--- a/src/main/webapp/resources/css/app.css
+++ b/src/main/webapp/resources/css/app.css
@@ -15,6 +15,11 @@ body {
   flex-direction: column;
 }
 
+body > .ant-layout {
+  height: 100vh;
+  background-color: #ffffff;
+}
+
 /****************************************************************************************
 * BOOTSTRAP OVERRIDES
 *****************************************************************************************/
@@ -26,8 +31,8 @@ body {
 }
 
 .nav-tabs {
-  border-bottom: 1px solid #e6e8eb !important;
   margin-bottom: 1.3rem;
+  border-bottom: 1px solid #e6e8eb !important;
   li {
     a {
       border: none !important;
@@ -38,8 +43,8 @@ body {
       border-bottom: 1px solid #1c2833 !important;
     }
     &:not(.active) a {
-      background-color: transparent !important;
       color: #717f8c !important;
+      background-color: transparent !important;
     }
   }
 }
@@ -54,20 +59,20 @@ label.ant-checkbox-wrapper {
 
 @keyframes fadeInDown {
   from {
-    opacity: 0;
     transform: translate3d(0, -100%, 0);
+    opacity: 0;
   }
 
   to {
-    opacity: 1;
     transform: translate3d(0, 0, 0);
+    opacity: 1;
   }
 }
 
 .fadeInDown {
+  animation-name: fadeInDown;
   animation-duration: 0.5s;
   animation-fill-mode: both;
-  animation-name: fadeInDown;
 }
 
 @keyframes fadeOutUp {
@@ -76,15 +81,15 @@ label.ant-checkbox-wrapper {
   }
 
   to {
-    opacity: 0;
     transform: translate3d(0, -100%, 0);
+    opacity: 0;
   }
 }
 
 .fadeOutUp {
+  animation-name: fadeOutUp;
   animation-duration: 0.5s;
   animation-fill-mode: both;
-  animation-name: fadeOutUp;
 }
 
 /****************************************************************************************
@@ -96,10 +101,10 @@ label.ant-checkbox-wrapper {
 }
 
 .body-content {
-  flex-grow: 1;
-  width: 100%;
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
+  width: 100%;
 }
 
 .navbar-collapse {
@@ -131,23 +136,23 @@ label.ant-checkbox-wrapper {
 
 /*// Notifications*/
 .navbar-notification .angular-notifications-icon {
-  background-color: #3092d0;
-  border-radius: 10px;
   top: 3px;
   right: -3px;
-  height: 20px;
   width: 20px !important;
+  height: 20px;
   padding: 0 !important;
   font-size: 1.3rem;
   line-height: 2rem;
+  background-color: #3092d0;
+  border-radius: 10px;
 }
 
 /*// Allow for proper styling in collapsed navigation.*/
 @media (max-width: 768px) {
   #global-search {
     .search-wrapper {
-      width: 100%;
       display: block;
+      width: 100%;
 
       input[type="search"] {
         width: 100%;
@@ -194,26 +199,26 @@ h2.h2-muted {
 }
 
 .selected__counts {
-  color: white !important;
-  border-radius: 4px;
-  padding: 4px 8px 6px 8px;
   margin: 5px;
+  padding: 4px 8px 6px 8px;
+  color: white !important;
   background-color: rgba(0, 0, 0, 0.5);
   border-top: 1px solid rgba(0, 0, 0, 0.4);
+  border-radius: 4px;
 }
 
 .crop {
   max-width: 250px !important;
-  white-space: nowrap !important;
   overflow: hidden !important;
+  white-space: nowrap !important;
   text-overflow: ellipsis !important;
 }
 
 .wrap-cell {
   max-width: 160px !important;
   white-space: normal;
-  word-wrap: break-word;
   text-align: left !important;
+  word-wrap: break-word;
 }
 
 /*// Defaults spacing for the bottom of elements.*/
@@ -261,22 +266,22 @@ ol.continue li:before {
 }
 
 .remote-hint {
-  font-size: 1.4em;
   padding-bottom: 10px;
+  font-size: 1.4em;
 }
 
 /*// Display a number next above and to the right*/
 /*// of a button. Ex. Cart icon in navbar.*/
 .btn__badge {
-  background-color: RGB(54, 147, 206);
-  border-radius: 2px;
-  color: white;
-
-  padding: 1px 5px;
-  font-size: 0.8em;
   position: absolute;
   top: 5px;
   right: 0;
+
+  padding: 1px 5px;
+  color: white;
+  font-size: 0.8em;
+  background-color: RGB(54, 147, 206);
+  border-radius: 2px;
 }
 
 /*// Wrapping long sample names to the size of the container*/
@@ -290,9 +295,9 @@ ol.continue li:before {
 
 /*// OVERLAY*/
 .ag-overlay-loading-center.irida-ag-overlay {
-  border-color: #95d7fb !important;
-  background-color: #e7f7ff !important;
   font-size: 14px !important;
+  background-color: #e7f7ff !important;
+  border-color: #95d7fb !important;
 }
 
 .irida-ag-overlay-loading-icon {

--- a/src/main/webapp/resources/js/components/page/NarrowPageWrapper.jsx
+++ b/src/main/webapp/resources/js/components/page/NarrowPageWrapper.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Col, Layout, PageHeader, Row } from "antd";
+import "./styles.css";
 
 /**
  * Standard page layout for pages that have a narrow width layout (e.g. user account details)

--- a/src/main/webapp/resources/js/components/page/PageWrapper.jsx
+++ b/src/main/webapp/resources/js/components/page/PageWrapper.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Layout, PageHeader } from "antd";
 import { grey1 } from "../../styles/colors";
 import { SPACE_MD } from "../../styles/spacing";
+import "./styles.css";
 
 const { Content } = Layout;
 
@@ -24,7 +25,7 @@ export function PageWrapper({
   subTitle = "",
 }) {
   return (
-    <Layout style={{ height: "100%", minHeight: "100%" }}>
+    <Layout>
       <PageHeader
         className="t-main-heading"
         title={title}

--- a/src/main/webapp/resources/js/components/page/styles.css
+++ b/src/main/webapp/resources/js/components/page/styles.css
@@ -1,0 +1,4 @@
+body,
+body > .ant-layout {
+  background-color: hsl(216deg 20% 95%);
+}

--- a/src/main/webapp/resources/js/pages/user/components/UserAccountLayout.jsx
+++ b/src/main/webapp/resources/js/pages/user/components/UserAccountLayout.jsx
@@ -38,13 +38,12 @@ export default function UserAccountLayout() {
       }
       onBack={showBack ? goToAdminUserListPage : undefined}
     >
-      <Layout>
-        <Sider width={200} style={{ backgroundColor: grey1 }}>
+      <Layout style={{ backgroundColor: grey1 }}>
+        <Sider width={200}>
           <UserAccountNav />
         </Sider>
         <Content
           style={{
-            backgroundColor: grey1,
             padding: SPACE_LG,
             marginBottom: SPACE_LG,
           }}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
@@ -339,7 +339,7 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		sampleNameFilterToggle.click();
 		nameFilterInput.sendKeys(name);
 		nameFilterInput.sendKeys(Keys.ENTER);
-		sampleNameFilterToggle.click();
+		nameFilterInput.sendKeys(Keys.TAB);
 		waitForTableToUpdate();
 	}
 
@@ -347,7 +347,7 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		sampleNameFilterToggle.click();
 		WebElement filter = nameFilterSelectedOptions.findElement(By.cssSelector("[title=\"" + name + "\"]"));
 		filter.findElement(By.className("ant-select-selection-item-remove")).click();
-		sampleNameFilterToggle.click();
+		sampleNameFilterToggle.sendKeys(Keys.TAB);
 		waitForTableToUpdate();
 	}
 
@@ -355,7 +355,7 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		organismFilterToggle.click();
 		organismSelectInput.sendKeys(organism);
 		organismSelectInput.sendKeys(Keys.ENTER);
-		organismFilterToggle.click();
+		organismFilterToggle.sendKeys(Keys.TAB);
 		waitForTableToUpdate();
 	}
 
@@ -363,7 +363,7 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		organismFilterToggle.click();
 		WebElement filter = organismFilterSelectedOptions.findElement(By.cssSelector("[title=\"" + organism + "\"]"));
 		filter.findElement(By.className("ant-select-selection-item-remove")).click();
-		organismFilterToggle.click();
+		organismFilterToggle.sendKeys(Keys.TAB);
 		waitForTableToUpdate();
 	}
 


### PR DESCRIPTION
## Description of changes

Fixes the need to add `background-color: hsl(216deg 20% 95%);` to the body of pages that use the `NarrowPageWrapper` or the `PageWrapper`.  This is done by importing a small CSS file into the layout component.  Do not need to use `styled-components` for this since you need direct access to the `body` tag and we have been having some issues with conflicts with multiple instances of `styled-components`.

## Relatefile d issue

Link to the GitHub issue this pull request addresses using the `#issuenum` format. If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist

Things for the developer to confirm they've done before the PR should be accepted:

*   [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
*   [ ] Tests added (or description of how to test) for any new features.
*   [ ] User documentation updated for UI or technical changes.