### PR TITLE
Hotfix/22.05.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## [22.05.3] - 2022/06/14
+* [Developer]: Fix bug where users with only group access to a project couldn't view sample details or metadata. See [PR 1313](https://github.com/phac-nml/irida/pull/1313)
+* [Developer]: Fix sql order by bug on admin statistics page that was causing page not to load when `ONLY_FULL_GROUP_BY` enabled. See [PR 1313](https://github.com/phac-nml/irida/pull/1313)
+
 ## [22.05.2] - 2022/06/10
 * [Developer/UI]: Fix flaky UI Integration tests. See [PR 1313](https://github.com/phac-nml/irida/pull/1313)
 * [Developer]: Update war build to decrease size and remove executable ability. See [PR 1313](https://github.com/phac-nml/irida/pull/1313)
@@ -86,6 +90,7 @@
 
 ## [...previous](https://github.com/phac-nml/irida/blob/21.09.2/CHANGELOG.md)
 
+[22.05.3]: https://github.com/phac-nml/irida/compare/22.05.2...22.05.3
 [22.05.2]: https://github.com/phac-nml/irida/compare/22.05.1...22.05.2
 [22.05.1]: https://github.com/phac-nml/irida/compare/22.05...22.05.1
 [22.05]: https://github.com/phac-nml/irida/compare/22.03.1...22.05

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>ca.corefacility.bioinformatics</groupId>
   <artifactId>irida</artifactId>
   <packaging>war</packaging>
-  <version>22.05.2</version>
+  <version>22.05.3</version>
   <name>irida</name>
   <url>http://www.irida.ca</url>
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRole.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRole.java
@@ -53,7 +53,8 @@ public enum ProjectMetadataRole {
 	}
 
 	/**
-	 * Static method to compare a {@link ProjectUserJoin} and a collection of {@link UserGroupProjectJoin} and return the max {@link ProjectMetadataRole} from them
+	 * Static method to compare a {@link ProjectUserJoin} and a collection of {@link UserGroupProjectJoin} and return
+	 * the max {@link ProjectMetadataRole} from them
 	 *
 	 * @param userJoin   a user's {@link ProjectUserJoin}
 	 * @param groupJoins a collection of {@link UserGroupProjectJoin}
@@ -65,14 +66,16 @@ public enum ProjectMetadataRole {
 
 		if (userJoin != null) {
 			metadataRole = userJoin.getMetadataRole();
+			if (metadataRole == ProjectMetadataRole.LEVEL_4) {
+				return metadataRole;
+			}
 		}
 
-		if(metadataRole != ProjectMetadataRole.LEVEL_4) {
+		if (metadataRole != ProjectMetadataRole.LEVEL_4) {
 			for (UserGroupProjectJoin group : groupJoins) {
-				if (metadataRole.getLevel() < group.getMetadataRole()
-						.getLevel()) {
+				if (metadataRole == null || metadataRole.getLevel() < group.getMetadataRole().getLevel()) {
 					metadataRole = group.getMetadataRole();
-					if(metadataRole == ProjectMetadataRole.LEVEL_4) {
+					if (metadataRole == ProjectMetadataRole.LEVEL_4) {
 						break;
 					}
 				}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/StatisticTimePeriod.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/StatisticTimePeriod.java
@@ -15,29 +15,31 @@ public enum StatisticTimePeriod {
 	 * Time Period: Last day
 	 * Grouped by: HOUR
 	 */
-	HOURLY(new int[] { 1 }, "%H:00"),
+	HOURLY(new int[] { 1 }, "%H:00", "%H:00"),
 	/*
 	 * Time Period: 7, 14, and 30 days
 	 * Grouped by: month/day
 	 */
-	DAILY(new int[] { 7, 14, 30 }, "%m %d %Y"),
+	DAILY(new int[] { 7, 14, 30 }, "%Y-%m-%d", "MMM d"),
 	/*
 	 * Time Period: 90 and 365 days
 	 * Grouped by: month/year
 	 */
-	MONTHLY(new int[] { 90, 365 }, "%m %Y"),
+	MONTHLY(new int[] { 90, 365 }, "%Y-%m-01", "MMM Y"),
 	/*
 	 * Time Period: 730, 1825, and 3650 days (2 years, 5 years, 10 years)
 	 * Grouped by: year
 	 */
-	YEARLY(new int[] { 730, 1825, 3650 }, "%Y");
+	YEARLY(new int[] { 730, 1825, 3650 }, "%Y-01-01", "Y");
 
 	private int[] values;
 	private String groupByFormat;
+	private String displayFormat;
 
-	private StatisticTimePeriod(int[] values, String groupByFormat) {
+	private StatisticTimePeriod(int[] values, String groupByFormat, String displayFormat) {
 		this.values = values;
 		this.groupByFormat = groupByFormat;
+		this.displayFormat = displayFormat;
 	}
 
 	public int[] getValues() {
@@ -46,5 +48,9 @@ public enum StatisticTimePeriod {
 
 	public String getGroupByFormat() {
 		return groupByFormat;
+	}
+
+	public String getDisplayFormat() {
+		return displayFormat;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/StatisticTimePeriod.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/enums/StatisticTimePeriod.java
@@ -11,7 +11,6 @@ public enum StatisticTimePeriod {
 	 * which is used to group statistics by the defined string.
 	 */
 
-
 	/*
 	 * Time Period: Last day
 	 * Grouped by: HOUR
@@ -21,12 +20,12 @@ public enum StatisticTimePeriod {
 	 * Time Period: 7, 14, and 30 days
 	 * Grouped by: month/day
 	 */
-	DAILY(new int[] { 7, 14, 30 }, "%b %e"),
+	DAILY(new int[] { 7, 14, 30 }, "%m %d %Y"),
 	/*
 	 * Time Period: 90 and 365 days
 	 * Grouped by: month/year
 	 */
-	MONTHLY(new int[] { 90, 365 }, "%b %Y"),
+	MONTHLY(new int[] { 90, 365 }, "%m %Y"),
 	/*
 	 * Time Period: 730, 1825, and 3650 days (2 years, 5 years, 10 years)
 	 * Grouped by: year

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/ProjectRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/ProjectRepository.java
@@ -97,6 +97,6 @@ public interface ProjectRepository extends IridaJpaRepository<Project, Long>, Pr
 	 * @return A list of {@link GenericStatModel}s
 	 */
 	@Query("select new ca.corefacility.bioinformatics.irida.ria.web.admin.dto.statistics.GenericStatModel(function('date_format', p.createdDate, ?2), count(p.id))"
-			+ "from Project p where p.createdDate >= ?1 group by function('date_format', p.createdDate, ?2) order by p.createdDate asc")
+			+ "from Project p where p.createdDate >= ?1 group by function('date_format', p.createdDate, ?2) order by function('date_format', p.createdDate, ?2) asc")
 	public List<GenericStatModel> countProjectsCreatedGrouped(Date createdDate, String groupByFormat);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/analysis/submission/AnalysisSubmissionRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/analysis/submission/AnalysisSubmissionRepository.java
@@ -149,7 +149,7 @@ public interface AnalysisSubmissionRepository extends IridaJpaRepository<Analysi
 	 * @return A list of {@link GenericStatModel}s
 	 */
 	@Query("select new ca.corefacility.bioinformatics.irida.ria.web.admin.dto.statistics.GenericStatModel(function('date_format', s.createdDate, ?2), count(s.id))"
-			+ "from AnalysisSubmission s where s.createdDate >= ?1 group by function('date_format', s.createdDate, ?2) order by s.createdDate asc")
+			+ "from AnalysisSubmission s where s.createdDate >= ?1 group by function('date_format', s.createdDate, ?2) order by function('date_format', s.createdDate, ?2) asc")
 	public List<GenericStatModel> countAnalysesRanGrouped(Date createdDate, String groupByFormat);
 
 	/**
@@ -161,5 +161,3 @@ public interface AnalysisSubmissionRepository extends IridaJpaRepository<Analysi
 	@Query("select count(s.id) from AnalysisSubmission s where s.submitter = ?1")
 	public int countAnalysesRanByUser(User user);
 }
-
-

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/SampleRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/sample/SampleRepository.java
@@ -83,6 +83,6 @@ public interface SampleRepository extends IridaJpaRepository<Sample, Long>, Samp
 	 * @return A list of {@link GenericStatModel}s
 	 */
 	@Query("select new ca.corefacility.bioinformatics.irida.ria.web.admin.dto.statistics.GenericStatModel(function('date_format', s.createdDate, ?2), count(s.id))"
-			+ "from Sample s where s.createdDate >= ?1 group by function('date_format', s.createdDate, ?2) order by s.createdDate asc")
+			+ "from Sample s where s.createdDate >= ?1 group by function('date_format', s.createdDate, ?2) order by function('date_format', s.createdDate, ?2) asc")
 	public List<GenericStatModel> countSamplesCreatedGrouped(Date createdDate, String groupByFormat);
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/user/UserRepository.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/user/UserRepository.java
@@ -63,7 +63,7 @@ public interface UserRepository extends IridaJpaRepository<User, Long>, UserDeta
 	 * @return A list of {@link GenericStatModel}s
 	 */
 	@Query("select new ca.corefacility.bioinformatics.irida.ria.web.admin.dto.statistics.GenericStatModel(function('date_format', u.createdDate, ?2), count(u.id))"
-			+ "from User u where u.createdDate >= ?1 group by function('date_format', u.createdDate, ?2) order by u.createdDate asc")
+			+ "from User u where u.createdDate >= ?1 group by function('date_format', u.createdDate, ?2) order by function('date_format', u.createdDate, ?2) asc")
 	public List<GenericStatModel> countUsersCreatedGrouped(Date createdDate, String groupByFormat);
 
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/admin/dto/statistics/StatisticsResponse.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/admin/dto/statistics/StatisticsResponse.java
@@ -1,7 +1,12 @@
 package ca.corefacility.bioinformatics.irida.ria.web.admin.dto.statistics;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
+import ca.corefacility.bioinformatics.irida.model.enums.StatisticTimePeriod;
 import ca.corefacility.bioinformatics.irida.ria.web.ajax.dto.ajax.AjaxResponse;
 
 /**
@@ -11,8 +16,8 @@ import ca.corefacility.bioinformatics.irida.ria.web.ajax.dto.ajax.AjaxResponse;
 public class StatisticsResponse extends AjaxResponse {
 	private List<GenericStatModel> statistics;
 
-	public StatisticsResponse(List<GenericStatModel> statistics) {
-		this.statistics = statistics;
+	public StatisticsResponse(List<GenericStatModel> statistics, StatisticTimePeriod statisticTimePeriod) {
+		this.statistics = formatStatistics(statistics, statisticTimePeriod);
 	}
 
 	public List<GenericStatModel> getStatistics() {
@@ -21,5 +26,33 @@ public class StatisticsResponse extends AjaxResponse {
 
 	public void setStatistics(List<GenericStatModel> statistics) {
 		this.statistics = statistics;
+	}
+
+	private List<GenericStatModel> formatStatistics(List<GenericStatModel> statistics,
+			StatisticTimePeriod statisticTimePeriod) {
+		List<GenericStatModel> formattedStatistics = new ArrayList<>();
+
+		if (statisticTimePeriod.getGroupByFormat().equals(statisticTimePeriod.getDisplayFormat())) {
+			return statistics;
+		} else {
+			SimpleDateFormat parser = new SimpleDateFormat("yyyy-MM-dd");
+			SimpleDateFormat formatter = new SimpleDateFormat(statisticTimePeriod.getDisplayFormat());
+
+			for (GenericStatModel statistic : statistics) {
+				Date date;
+				String formattedKey;
+				try {
+					date = parser.parse(statistic.getKey());
+					formattedKey = formatter.format(date);
+				} catch (ParseException e) {
+					formattedKey = statistic.getKey();
+				}
+
+				GenericStatModel formattedStatistic = new GenericStatModel(formattedKey, statistic.getValue());
+				formattedStatistics.add(formattedStatistic);
+			}
+		}
+
+		return formattedStatistics;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIAdminStatisticsService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIAdminStatisticsService.java
@@ -68,7 +68,8 @@ public class UIAdminStatisticsService {
 		StatisticTimePeriod statisticTimePeriod = getStatisticTimePeriod(timePeriod);
 
 		return new StatisticsResponse(
-				analysisSubmissionService.getAnalysesRanGrouped(minimumCreatedDate, statisticTimePeriod));
+				analysisSubmissionService.getAnalysesRanGrouped(minimumCreatedDate, statisticTimePeriod),
+				statisticTimePeriod);
 	}
 
 	/**
@@ -81,8 +82,8 @@ public class UIAdminStatisticsService {
 		Date minimumCreatedDate = getMinimumCreatedDate(timePeriod);
 		StatisticTimePeriod statisticTimePeriod = getStatisticTimePeriod(timePeriod);
 
-		return new StatisticsResponse(
-				projectService.getProjectsCreatedGrouped(minimumCreatedDate, statisticTimePeriod));
+		return new StatisticsResponse(projectService.getProjectsCreatedGrouped(minimumCreatedDate, statisticTimePeriod),
+				statisticTimePeriod);
 	}
 
 	/**
@@ -95,7 +96,8 @@ public class UIAdminStatisticsService {
 		Date minimumCreatedDate = getMinimumCreatedDate(timePeriod);
 		StatisticTimePeriod statisticTimePeriod = getStatisticTimePeriod(timePeriod);
 
-		return new StatisticsResponse(sampleService.getSamplesCreatedGrouped(minimumCreatedDate, statisticTimePeriod));
+		return new StatisticsResponse(sampleService.getSamplesCreatedGrouped(minimumCreatedDate, statisticTimePeriod),
+				statisticTimePeriod);
 	}
 
 	/**
@@ -108,7 +110,8 @@ public class UIAdminStatisticsService {
 		Date minimumCreatedDate = getMinimumCreatedDate(timePeriod);
 		StatisticTimePeriod statisticTimePeriod = getStatisticTimePeriod(timePeriod);
 
-		return new StatisticsResponse(userService.getUsersCreatedGrouped(minimumCreatedDate, statisticTimePeriod));
+		return new StatisticsResponse(userService.getUsersCreatedGrouped(minimumCreatedDate, statisticTimePeriod),
+				statisticTimePeriod);
 	}
 
 	/**

--- a/src/test/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRoleTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/model/enums/ProjectMetadataRoleTest.java
@@ -1,0 +1,56 @@
+package ca.corefacility.bioinformatics.irida.model.enums;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import ca.corefacility.bioinformatics.irida.model.joins.impl.ProjectUserJoin;
+import ca.corefacility.bioinformatics.irida.model.project.Project;
+import ca.corefacility.bioinformatics.irida.model.user.User;
+import ca.corefacility.bioinformatics.irida.model.user.group.UserGroup;
+import ca.corefacility.bioinformatics.irida.model.user.group.UserGroupProjectJoin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ProjectMetadataRoleTest {
+
+    private User user = new User(1L, "jdoe", "john.doe@somewhere.com", "ABCDEFGHIJ", "John", "Doe", "6666");
+    private Project project = new Project("NewProject");
+    private ProjectUserJoin levelOnePuj = new ProjectUserJoin(project, user, ProjectRole.PROJECT_USER,
+            ProjectMetadataRole.LEVEL_1);
+    private ProjectUserJoin levelFourPuj = new ProjectUserJoin(project, user, ProjectRole.PROJECT_USER,
+            ProjectMetadataRole.LEVEL_4);
+    private UserGroup group = new UserGroup("NewGroup");
+    private UserGroupProjectJoin levelOneUgjp = new UserGroupProjectJoin(project, group, ProjectRole.PROJECT_USER,
+            ProjectMetadataRole.LEVEL_1);
+    private UserGroupProjectJoin levelFourUgjp = new UserGroupProjectJoin(project, group, ProjectRole.PROJECT_USER,
+            ProjectMetadataRole.LEVEL_4);
+
+    @Test
+    public void testGetMaxRoleForProjectAndGroups() {
+        ProjectMetadataRole role;
+
+        // when no direct project membership and no group membership
+        role = ProjectMetadataRole.getMaxRoleForProjectAndGroups(null, Collections.<UserGroupProjectJoin>emptyList());
+        assertNull(role, "Expect null when no direct project membership or group membership");
+
+        // when group membership only
+        role = ProjectMetadataRole.getMaxRoleForProjectAndGroups(null, List.of(levelOneUgjp));
+        assertEquals(role, levelOneUgjp.getMetadataRole(), "Expect to return group membership role");
+
+        // when direct project membership only
+        role = ProjectMetadataRole.getMaxRoleForProjectAndGroups(levelOnePuj,
+                Collections.<UserGroupProjectJoin>emptyList());
+        assertEquals(role, levelOnePuj.getMetadataRole(), "Expect to return project membership role");
+
+        // when group project metadata role is greater than user project role
+        role = ProjectMetadataRole.getMaxRoleForProjectAndGroups(levelOnePuj, List.of(levelFourUgjp));
+        assertEquals(role, levelFourUgjp.getMetadataRole(), "Expect to return group membership role");
+
+        // when group project metadata role is less than user project metadata role
+        role = ProjectMetadataRole.getMaxRoleForProjectAndGroups(levelFourPuj, List.of(levelOneUgjp));
+        assertEquals(role, levelFourPuj.getMetadataRole(), "Expect to return project membership role");
+    }
+}


### PR DESCRIPTION
## Description of changes
* [Developer]: Fix bug where users with only group access to a project couldn't view sample details or metadata.
* [Developer]: Fix sql order by bug on admin statistics page that was causing page not to load when `ONLY_FULL_GROUP_BY` enabled. 

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
