### PR TITLE
Fixes issue where sample selection is not maintained between table pages.

### DIFF
--- a/src/main/webapp/resources/js/pages/projects/redux/samplesSlice.js
+++ b/src/main/webapp/resources/js/pages/projects/redux/samplesSlice.js
@@ -20,6 +20,11 @@ const removeSelectedSample = createAction("samples/table/selected/remove");
 const clearSelectedSamples = createAction("samples/table/selected/clear");
 const clearFilterByFile = createAction("samples/table/clearFilterByFile");
 
+/**
+ * Updates the state of the table filters and search, which triggers
+ * the re-render of the samples table.
+ * @type {AsyncThunk<unknown, void, {}>}
+ */
 const updateTable = createAsyncThunk(
   "samples/table/update",
   async (values, { getState }) => {

--- a/src/main/webapp/resources/js/pages/projects/redux/samplesSlice.js
+++ b/src/main/webapp/resources/js/pages/projects/redux/samplesSlice.js
@@ -31,8 +31,6 @@ const updateTable = createAsyncThunk(
     const {
       samples: { options, selected, selectedCount },
     } = getState();
-    console.log("SEARCH", { state: options.search, values: values.search });
-    console.log("FILTERS", { state: options.filters, values: values.filters });
     if (
       isEqual(values?.search, options.search) &&
       isEqual(values?.filters, options.filters)
@@ -41,7 +39,6 @@ const updateTable = createAsyncThunk(
       return { options: values, selected, selectedCount };
     }
     // Filters applied therefore need to clear any selections
-    console.log("FILTERS CHANGED");
     return { options: values, selected: {}, selectedCount: 0 };
   }
 );

--- a/src/main/webapp/resources/js/pages/projects/redux/samplesSlice.js
+++ b/src/main/webapp/resources/js/pages/projects/redux/samplesSlice.js
@@ -31,6 +31,8 @@ const updateTable = createAsyncThunk(
     const {
       samples: { options, selected, selectedCount },
     } = getState();
+    console.log("SEARCH", { state: options.search, values: values.search });
+    console.log("FILTERS", { state: options.filters, values: values.filters });
     if (
       isEqual(values?.search, options.search) &&
       isEqual(values?.filters, options.filters)
@@ -39,6 +41,7 @@ const updateTable = createAsyncThunk(
       return { options: values, selected, selectedCount };
     }
     // Filters applied therefore need to clear any selections
+    console.log("FILTERS CHANGED");
     return { options: values, selected: {}, selectedCount: 0 };
   }
 );
@@ -165,7 +168,6 @@ const initialState = {
 export default createReducer(initialState, (builder) => {
   builder
     .addCase(updateTable.fulfilled, (state, action) => {
-      console.log("FULFILLED", action.payload);
       state.options = action.payload.options;
       state.selected = action.payload.selected;
       state.selectedCount = action.payload.selectedCount;

--- a/src/main/webapp/resources/js/pages/projects/samples/components/SamplesTable.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/SamplesTable.jsx
@@ -66,7 +66,6 @@ export function SamplesTable() {
    * @param sample
    */
   const onRowSelectionChange = (event, sample) => {
-    console.log(selected);
     if (event.target.checked) {
       dispatch(addSelectedSample(sample));
     } else {

--- a/src/main/webapp/resources/js/pages/projects/samples/components/SamplesTable.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/SamplesTable.jsx
@@ -43,24 +43,22 @@ export function SamplesTable() {
   } = useSelector((state) => state.samples);
 
   /**
-   * Fetch the current state of the table.  Will refetch whenever one of the
+   * Fetch the current state of the table.
+   * Re-fetch whenever one of the
    * table options (filter, sort, or pagination) changes.
    */
-  const {
-    data: { content: samples, total } = {},
-    isFetching,
-  } = useListSamplesQuery(options, {
-    refetchOnMountOrArgChange: true,
-  });
+  const { data: { content: samples, total } = {}, isFetching } =
+    useListSamplesQuery(options, {
+      refetchOnMountOrArgChange: true,
+    });
 
   /**
    * Fetch projects that have been associated with this project.
    * Request formats them into a format that can be consumed by the
    * project column filter.
    */
-  const { data: associatedProjects } = useListAssociatedProjectsQuery(
-    projectId
-  );
+  const { data: associatedProjects } =
+    useListAssociatedProjectsQuery(projectId);
 
   /**
    * Handle row selection change event
@@ -68,8 +66,8 @@ export function SamplesTable() {
    * @param sample
    */
   const onRowSelectionChange = (event, sample) => {
-    const selected = event.target.checked;
-    if (selected) {
+    console.log(selected);
+    if (event.target.checked) {
       dispatch(addSelectedSample(sample));
     } else {
       dispatch(removeSelectedSample(sample.key));

--- a/src/main/webapp/resources/js/pages/projects/samples/components/SamplesTable.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/SamplesTable.jsx
@@ -99,7 +99,7 @@ export function SamplesTable() {
 
     dispatch(
       updateTable({
-        filters: { associated },
+        filters: { associated: associated === undefined ? null : associated }, // Null conversion for comparision with default values in slice
         pagination,
         order: formatSort(sorter),
         search,

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
@@ -242,6 +242,13 @@ public class ProjectSamplesPage extends ProjectPageBase {
 	@FindBy(className = "t-filter-cancel")
 	private WebElement filterCancelBtn;
 
+	@FindBy(className = "ant-pagination-prev")
+	private WebElement prevTablePage;
+
+	@FindBy(className = "ant-pagination-next")
+	private WebElement nextTablePage;
+
+
 	public ProjectSamplesPage(WebDriver driver) {
 		super(driver);
 	}
@@ -581,5 +588,15 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		int total = getTableSummary().getTotal();
 		filterSubmitBtn.click();
 		waitForTableToUpdate(total);
+	}
+
+	public void goToNextTablePage() {
+		nextTablePage.click();
+		waitForTime(200);
+	}
+
+	public void gotToPreviousTablePage() {
+		prevTablePage.click();
+		waitForTime(200);
 	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -105,6 +105,13 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 		summary = page.getTableSummary();
 		assertEquals(1, summary.getSelected(), "Should be 1 selected samples");
 
+		// Ensure selection maintains between pages
+		page.goToNextTablePage();
+		assertEquals(1, summary.getSelected(), "Should be 1 selected samples");
+		page.gotToPreviousTablePage();
+		assertEquals(1, summary.getSelected(), "Should be 1 selected samples");
+
+
 		page.toggleSelectAll();
 		summary = page.getTableSummary();
 		assertEquals(0, summary.getSelected(), "Should have all samples selected");


### PR DESCRIPTION
## Description of changes
There appears to be a change in the pay redux toolkit returns stat within a slice `addCase` callback, it now appears to return a proxy to the state, which was causing issues comparing objects.   This was causing sample selection across pages to become broken on the project samples table.

I fixed this issue by moving the logic up into an `createAsyncThunk` function where I can get the state directly using the `getState` method.  Instead of just strinifying the object, I updated it to use the lodash isEqual function.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~ 
  - Not required as this is a development issue.

* [X] Tests added (or description of how to test) for any new features.

~* [ ] User documentation updated for UI or technical changes.~
  - Not required an no UI or functional changes
