### PR TITLE
Fix AnalysisSubmission deletion null pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Changes
 * [UI]: Fixed: Excel output file preview displaying numeric values as a whole number rather than in scientific notation.
 * [UI]: Updated the sequence run page to use Ant Design.
 * [UI]: Updated `forgot password`, `account activation`, and `reset password` pages to use Ant Design.
+* [Developer/Workflow]: Fixed issue with deleting AnalysisSubmission raising null pointer execptions due to bean wiring issue (issue #1287).
 
 22.01 to 22.03
 --------------

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/analysis/submission/AnalysisSubmissionServiceImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/impl/analysis/submission/AnalysisSubmissionServiceImpl.java
@@ -1,6 +1,33 @@
 package ca.corefacility.bioinformatics.irida.service.impl.analysis.submission;
 
-import ca.corefacility.bioinformatics.irida.exceptions.*;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import javax.transaction.Transactional;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.history.Revision;
+import org.springframework.data.history.Revisions;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.prepost.PostFilter;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import ca.corefacility.bioinformatics.irida.exceptions.EntityExistsException;
+import ca.corefacility.bioinformatics.irida.exceptions.EntityNotFoundException;
+import ca.corefacility.bioinformatics.irida.exceptions.ExecutionManagerException;
+import ca.corefacility.bioinformatics.irida.exceptions.NoPercentageCompleteException;
 import ca.corefacility.bioinformatics.irida.model.enums.AnalysisCleanedState;
 import ca.corefacility.bioinformatics.irida.model.enums.AnalysisState;
 import ca.corefacility.bioinformatics.irida.model.enums.StatisticTimePeriod;
@@ -34,47 +61,24 @@ import ca.corefacility.bioinformatics.irida.service.SequencingObjectService;
 import ca.corefacility.bioinformatics.irida.service.analysis.execution.galaxy.AnalysisExecutionServiceGalaxyCleanupAsync;
 import ca.corefacility.bioinformatics.irida.service.impl.CRUDServiceImpl;
 import ca.corefacility.bioinformatics.irida.service.workflow.IridaWorkflowsService;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
-import org.springframework.data.history.Revision;
-import org.springframework.data.history.Revisions;
-import org.springframework.data.jpa.domain.Specification;
-import org.springframework.security.access.prepost.PostFilter;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Validator;
-import java.util.*;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Implementation of an AnalysisSubmissionService.
- *
- *
  */
 @Service
-public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, AnalysisSubmission> implements
-		AnalysisSubmissionService {
+public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, AnalysisSubmission>
+		implements AnalysisSubmissionService {
 	private static final Logger logger = LoggerFactory.getLogger(AnalysisSubmissionServiceImpl.class);
 
 	/**
-	 * A {@link Map} defining the progress transitions points for each state in
-	 * an {@link AnalysisSubmission}.
+	 * A {@link Map} defining the progress transitions points for each state in an {@link AnalysisSubmission}.
 	 */
 	// @formatter:off
 	public static final Map<AnalysisState,Float> STATE_PERCENTAGE = ImmutableMap.<AnalysisState,Float>builder().
@@ -105,6 +109,7 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	private JobErrorRepository jobErrorRepository;
 
 	// required, but not constructor injected because we have circular dependencies :(
+	@Lazy
 	@Autowired
 	private AnalysisExecutionServiceGalaxyCleanupAsync analysisExecutionService;
 
@@ -153,8 +158,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	public Page<AnalysisSubmission> listSubmissionsForProject(String search, String name, Set<AnalysisState> states,
 			Set<UUID> workflowIds, Project project, PageRequest pageRequest) {
 
-		Specification<AnalysisSubmission> specification = AnalysisSubmissionSpecification
-				.filterAnalyses(search, name, states, null, workflowIds, project, null);
+		Specification<AnalysisSubmission> specification = AnalysisSubmissionSpecification.filterAnalyses(search, name,
+				states, null, workflowIds, project, null);
 		return super.search(specification, pageRequest);
 	}
 
@@ -165,8 +170,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	public Page<AnalysisSubmission> listAllSubmissions(String search, String name, Set<AnalysisState> states,
 			Set<UUID> workflowIds, PageRequest pageRequest) {
-		Specification<AnalysisSubmission> specification = AnalysisSubmissionSpecification
-				.filterAnalyses(search, name, states, null, workflowIds, null, null);
+		Specification<AnalysisSubmission> specification = AnalysisSubmissionSpecification.filterAnalyses(search, name,
+				states, null, workflowIds, null, null);
 		return super.search(specification, pageRequest);
 	}
 
@@ -177,8 +182,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	@PreAuthorize("hasRole('ROLE_USER')")
 	public Page<AnalysisSubmission> listSubmissionsForUser(String search, String name, Set<AnalysisState> states,
 			User user, Set<UUID> workflowIds, PageRequest pageRequest) {
-		Specification<AnalysisSubmission> specification = AnalysisSubmissionSpecification
-				.filterAnalyses(search, name, states, user, workflowIds, null, false);
+		Specification<AnalysisSubmission> specification = AnalysisSubmissionSpecification.filterAnalyses(search, name,
+				states, user, workflowIds, null, false);
 		return super.search(specification, pageRequest);
 	}
 
@@ -360,8 +365,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	public List<ProjectSampleAnalysisOutputInfo> getAllAnalysisOutputInfoSharedWithProject(Long projectId) {
 		final Set<UUID> singleSampleWorkflowIds = iridaWorkflowsService.getSingleSampleWorkflows();
 		logger.trace("N=" + singleSampleWorkflowIds.size() + ", Single sample workflows: " + singleSampleWorkflowIds);
-		final List<ProjectSampleAnalysisOutputInfo> infos = analysisSubmissionRepository.getAllAnalysisOutputInfoSharedWithProject(
-				projectId, singleSampleWorkflowIds);
+		final List<ProjectSampleAnalysisOutputInfo> infos = analysisSubmissionRepository
+				.getAllAnalysisOutputInfoSharedWithProject(projectId, singleSampleWorkflowIds);
 		logger.trace("Found " + infos.size() + " output files for project id=" + projectId);
 		return infos;
 	}
@@ -374,8 +379,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	public List<ProjectSampleAnalysisOutputInfo> getAllAutomatedAnalysisOutputInfoForAProject(Long projectId) {
 		final Set<UUID> singleSampleWorkflowIds = iridaWorkflowsService.getSingleSampleWorkflows();
 		logger.trace("N=" + singleSampleWorkflowIds.size() + ", Single sample workflows: " + singleSampleWorkflowIds);
-		final List<ProjectSampleAnalysisOutputInfo> infos = analysisSubmissionRepository.getAllAutomatedAnalysisOutputInfoForAProject(
-				projectId, singleSampleWorkflowIds);
+		final List<ProjectSampleAnalysisOutputInfo> infos = analysisSubmissionRepository
+				.getAllAutomatedAnalysisOutputInfoForAProject(projectId, singleSampleWorkflowIds);
 		logger.trace("Found " + infos.size() + " output files for project id=" + projectId);
 		return infos;
 	}
@@ -387,9 +392,7 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	@PreAuthorize("hasRole('ROLE_USER')")
 	public AnalysisSubmission create(AnalysisSubmission analysisSubmission)
 			throws ConstraintViolationException, EntityExistsException {
-		UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext()
-				.getAuthentication()
-				.getPrincipal();
+		UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 		User user = userRepository.loadUserByUsername(userDetails.getUsername());
 		analysisSubmission.setSubmitter(user);
 
@@ -425,7 +428,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	@Override
 	@PreAuthorize("hasRole('ROLE_USER')")
 	@PostFilter("hasPermission(filterObject, 'canReadAnalysisSubmission')")
-	public List<AnalysisSubmission> getAnalysisSubmissionsAccessibleByCurrentUserByWorkflowIds(Collection<UUID> workflowIds) {
+	public List<AnalysisSubmission> getAnalysisSubmissionsAccessibleByCurrentUserByWorkflowIds(
+			Collection<UUID> workflowIds) {
 		return analysisSubmissionRepository.findByWorkflowIds(workflowIds);
 	}
 
@@ -494,12 +498,12 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 		List<AnalysisSubmissionTemplate> analysisTemplatesForProject = getAnalysisTemplatesForProject(project);
 
 		Optional<AnalysisSubmissionTemplate> first = analysisTemplatesForProject.stream()
-				.filter(t -> t.getId()
-						.equals(id))
+				.filter(t -> t.getId().equals(id))
 				.findFirst();
 
-		if(!first.isPresent()){
-			throw new EntityNotFoundException("Could not get analysis template " + id + " for project " + project.getId());
+		if (!first.isPresent()) {
+			throw new EntityNotFoundException(
+					"Could not get analysis template " + id + " for project " + project.getId());
 		}
 
 		return first.get();
@@ -534,7 +538,7 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 		if (description.acceptsSingleSequenceFiles()) {
 			final Map<Sample, SingleEndSequenceFile> samplesMap = sequencingObjectService
 					.getUniqueSamplesForSequencingObjects(Sets.newHashSet(sequenceFiles));
-			for (final Map.Entry<Sample,SingleEndSequenceFile> entry : samplesMap.entrySet()) {
+			for (final Map.Entry<Sample, SingleEndSequenceFile> entry : samplesMap.entrySet()) {
 				Sample s = entry.getKey();
 				SingleEndSequenceFile file = entry.getValue();
 				// Build the analysis submission
@@ -578,7 +582,7 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 			final Map<Sample, SequenceFilePair> samplesMap = sequencingObjectService
 					.getUniqueSamplesForSequencingObjects(Sets.newHashSet(sequenceFilePairs));
 
-			for (final Map.Entry<Sample,SequenceFilePair> entry : samplesMap.entrySet()) {
+			for (final Map.Entry<Sample, SequenceFilePair> entry : samplesMap.entrySet()) {
 				Sample s = entry.getKey();
 				SequenceFilePair filePair = entry.getValue();
 				// Build the analysis submission
@@ -656,8 +660,7 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 
 		// Add any paired end sequencing files.
 		if (description.acceptsPairedSequenceFiles()) {
-			if (!sequenceFilePairs.isEmpty())
-			{
+			if (!sequenceFilePairs.isEmpty()) {
 				builder.inputFiles(Sets.newHashSet(sequenceFilePairs));
 			}
 		}
@@ -697,8 +700,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	 */
 	@Override
 	@PreAuthorize("hasRole('ROLE_ADMIN') or hasPermission(#id, 'canReadAnalysisSubmission')")
-	public float getPercentCompleteForAnalysisSubmission(Long id) throws EntityNotFoundException,
-			ExecutionManagerException, NoPercentageCompleteException {
+	public float getPercentCompleteForAnalysisSubmission(Long id)
+			throws EntityNotFoundException, ExecutionManagerException, NoPercentageCompleteException {
 		AnalysisSubmission analysisSubmission = read(id);
 		AnalysisState analysisState = analysisSubmission.getAnalysisState();
 
@@ -709,28 +712,20 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 		case SUBMITTING:
 			return STATE_PERCENTAGE.get(analysisState);
 
-			/**
-			 * If the analysis is in a state of {@link AnalysisState.RUNNING}
-			 * then we are able to ask Galaxy for the proportion of jobs that
-			 * are complete. We can scale this value between RUNNING_PERCENT
-			 * (10%) and FINISHED_RUNNING_PERCENT (90%) so that after all jobs
-			 * are complete we are only at 90%. The remaining 10% involves
-			 * transferring files back to Galaxy.
-			 *
-			 * For example, if there are 10 out of 20 jobs finished on Galaxy,
-			 * then the proportion of jobs complete is 10/20 = 0.5. So, the
-			 * percent complete for the overall analysis is: percentComplete =
-			 * 10 + (90 - 10) * 0.5 = 50%.
-			 *
-			 * If there are 20 out of 20 jobs finished in Galaxy, then the
-			 * percent complete is: percentComplete = 10 + (90 - 10) * 1.0 =
-			 * 90%.
-			 */
+		/**
+		 * If the analysis is in a state of {@link AnalysisState.RUNNING} then we are able to ask Galaxy for the
+		 * proportion of jobs that are complete. We can scale this value between RUNNING_PERCENT (10%) and
+		 * FINISHED_RUNNING_PERCENT (90%) so that after all jobs are complete we are only at 90%. The remaining 10%
+		 * involves transferring files back to Galaxy. For example, if there are 10 out of 20 jobs finished on Galaxy,
+		 * then the proportion of jobs complete is 10/20 = 0.5. So, the percent complete for the overall analysis is:
+		 * percentComplete = 10 + (90 - 10) * 0.5 = 50%. If there are 20 out of 20 jobs finished in Galaxy, then the
+		 * percent complete is: percentComplete = 10 + (90 - 10) * 1.0 = 90%.
+		 */
 		case RUNNING:
 			String workflowHistoryId = analysisSubmission.getRemoteAnalysisId();
 			GalaxyWorkflowStatus workflowStatus = galaxyHistoriesService.getStatusForHistory(workflowHistoryId);
-			return RUNNING_PERCENT + (FINISHED_RUNNING_PERCENT - RUNNING_PERCENT)
-					* workflowStatus.getProportionComplete();
+			return RUNNING_PERCENT
+					+ (FINISHED_RUNNING_PERCENT - RUNNING_PERCENT) * workflowStatus.getProportionComplete();
 
 		case FINISHED_RUNNING:
 		case COMPLETING:
@@ -799,7 +794,9 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	@Override
 	@PreAuthorize("hasPermission(#project, 'canReadProject')")
 	public Collection<AnalysisSubmission> getAnalysisSubmissionsSharedToProject(Project project) {
-		return pasRepository.getSubmissionsForProject(project).stream().map(ProjectAnalysisSubmissionJoin::getObject)
+		return pasRepository.getSubmissionsForProject(project)
+				.stream()
+				.map(ProjectAnalysisSubmissionJoin::getObject)
 				.collect(Collectors.toSet());
 	}
 
@@ -828,7 +825,8 @@ public class AnalysisSubmissionServiceImpl extends CRUDServiceImpl<Long, Analysi
 	 */
 	@PreAuthorize("hasRole('ROLE_ADMIN')")
 	public List<GenericStatModel> getAnalysesRanGrouped(Date createdDate, StatisticTimePeriod statisticTimePeriod) {
-		return analysisSubmissionRepository.countAnalysesRanGrouped(createdDate, statisticTimePeriod.getGroupByFormat());
+		return analysisSubmissionRepository.countAnalysesRanGrouped(createdDate,
+				statisticTimePeriod.getGroupByFormat());
 	}
 
 	/**


### PR DESCRIPTION
## Description of changes
Fixed issue with bean wiring for AnalysisExecutionServiceGalaxyCleanupAsync that was causing dependant beans to be null instead of wiring in correctly. This was causing null pointer exceptions in cleanupSubmission.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

Fixes #1287

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
