### PR TITLE
Remove synced files that have been remotely deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [Developer]: Switched custom exception handling to use built in Spring Boot exception handling. See [PR 1319](https://github.com/phac-nml/irida/pull/1319)
 * [UI]: Fixed issue with sorting OAuth clients table in admin panel. See [PR 1342](https://github.com/phac-nml/irida/pull/1342)
 * [UI]: Updated share samples review page to list the actual samples which will not be shared with the target project either due to the same sample identifiers or the same samples names already in the target project. See [PR 1343](https://github.com/phac-nml/irida/pull/1343)
+* [REST]: Updated synchronizing of sample data to remove sequencing objects and assemblies that no longer exist on the remote sample. See [PR 1345](https://github.com/phac-nml/irida/pull/1345)
 
 ## [22.05.5] - 2022/06/28
 * [UI]: Fixed bug preventing export of project samples table due to invalid url. [PR 1331](https://github.com/phac-nml/irida/pull/1331)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/config/services/scheduled/ProjectSyncScheduledTaskConfig.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/config/services/scheduled/ProjectSyncScheduledTaskConfig.java
@@ -9,7 +9,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 /**
  * Scheduled task configuration for synchronizing projects from other IRIDA installations
  */
-@Profile({ "prod", "sync" })
+@Profile({ "prod", "sync", "dev" })
 @Configuration
 public class ProjectSyncScheduledTaskConfig {
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/service/remote/ProjectSynchronizationService.java
@@ -1,5 +1,16 @@
 package ca.corefacility.bioinformatics.irida.service.remote;
 
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.time.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
 import ca.corefacility.bioinformatics.irida.exceptions.IridaOAuthException;
 import ca.corefacility.bioinformatics.irida.exceptions.LinkNotFoundException;
 import ca.corefacility.bioinformatics.irida.exceptions.ProjectSynchronizationException;
@@ -17,22 +28,15 @@ import ca.corefacility.bioinformatics.irida.model.remote.RemoteSynchronizable;
 import ca.corefacility.bioinformatics.irida.model.sample.Sample;
 import ca.corefacility.bioinformatics.irida.model.sample.SampleSequencingObjectJoin;
 import ca.corefacility.bioinformatics.irida.model.sample.metadata.MetadataEntry;
-import ca.corefacility.bioinformatics.irida.model.sequenceFile.*;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.Fast5Object;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequenceFilePair;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SequencingObject;
+import ca.corefacility.bioinformatics.irida.model.sequenceFile.SingleEndSequenceFile;
 import ca.corefacility.bioinformatics.irida.model.user.User;
 import ca.corefacility.bioinformatics.irida.security.ProjectSynchronizationAuthenticationToken;
 import ca.corefacility.bioinformatics.irida.service.*;
 import ca.corefacility.bioinformatics.irida.service.sample.MetadataTemplateService;
 import ca.corefacility.bioinformatics.irida.service.sample.SampleService;
-import org.apache.commons.lang3.time.DateUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 import com.google.common.collect.Lists;
 
@@ -387,14 +391,14 @@ public class ProjectSynchronizationService {
 				.map(fast5Object -> fast5Object.getRemoteStatus().getURL())
 				.collect(Collectors.toSet()));
 
-		//get a list of all remote sequencingObject URLs in the sample
+		//get a list of all local sequencingObject URLs in the sample
 		Set<String> localObjectUrls = new HashSet<>(objectsByUrl.keySet());
 		//remove any URL from the local list that we've seen remotely
 		remoteObjectUrls.forEach(objectUrl -> {
 			localObjectUrls.remove(objectUrl);
 		});
 
-		//if any URLs still exists in localObjectUrls, it must have been deleted remotely
+		//if any URLs still exist in localObjectUrls, it must have been deleted remotely
 		for (String localObjectUrl : localObjectUrls) {
 			logger.trace(
 					"SequencingObject " + localObjectUrl + " has been removed remotely. Removing from local sample.");
@@ -467,14 +471,14 @@ public class ProjectSynchronizationService {
 				.map(fast5Object -> fast5Object.getRemoteStatus().getURL())
 				.collect(Collectors.toSet()));
 
-		//get a list of all remote assembly URLs in the sample
+		//get a list of all local assembly URLs in the sample
 		Set<String> localAssemblyUrls = new HashSet<>(assembliesByUrl.keySet());
 		//remove any URL from the local list that we've seen remotely
 		remoteAssemblyUrls.forEach(assemblyUrl -> {
 			localAssemblyUrls.remove(assemblyUrl);
 		});
 
-		//if any URLs still exists in localAssemblyUrls, it must have been deleted remotely
+		//if any URLs still exist in localAssemblyUrls, it must have been deleted remotely
 		for (String localAssemblyUrl : localAssemblyUrls) {
 			logger.trace(
 					"GenomeAssembly " + localAssemblyUrl + " has been removed remotely. Removing from local sample.");


### PR DESCRIPTION
## Description of changes
When syncing a sample delete previously synced sequencing objects and assemblies that no longer exist on the source.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
