### PR TITLE
Fix delete project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 * [UI]: Updated share samples review page to list the actual samples which will not be shared with the target project either due to the same sample identifiers or the same samples names already in the target project. See [PR 1343](https://github.com/phac-nml/irida/pull/1343)
 * [REST]: Updated synchronizing of sample data to remove sequencing objects and assemblies that no longer exist on the remote sample. See [PR 1345](https://github.com/phac-nml/irida/pull/1345)
 * [UI]: Fixed issue with filtering samples by files using a windows encoded text file causing sample name truncation. See [PR 1346](https://github.com/phac-nml/irida/pull/1346)
-
+* [Developer]: Fixed deleting a project with project subscriptions. See [PR 1348](https://github.com/phac-nml/irida/pull/1348)
+* 
 ## [22.05.5] - 2022/06/28
 * [UI]: Fixed bug preventing export of project samples table due to invalid url. [PR 1331](https://github.com/phac-nml/irida/pull/1331)
 * [UI]: Updated user account security page to allow admins to change passwords for other users. See [PR 1330](https://github.com/phac-nml/irida/pull/1330)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [REST]: Updated synchronizing of sample data to remove sequencing objects and assemblies that no longer exist on the remote sample. See [PR 1345](https://github.com/phac-nml/irida/pull/1345)
 * [UI]: Fixed issue with filtering samples by files using a windows encoded text file causing sample name truncation. See [PR 1346](https://github.com/phac-nml/irida/pull/1346)
 * [Developer]: Fixed deleting a project with project subscriptions. See [PR 1348](https://github.com/phac-nml/irida/pull/1348)
-* 
+
 ## [22.05.5] - 2022/06/28
 * [UI]: Fixed bug preventing export of project samples table due to invalid url. [PR 1331](https://github.com/phac-nml/irida/pull/1331)
 * [UI]: Updated user account security page to allow admins to change passwords for other users. See [PR 1330](https://github.com/phac-nml/irida/pull/1330)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/project/Project.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/project/Project.java
@@ -139,7 +139,7 @@ public class Project extends IridaRepresentationModel
 	@OneToMany(cascade = CascadeType.REMOVE, mappedBy = "project")
 	private List<NcbiExportSubmission> ncbiSubmissions;
 
-	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, mappedBy = "user")
+	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, mappedBy = "project")
 	private List<ProjectSubscription> projectSubscriptions;
 	//End of cascade deletion properties
 

--- a/src/main/resources/ca/corefacility/bioinformatics/irida/sql/required-data.sql
+++ b/src/main/resources/ca/corefacility/bioinformatics/irida/sql/required-data.sql
@@ -351,7 +351,6 @@ INSERT INTO project_subscription (`created_date`, `project_id`, `user_id`, `emai
 INSERT INTO project_subscription (`created_date`, `project_id`, `user_id`, `email_subscription`) VALUES (now(), 50, 1, 0);
 INSERT INTO project_subscription (`created_date`, `project_id`, `user_id`, `email_subscription`) VALUES (now(), 50, 2, 0);
 INSERT INTO project_subscription (`created_date`, `project_id`, `user_id`, `email_subscription`) VALUES (now(), 50, 3, 0);
->>>>>>> development
 
 -- genome assembly
 INSERT INTO `genome_assembly` (id,created_date) VALUES (1, '2014-07-30 08:24:35');

--- a/src/main/webapp/resources/js/pages/projects/settings/components/DeleteProject.jsx
+++ b/src/main/webapp/resources/js/pages/projects/settings/components/DeleteProject.jsx
@@ -45,10 +45,14 @@ export default function DeleteProject() {
           }
         />
 
-        <Checkbox onChange={(e) => setDisabled(!e.target.checked)}>
+        <Checkbox
+          className="t-confirm-delete-project"
+          onChange={(e) => setDisabled(!e.target.checked)}
+        >
           {i18n("DeleteProject.confirm")}
         </Checkbox>
         <Button
+          className="t-delete-project-button"
           type="primary"
           danger
           disabled={disabled}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectDeletePage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectDeletePage.java
@@ -12,10 +12,10 @@ import ca.corefacility.bioinformatics.irida.ria.integration.pages.AbstractPage;
  */
 public class ProjectDeletePage extends AbstractPage {
 
-	@FindBy(id = "confirm-deletion")
+	@FindBy(className = "t-confirm-delete-project")
 	private WebElement confirmCheckbox;
 
-	@FindBy(id = "submit-delete")
+	@FindBy(className = "t-delete-project-button")
 	private WebElement submitDelete;
 
 	public ProjectDeletePage(WebDriver driver) {
@@ -28,11 +28,11 @@ public class ProjectDeletePage extends AbstractPage {
 		return PageFactory.initElements(driver, ProjectDeletePage.class);
 	}
 
-	public boolean canClickDelete(){
+	public boolean canClickDelete() {
 		return submitDelete.isEnabled();
 	}
 
-	public void clickConfirm(){
+	public void clickConfirm() {
 		confirmCheckbox.click();
 	}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectDeletePageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectDeletePageIT.java
@@ -1,6 +1,5 @@
 package ca.corefacility.bioinformatics.irida.ria.integration.projects;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
@@ -24,7 +23,6 @@ public class ProjectDeletePageIT extends AbstractIridaUIITChromeDriver {
 	private ProjectDeletePage page;
 
 	@Test
-	@Disabled
 	public void deleteProjectAsAdmin() {
 		LoginPage.loginAsAdmin(driver());
 
@@ -48,7 +46,6 @@ public class ProjectDeletePageIT extends AbstractIridaUIITChromeDriver {
 	}
 
 	@Test
-	@Disabled
 	public void deleteProjectAsOwner() {
 		LoginPage.loginAsManager(driver());
 

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml
@@ -62,6 +62,24 @@
                   projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0"
                   metadataRole="LEVEL_4"/>
 
+    <project_subscription id="1" project_id="1" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="2" project_id="2" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="true"/>
+    <project_subscription id="3" project_id="3" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="4" project_id="4" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="5" project_id="1" user_id="2"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="6" project_id="2" user_id="2"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="7" project_id="6" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="8" project_id="7" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
+    <project_subscription id="9" project_id="8" user_id="1"
+                          created_date="2013-07-18 14:20:19.0" email_subscription="false"/>
 
     <related_project id="1" subject_id="1" relatedProject_id="2" createdDate="2013-07-18 14:20:19.0"/>
     <related_project id="2" subject_id="1" relatedProject_id="3" createdDate="2013-07-18 14:20:19.0"/>


### PR DESCRIPTION
## Description of changes
A notification with "Internal Error" pops up when a user tries to delete a project with project subscriptions.

This is due to the following:

Caused by: java.sql.SQLIntegrityConstraintViolationException: Cannot delete or update a parent row: a foreign key constraint fails (`irida_test`.`project_subscription`, CONSTRAINT `FK_PROJECT_SUBSCRIPTION_PROJECT` FOREIGN KEY (`project_id`) REFERENCES `project` (`id`))

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* ~[ ] User documentation updated for UI or technical changes.~
