### PR TITLE
fix: update year formatting from week year to calendar year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [Developer/UI]: Increased speed of Project Samples table export and added estimated coverage to Project Samples table and exports. See [PR 1360](https://github.com/phac-nml/irida/pull/1360)
 * [Workflow]: Start the Galaxy Data Library timeout when an upload begins rather than when it is first queued up. See [PR 1337](https://github.com/phac-nml/irida/pull/1337)
 * [Developer]: Added description and metadata to create & update project sample endpoints. See [PR 1359](https://github.com/phac-nml/irida/pull/1359)
+* [UI]: Fix issue where year is displayed incorrectly when the last day of the week for the date is in another year. See [PR 1364](https://github.com/phac-nml/irida/pull/1364)
 
 ## [22.05.5] - 2022/06/28
 * [UI]: Fixed bug preventing export of project samples table due to invalid url. [PR 1331](https://github.com/phac-nml/irida/pull/1331)

--- a/doc/developer/rest/index.md
+++ b/doc/developer/rest/index.md
@@ -635,7 +635,7 @@ An individual sample contains the metadata associated with an isolate. The sampl
 | `sampleName` | The name used to refer to the sample by the user. This is often the same as `sequencerSampleId`, but *may* be different. | Required. Must be at least 3 characters long. Must not contain any of the following characters: `? ( ) [ ] / \ = + < > : ; " , * ^ | & ' . |` (note: this blocklist of characters is defined by the set of invalid characters on the Windows file system)|
 | `description` | A plain-text description of the sample. | Not required. |
 | `strain` | The microbial or eukaryotic strain name. | Not required. Must be at least 3 characters long. |
-| `collectionDate` | The date that the sample was collected. | Not required. Must be a valid date in the format of "YYYY-MM-DD" (e.g,. "2019-01-25" for January 25, 2019). |
+| `collectionDate` | The date that the sample was collected. | Not required. Must be a valid date in the format of "yyyy-MM-DD" (e.g,. "2019-01-25" for January 25, 2019). |
 | `collectedBy` | The person (or organization) that collected the sample. | Not required. Must be at least 3 characters long. |
 | `latitude` | The latitude of the location where the sample was collected. | Not required. Must be a valid latitude (must match the pattern `^-?(\d){1,2}(\.\d+)?$` and the first number group must be in the range `[-90, 90]`). |
 | `longitude` | The longitude of the location where the sample was collected. | Not required. Must be a valid longitude (must match the pattern `-?(\d){1,3}(\.\d+)?$` and the first number group must be in the range `[-180, 180]`). |

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/json/DateJson.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/json/DateJson.java
@@ -1,10 +1,10 @@
 package ca.corefacility.bioinformatics.irida.web.controller.api.json;
 
 import java.io.IOException;
-import java.util.Date;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -20,8 +20,9 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 public class DateJson {
 
 	private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
 	/**
-	 * Custom JSON serializer to format date as YYYY-MM-DD.
+	 * Custom JSON serializer to format date as yyyy-MM-DD.
 	 */
 	public static class DateSerializer extends StdSerializer<Date> {
 
@@ -41,7 +42,7 @@ public class DateJson {
 	}
 
 	/**
-	 * Custom JSON deserializer date from format YYYY-MM-DD.
+	 * Custom JSON deserializer date from format yyyy-MM-DD.
 	 */
 	public static class DateDeserializer extends StdDeserializer<Date> {
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -3,8 +3,8 @@ generic.unknown=unknown
 generic.percent-complete={0}% Complete
 generic.irida.website=IRIDA Website
 generic.irida.contact=Contact Us
-generic.dateformat=MMM dd, YYYY
-generic.datetimeformat=MMM dd, YYYY, h:m:s a
+generic.dateformat=MMM dd, yyyy
+generic.datetimeformat=MMM dd, yyyy, h:m:s a
 generic.ajax-unexpected-error=Unexpected error has occurred.
 
 pipeline=Pipeline
@@ -1020,7 +1020,7 @@ project.sample.filter.date.month=Previous Month
 project.sample.filter.date.months3=Previous 3 Months
 project.sample.filter.date.months6=Previous 6 Months
 project.sample.filter.date.year=Previous Year
-project.sample.filter.date.format=MMMM DD, YYYY
+project.sample.filter.date.format=MMMM DD, yyyy
 project.sample.filter.apply=Apply Filters
 project.sample.filterByFile=Filter & Select by File
 project.sample.ClearFilterByFile=Clear File Filter
@@ -1536,10 +1536,10 @@ location.latitude=Latitude
 location.longitude=Longitude
 
 # LOCALE
-locale.date.short=dd MMM YYYY
+locale.date.short=dd MMM yyyy
 datepicker.short=dd MMM yyyy
-locale.date.long=dd MMM, YYYY - h:mm a
-date.iso-8601=YYYYMMdd
+locale.date.long=dd MMM, yyyy - h:mm a
+date.iso-8601=yyyyMMdd
 
 # ANALYSIS
 analysis.page.admin.title=All Analyses

--- a/src/main/webapp/pages/projects/export/ncbi.html
+++ b/src/main/webapp/pages/projects/export/ncbi.html
@@ -46,7 +46,7 @@
             </div>
             <div class="form-group col-md-6">
               <label for="release_date" th:text="#{project.export.release_date.title}">_Release Date_</label>
-              <input type="date" id="release_date" class="form-control" th:value="${#calendars.format(#dates.createToday(),'YYYY-MM-dd')}">
+              <input type="date" id="release_date" class="form-control" th:value="${#calendars.format(#dates.createToday(),'yyyy-MM-dd')}">
               <p class="help-block" th:text="#{project.export.release_date.description}">_When data will be released_</p>
             </div>
           </div>

--- a/src/main/webapp/pages/samples/sample_files.html
+++ b/src/main/webapp/pages/samples/sample_files.html
@@ -229,7 +229,7 @@
 					<td>
 						<div class="td_info pull-right">
 							<div class="td_info--value"
-								 th:text="${#dates.format(file.createdDate, dateFormat)}"></div>
+								 th:text="${#dates.format(file.getCreatedDate(), dateFormat)}"></div>
 							<div class="small text-muted pull-right td_info--desc"
 								 th:text="#{samples.files.createdDate}">Created Date</div>
 						</div>

--- a/src/main/webapp/pages/templates/_sequenceFile.html
+++ b/src/main/webapp/pages/templates/_sequenceFile.html
@@ -42,7 +42,7 @@
 	</td>
 	<td>
 		<div class="td_info pull-right">
-			<div class="td_info--value"
+			<div class="td_info--value created-date"
 			     th:text="${#dates.format(file.getCreatedDate(), dateFormat)}"></div>
 			<div class="small text-muted pull-right td_info--desc"
 			     th:text="#{samples.files.createdDate}">Created Date

--- a/src/main/webapp/resources/js/pages/projects/linelist/components/Table/Table.jsx
+++ b/src/main/webapp/resources/js/pages/projects/linelist/components/Table/Table.jsx
@@ -203,7 +203,7 @@ export class TableComponent extends React.Component {
    * @returns {string}
    */
   generateFileName = (ext) => {
-    // YYYY-MM-dd-project-X-<metadata template name>.csv
+    // yyyy-MM-dd-project-X-<metadata template name>.csv
     const fullDate = new Date();
     const date = `${fullDate.getFullYear()}-${
       fullDate.getMonth() + 1

--- a/src/main/webapp/resources/js/utilities/date-utilities.js
+++ b/src/main/webapp/resources/js/utilities/date-utilities.js
@@ -44,7 +44,7 @@ export function fromNow({ date }) {
 /**
  * Format unix timestamp as human readable string.
  * @param  {(string | number)} date unix timestamp
- * @param {String} format defaults to "lll" which is mmm dd, YYYY h:mm AM
+ * @param {String} format defaults to "lll" which is mmm dd, yyyy h:mm AM
  * @return {string} formatted date
  */
 export function formatDate({ date, format }) {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/samples/SampleFilesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/samples/SampleFilesPage.java
@@ -17,7 +17,6 @@ import ca.corefacility.bioinformatics.irida.ria.integration.pages.AbstractPage;
  * <p>
  * Page Object to represent the sample sequence files page.
  * </p>
- *
  */
 public class SampleFilesPage extends AbstractPage {
 	public static final String RELATIVE_URL = "samples/{id}/sequenceFiles";
@@ -38,43 +37,50 @@ public class SampleFilesPage extends AbstractPage {
 		return driver.findElements(By.className("file-name")).get(0).getText();
 	}
 
+	public String getSequenceFileCreatedDate(String sequenceFileName) {
+		WebElement createdDateDiv = driver
+				.findElement(By.xpath("//tr[contains(@class, 'sequence-file-row')]/td/a[text()='" + sequenceFileName
+						+ "']/../../td/div/div[contains(@class, 'created-date')]"));
+		return createdDateDiv.getText();
+	}
+
 	public int getSequenceFileCount() {
 		return driver.findElements(By.className("sequence-file-row")).size();
 	}
-	
+
 	public int getAssemblyFileCount() {
 		return driver.findElements(By.className("assembly_row")).size();
 	}
-	
-	public String getSampleName(){
+
+	public String getSampleName() {
 		return driver.findElement(By.id("sample-name")).getText();
 	}
-	
+
 	public int getQcEntryCount() {
 		return driver.findElements(By.className("qc-item")).size();
 	}
-	
-	public void deleteFirstSequenceFile(){
+
+	public void deleteFirstSequenceFile() {
 		WebElement removeButton = driver.findElements(By.className("remove-file")).iterator().next();
 		removeButton.click();
-		WebElement confirmRemoveButton = (new WebDriverWait(driver, 10)).until(ExpectedConditions.elementToBeClickable(By
-				.id("remove-file-confirm")));
+		WebElement confirmRemoveButton = (new WebDriverWait(driver, 10))
+				.until(ExpectedConditions.elementToBeClickable(By.id("remove-file-confirm")));
 		confirmRemoveButton.click();
 	}
-	
-	public void deleteFirstSequenceFilePair(){
+
+	public void deleteFirstSequenceFilePair() {
 		WebElement removeButton = driver.findElements(By.className("remove-pair")).iterator().next();
 		removeButton.click();
-		WebElement confirmRemoveButton = (new WebDriverWait(driver, 10)).until(ExpectedConditions.elementToBeClickable(By
-				.id("remove-file-confirm")));
+		WebElement confirmRemoveButton = (new WebDriverWait(driver, 10))
+				.until(ExpectedConditions.elementToBeClickable(By.id("remove-file-confirm")));
 		confirmRemoveButton.click();
 	}
-	
-	public void deleteFirstAssemblyFile(){
+
+	public void deleteFirstAssemblyFile() {
 		WebElement removeButton = driver.findElements(By.className("remove-assembly")).iterator().next();
 		removeButton.click();
-		WebElement confirmRemoveButton = (new WebDriverWait(driver, 10)).until(ExpectedConditions.elementToBeClickable(By
-				.id("remove-file-confirm")));
+		WebElement confirmRemoveButton = (new WebDriverWait(driver, 10))
+				.until(ExpectedConditions.elementToBeClickable(By.id("remove-file-confirm")));
 		confirmRemoveButton.click();
 	}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/samples/SampleFilesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/samples/SampleFilesPageIT.java
@@ -18,8 +18,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * <p> Integration test to ensure that the Sample Details Page. </p>
- *
+ * <p>
+ * Integration test to ensure that the Sample Details Page.
+ * </p>
  */
 @DatabaseSetup("/ca/corefacility/bioinformatics/irida/ria/web/samples/SamplePagesIT.xml")
 public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
@@ -32,12 +33,8 @@ public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
 	private SampleFilesPage page;
 
 	private final List<Map<String, String>> BREADCRUMBS = ImmutableList.of(
-			ImmutableMap.of(
-					"href", "/samples",
-					"text", "Samples"
-			),
-			ImmutableMap.of("href", "/samples/" + SAMPLE_ID, "text", "sample1")
-	);
+			ImmutableMap.of("href", "/samples", "text", "Samples"),
+			ImmutableMap.of("href", "/samples/" + SAMPLE_ID, "text", "sample1"));
 
 	@BeforeEach
 	public void setUpTest() {
@@ -54,14 +51,14 @@ public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
 		assertEquals(4, page.getSequenceFileCount(), "Displays the correct number of sequence files");
 		assertEquals(2, page.getAssemblyFileCount(), "Displays the correct number of assemblies");
 		assertEquals(1, page.getQcEntryCount(), "should be 1 qc entry");
-		
+
 		page.checkBreadCrumbs(BREADCRUMBS);
 	}
-	
+
 	@Test
 	public void testDeleteFile() {
 		page.gotoPage(SAMPLE_ID);
-		
+
 		page.deleteFirstSequenceFile();
 		assertTrue(page.isDeleteConfirmationMessageDisplayed(),
 				"Should display a confirmation message that the file was deleted");
@@ -69,23 +66,25 @@ public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
 	}
 
 	@Test
-	public void testDeletePair(){
+	public void testDeletePair() {
 		page.gotoPage(SAMPLE_ID);
-		
+
 		page.deleteFirstSequenceFilePair();
-		assertTrue(page.isDeleteConfirmationMessageDisplayed(), "Should display a confirmation message that the file was deleted");
+		assertTrue(page.isDeleteConfirmationMessageDisplayed(),
+				"Should display a confirmation message that the file was deleted");
 		assertEquals(2, page.getSequenceFileCount(), "Displays the correct number of sequence files");
 	}
-	
+
 	@Test
 	public void testDeleteAssembly() {
 		page.gotoPage(SAMPLE_ID);
-		
+
 		page.deleteFirstAssemblyFile();
 		assertTrue(page.isDeleteConfirmationMessageDisplayed(),
 				"Should display a confirmation message that the file was deleted");
 		assertEquals(1, page.getAssemblyFileCount(), "Displays the correct number of assemblies");
-		assertEquals(4, page.getSequenceFileCount(), "Should not have deleted sequence files (displays correct number of sequence files)");
+		assertEquals(4, page.getSequenceFileCount(),
+				"Should not have deleted sequence files (displays correct number of sequence files)");
 	}
 
 	@Test
@@ -98,7 +97,8 @@ public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
 		page.gotoPage(SAMPLE_ID);
 		// Test wrong file format
 		page.uploadSequenceFile(FASTA_FILE);
-		assertTrue(page.isFileTypeWarningDisplayed(), "Should display a warning if the wrong file type is being uploaded.");
+		assertTrue(page.isFileTypeWarningDisplayed(),
+				"Should display a warning if the wrong file type is being uploaded.");
 	}
 
 	@Test
@@ -110,9 +110,10 @@ public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
 		assertEquals(3, page.getAssemblyFileCount(), "Displays the correct number of assemblies displayed");
 		// Test wrong file format
 		page.uploadAssemblyFile(FASTQ_FILE);
-		assertTrue(page.isFileTypeWarningDisplayed(), "Should display a warning if the wrong file type is being uploaded.");
+		assertTrue(page.isFileTypeWarningDisplayed(),
+				"Should display a warning if the wrong file type is being uploaded.");
 	}
-	
+
 	@Test
 	public void testAccessMultiProjectSamplePage() {
 		LoginPage.logout(driver());
@@ -120,5 +121,12 @@ public class SampleFilesPageIT extends AbstractIridaUIITChromeDriver {
 		page = new SampleFilesPage(driver());
 		page.gotoPage(5L);
 		assertTrue(page.getPageTitle().contains("sample5"), "Page Title contains the sample label");
+	}
+
+	@Test
+	public void testCorrectYear() {
+		page.gotoPage(SAMPLE_ID);
+		assertEquals("31 Dec 2013", page.getSequenceFileCreatedDate("03-3333_S1_L001_R1_001.fastq"),
+				"Year should be 2013");
 	}
 }

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/samples/SamplePagesIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/samples/SamplePagesIT.xml
@@ -104,12 +104,12 @@
 		file_path="src/test/resources/files/sequence-files/02-2222_S1_L001_R1_001.fastq" />
 	<sequence_file id="3" created_date="2013-07-18 14:20:19.0"
 		file_path="src/test/resources/files/sequence-files/02-2222_S1_L001_R2_001.fastq" />
-	<sequence_file id="4" created_date="2013-07-18 14:20:19.0"
+	<sequence_file id="4" created_date="2013-12-31 14:20:19.0"
 		file_path="src/test/resources/files/sequence-files/03-3333_S1_L001_R1_001.fastq" />
 
 	<sequencing_object id="1" created_date="2013-07-18 14:20:19.0" />
 	<sequencing_object id="2" created_date="2013-07-18 14:20:19.0" />
-	<sequencing_object id="3" created_date="2013-07-18 14:20:19.0" />
+	<sequencing_object id="3" created_date="2013-12-31 14:20:19.0" />
 
 	<sequence_file_pair id="1" />
 	<sequence_file_pair_files pair_id="1"
@@ -127,7 +127,7 @@
 		created_date="2013-07-18 14:20:19.0" sample_id="1"
 		sequencingobject_id="2" />
 	<sample_sequencingobject id="3"
-		created_date="2013-07-18 14:20:19.0" sample_id="1"
+		created_date="2013-12-31 14:20:19.0" sample_id="1"
 		sequencingobject_id="3" />
 
 	<analysis_submission id="1" name="my analysis"


### PR DESCRIPTION
## Description of changes
`YYYY` year format is actually week year which results in the incorrect calendar year being shown.

i.e. date is December 31, 2021, when using `YYYY` year is displayed as 2022 instead of 2021.

This is due to the last day of that week being in 2022. (i.e. January 1, 2022 is Saturday which is the last day of that week).

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
