### PR TITLE
Hotfix: Sample details modal add/remove to/from cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## [22.09.2]
 * [UI]: Fixed bug causing associated project samples to be added to the cart with the wrong project identifier. See [PR 1395](https://github.com/phac-nml/irida/pull/1395)
+* [UI]: Fixed bug where a sample added to the cart from the sample detail viewer still had a `Add to Cart` button if the viewer was closed and relaunched. See [PR 1397](https://github.com/phac-nml/irida/pull/1397)
 
 ## [22.09.1] - 2022/10/21
 * [UI]: Fixed when sharing or exporting sample on the project sample page, and other minor bugs. See [PR 1382](https://github.com/phac-nml/irida/pull/1382)

--- a/src/main/webapp/resources/js/apis/cart/cart.ts
+++ b/src/main/webapp/resources/js/apis/cart/cart.ts
@@ -122,7 +122,7 @@ export const {
   useRemoveSampleMutation,
 } = cartApi;
 
-const updateCart = (data: CartUpdated) => {
+export const updateCart = (data: CartUpdated) => {
   data.notifications.forEach((n) => notification[n.type](n));
   cartUpdated(data.count);
   return data.count;

--- a/src/main/webapp/resources/js/apis/samples/samples.ts
+++ b/src/main/webapp/resources/js/apis/samples/samples.ts
@@ -2,11 +2,14 @@ import { setBaseUrl } from "../../utilities/url-utilities";
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 import { get, post } from "../requests";
-import { AnalysisSubmission } from "../../types/irida";
+import { AnalysisSubmission, Sample } from "../../types/irida";
+import { CartUpdated, updateCart } from "../cart/cart";
 
 const URL = setBaseUrl(`ajax/samples`);
 
 const SEQUENCE_FILES_AJAX_URL = setBaseUrl("ajax/sequenceFiles");
+
+const CART_URL = setBaseUrl("ajax/cart");
 
 export type AnalysisState =
   | "NEW"
@@ -137,9 +140,7 @@ export interface SequencingObject {
  */
 export const sampleApi = createApi({
   reducerPath: `sampleApi`,
-  baseQuery: fetchBaseQuery({
-    baseUrl: setBaseUrl(URL),
-  }),
+  baseQuery: fetchBaseQuery({}),
   tagTypes: ["SampleDetails", "SampleMetadata"],
   endpoints: (build) => ({
     /*
@@ -147,7 +148,7 @@ export const sampleApi = createApi({
      */
     getSampleDetails: build.query({
       query: ({ sampleId, projectId }) => ({
-        url: `/${sampleId}/details?projectId=${projectId}`,
+        url: `${URL}/${sampleId}/details?projectId=${projectId}`,
       }),
       providesTags: ["SampleDetails"],
     }),
@@ -156,7 +157,7 @@ export const sampleApi = createApi({
      */
     updateSampleDetails: build.mutation({
       query: ({ sampleId, field, value }) => ({
-        url: `/${sampleId}/details`,
+        url: `${URL}/${sampleId}/details`,
         body: { field, value },
         method: "PUT",
       }),
@@ -170,7 +171,7 @@ export const sampleApi = createApi({
         metadataEntry,
         metadataRestriction,
       }) => ({
-        url: `/${sampleId}/metadata`,
+        url: `${URL}/${sampleId}/metadata`,
         body: { projectId, metadataField, metadataEntry, metadataRestriction },
         method: "POST",
       }),
@@ -178,7 +179,7 @@ export const sampleApi = createApi({
     }),
     removeSampleMetadata: build.mutation({
       query: ({ fieldId, entryId, projectId }) => ({
-        url: `/metadata?projectId=${projectId}&metadataFieldId=${fieldId}&metadataEntryId=${entryId}`,
+        url: `${URL}/metadata?projectId=${projectId}&metadataFieldId=${fieldId}&metadataEntryId=${entryId}`,
         method: "DELETE",
       }),
       invalidatesTags: ["SampleMetadata"],
@@ -193,7 +194,7 @@ export const sampleApi = createApi({
         metadataEntry,
         metadataRestriction,
       }) => ({
-        url: `/${sampleId}/metadata`,
+        url: `${URL}/${sampleId}/metadata`,
         body: {
           projectId,
           metadataFieldId,
@@ -208,7 +209,7 @@ export const sampleApi = createApi({
     }),
     removeSampleFiles: build.mutation({
       query: ({ sampleId, fileObjectId, type }) => ({
-        url: `/${sampleId}/files?fileObjectId=${fileObjectId}&fileType=${type}`,
+        url: `${URL}/${sampleId}/files?fileObjectId=${fileObjectId}&fileType=${type}`,
         method: "DELETE",
       }),
     }),
@@ -219,22 +220,42 @@ export const sampleApi = createApi({
         newFileName,
         removeOriginals,
       }) => ({
-        url: `/${sampleId}/files/concatenate?sequencingObjectIds=${sequencingObjectIds}&newFileName=${newFileName}&removeOriginals=${removeOriginals}`,
+        url: `${URL}/${sampleId}/files/concatenate?sequencingObjectIds=${sequencingObjectIds}&newFileName=${newFileName}&removeOriginals=${removeOriginals}`,
         method: "POST",
       }),
     }),
     updateDefaultSampleSequencingObject: build.mutation({
       query: ({ sampleId, sequencingObjectId }) => ({
-        url: `/${sampleId}/default-sequencing-object?sequencingObjectId=${sequencingObjectId}`,
+        url: `${URL}/${sampleId}/default-sequencing-object?sequencingObjectId=${sequencingObjectId}`,
         method: "PUT",
       }),
       invalidatesTags: ["SampleDetails"],
     }),
     updateDefaultSampleGenomeAssembly: build.mutation({
       query: ({ sampleId, genomeAssemblyId }) => ({
-        url: `/${sampleId}/default-genome-assembly?genomeAssemblyId=${genomeAssemblyId}`,
+        url: `${URL}/${sampleId}/default-genome-assembly?genomeAssemblyId=${genomeAssemblyId}`,
         method: "PUT",
       }),
+      invalidatesTags: ["SampleDetails"],
+    }),
+    putSampleInCart: build.mutation({
+      query: ({ projectId, samples }) => ({
+        url: CART_URL,
+        body: {
+          projectId,
+          sampleIds: samples.map((s: Sample) => s.id || s.identifier),
+        },
+        method: "POST",
+      }),
+      transformResponse: (res: CartUpdated) => updateCart(res),
+      invalidatesTags: ["SampleDetails"],
+    }),
+    removeSampleFromCart: build.mutation({
+      query: ({ sampleId }) => ({
+        url: `${CART_URL}/sample?sampleId=${sampleId}`,
+        method: "DELETE",
+      }),
+      transformResponse: (res: CartUpdated) => updateCart(res),
       invalidatesTags: ["SampleDetails"],
     }),
   }),
@@ -250,6 +271,8 @@ export const {
   useConcatenateSequencingObjectsMutation,
   useUpdateDefaultSampleGenomeAssemblyMutation,
   useUpdateDefaultSampleSequencingObjectMutation,
+  usePutSampleInCartMutation,
+  useRemoveSampleFromCartMutation,
 } = sampleApi;
 
 /**

--- a/src/main/webapp/resources/js/components/samples/SampleDetailViewer.tsx
+++ b/src/main/webapp/resources/js/components/samples/SampleDetailViewer.tsx
@@ -9,7 +9,7 @@ export interface SampleDetailViewerProps {
   projectId: number;
   displayActions?: boolean;
   children: React.ReactElement;
-  refetch?: () => void;
+  refetchCart?: () => void;
 }
 
 /**
@@ -26,7 +26,7 @@ export function SampleDetailViewer({
   projectId,
   displayActions = true,
   children,
-  refetch,
+  refetchCart,
 }: SampleDetailViewerProps): JSX.Element {
   const [visible, setVisible] = useState(false);
 
@@ -41,7 +41,7 @@ export function SampleDetailViewer({
             sampleId={sampleId}
             projectId={projectId}
             displayActions={displayActions}
-            refetchSample={refetch}
+            refetchCart={refetchCart}
             setVisible={setVisible}
             visible={visible}
           />

--- a/src/main/webapp/resources/js/components/samples/components/SampleDetailsModal.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/SampleDetailsModal.tsx
@@ -10,7 +10,7 @@ export interface DisplaySampleDetailsProps {
   sampleId: number;
   projectId: number;
   displayActions?: boolean;
-  refetch?: () => void;
+  refetchCart?: () => void;
   visible: boolean;
   setVisible: Dispatch<SetStateAction<boolean>>;
 }
@@ -21,7 +21,7 @@ export default function SampleDetailsModal({
   sampleId,
   projectId,
   displayActions,
-  refetch,
+  refetchCart,
   visible,
   setVisible,
 }: DisplaySampleDetailsProps) {
@@ -29,7 +29,11 @@ export default function SampleDetailsModal({
   const [component, setComponent] = React.useState<ViewerTab>("details");
 
   // Get the sample ready to display
-  const { data: details = {}, isLoading } = useGetSampleDetailsQuery({
+  const {
+    data: details = {},
+    isLoading,
+    refetch: refetchSample,
+  } = useGetSampleDetailsQuery({
     sampleId,
     projectId,
   });
@@ -85,7 +89,8 @@ export default function SampleDetailsModal({
             tab={component}
             onMenuChange={setComponent}
             displayActions={!!displayActions}
-            refetch={refetch}
+            refetchCart={refetchCart}
+            refetchSample={refetchSample}
           />
           <div
             style={{

--- a/src/main/webapp/resources/js/components/samples/components/SampleDetailsModal.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/SampleDetailsModal.tsx
@@ -29,11 +29,7 @@ export default function SampleDetailsModal({
   const [component, setComponent] = React.useState<ViewerTab>("details");
 
   // Get the sample ready to display
-  const {
-    data: details = {},
-    isLoading,
-    refetch: refetchSample,
-  } = useGetSampleDetailsQuery({
+  const { data: details = {}, isLoading } = useGetSampleDetailsQuery({
     sampleId,
     projectId,
   });
@@ -59,6 +55,7 @@ export default function SampleDetailsModal({
     details.projectId,
     details.projectName,
     details.sample,
+    details.inCart,
     dispatch,
     isLoading,
   ]);
@@ -90,7 +87,6 @@ export default function SampleDetailsModal({
             onMenuChange={setComponent}
             displayActions={!!displayActions}
             refetchCart={refetchCart}
-            refetchSample={refetchSample}
           />
           <div
             style={{

--- a/src/main/webapp/resources/js/components/samples/components/SampleDetailsWrapper.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/SampleDetailsWrapper.tsx
@@ -7,7 +7,7 @@ interface SampleDetailsWrapperProps {
   sampleId: number;
   projectId: number;
   displayActions: boolean;
-  refetchSample?: () => void;
+  refetchCart?: () => void;
   visible: boolean;
   setVisible: Dispatch<SetStateAction<boolean>>;
 }
@@ -16,7 +16,7 @@ export default function SampleDetailsWrapper({
   sampleId,
   projectId,
   displayActions,
-  refetchSample,
+  refetchCart,
   visible,
   setVisible,
 }: SampleDetailsWrapperProps) {
@@ -26,7 +26,7 @@ export default function SampleDetailsWrapper({
         sampleId={sampleId}
         projectId={projectId}
         displayActions={displayActions}
-        refetch={refetchSample}
+        refetchCart={refetchCart}
         visible={visible}
         setVisible={setVisible}
       />

--- a/src/main/webapp/resources/js/components/samples/components/ViewerHeader.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/ViewerHeader.tsx
@@ -4,10 +4,11 @@ import { useAppDispatch, useAppSelector } from "../../../hooks/useState";
 import { generateColourForItem } from "../../../utilities/colour-utilities";
 import { ViewerTab } from "./SampleDetailsModal";
 
+import { updateSampleInCart } from "../sampleSlice";
 import {
-  addSampleToCartThunk,
-  removeSampleFromCartThunk,
-} from "../sampleSlice";
+  usePutSampleInCartMutation,
+  useRemoveSampleFromCartMutation,
+} from "../../../apis/samples/samples";
 
 export const HEADER_HEIGHT = 90;
 export const HEADER_HEIGHT_WITH_PADDING = 97;
@@ -16,7 +17,6 @@ export default function ViewerHeader({
   displayActions,
   projectId,
   refetchCart,
-  refetchSample,
   tab,
   onMenuChange,
 }: {
@@ -24,7 +24,6 @@ export default function ViewerHeader({
   projectId: number;
   sampleId: number;
   refetchCart: undefined | (() => void);
-  refetchSample: () => void;
   tab: ViewerTab;
   onMenuChange: Dispatch<SetStateAction<ViewerTab>>;
 }): JSX.Element {
@@ -32,6 +31,9 @@ export default function ViewerHeader({
   const { inCart, sample, projectName } = useAppSelector(
     (state) => state.sampleReducer
   );
+
+  const [removeSampleFromCart] = useRemoveSampleFromCartMutation();
+  const [addSampleToCart] = usePutSampleInCartMutation();
 
   const projectColour = useMemo(
     () =>
@@ -85,9 +87,10 @@ export default function ViewerHeader({
             className="t-remove-sample-from-cart"
             danger
             onClick={() => {
-              dispatch(removeSampleFromCartThunk());
-              if (typeof refetchCart !== "undefined") refetchCart();
-              refetchSample();
+              removeSampleFromCart({ sampleId: sample.identifier }).then(() => {
+                dispatch(updateSampleInCart({ inCart: false }));
+                if (typeof refetchCart !== "undefined") refetchCart();
+              });
             }}
           >
             {i18n("SampleDetailsViewer.removeFromCart")}
@@ -98,9 +101,10 @@ export default function ViewerHeader({
             size="small"
             className="t-add-sample-to-cart"
             onClick={() => {
-              dispatch(addSampleToCartThunk());
-              if (typeof refetchCart !== "undefined") refetchCart();
-              refetchSample();
+              addSampleToCart({ projectId, samples: [sample] }).then(() => {
+                dispatch(updateSampleInCart({ inCart: true }));
+                if (typeof refetchCart !== "undefined") refetchCart();
+              });
             }}
           >
             {i18n("SampleDetailsViewer.addToCart")}

--- a/src/main/webapp/resources/js/components/samples/components/ViewerHeader.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/ViewerHeader.tsx
@@ -58,7 +58,7 @@ export default function ViewerHeader({
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
-          margin: `10px 50px 0 20px`,
+          margin: `10px 56px 0 20px`,
         }}
       >
         <Space>

--- a/src/main/webapp/resources/js/components/samples/components/ViewerHeader.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/ViewerHeader.tsx
@@ -15,14 +15,16 @@ export const HEADER_HEIGHT_WITH_PADDING = 97;
 export default function ViewerHeader({
   displayActions,
   projectId,
-  refetch,
+  refetchCart,
+  refetchSample,
   tab,
   onMenuChange,
 }: {
   displayActions: boolean;
   projectId: number;
   sampleId: number;
-  refetch: undefined | (() => void);
+  refetchCart: undefined | (() => void);
+  refetchSample: () => void;
   tab: ViewerTab;
   onMenuChange: Dispatch<SetStateAction<ViewerTab>>;
 }): JSX.Element {
@@ -84,7 +86,8 @@ export default function ViewerHeader({
             danger
             onClick={() => {
               dispatch(removeSampleFromCartThunk());
-              if (typeof refetch !== "undefined") refetch();
+              if (typeof refetchCart !== "undefined") refetchCart();
+              refetchSample();
             }}
           >
             {i18n("SampleDetailsViewer.removeFromCart")}
@@ -96,7 +99,8 @@ export default function ViewerHeader({
             className="t-add-sample-to-cart"
             onClick={() => {
               dispatch(addSampleToCartThunk());
-              if (typeof refetch !== "undefined") refetch();
+              if (typeof refetchCart !== "undefined") refetchCart();
+              refetchSample();
             }}
           >
             {i18n("SampleDetailsViewer.addToCart")}

--- a/src/main/webapp/resources/js/components/samples/sampleSlice.ts
+++ b/src/main/webapp/resources/js/components/samples/sampleSlice.ts
@@ -4,7 +4,6 @@ import {
   SampleMetadataFieldEntry,
 } from "../../apis/samples/samples";
 import { Sample } from "../../types/irida";
-import { putSampleInCart, removeSample } from "../../apis/cart/cart";
 
 /**
  * Action to set the target sample
@@ -119,25 +118,11 @@ export const updateDetails = createAction(
   })
 );
 
-export const addSampleToCartThunk = createAsyncThunk(
-  "sample/addSampleToCartThunk",
-  async (_, { getState }) => {
-    const { sampleReducer } = getState();
-    await putSampleInCart(sampleReducer.projectId, [sampleReducer.sample]);
-    return {};
-  }
-);
-
-export const removeSampleFromCartThunk = createAsyncThunk(
-  "sample/removeSampleFromCartThunk",
-  async (_, { getState }) => {
-    const { sampleReducer } = getState();
-    await removeSample(
-      sampleReducer.projectId,
-      sampleReducer.sample.identifier
-    );
-    return {};
-  }
+export const updateSampleInCart = createAction(
+  `sample/updateSampleInCart`,
+  ({ inCart }) => ({
+    payload: { inCart },
+  })
 );
 
 /**
@@ -261,12 +246,8 @@ const sampleSlice = createSlice({
       };
     });
 
-    builder.addCase(addSampleToCartThunk.fulfilled, (state) => {
-      state.inCart = true;
-    });
-
-    builder.addCase(removeSampleFromCartThunk.fulfilled, (state) => {
-      state.inCart = false;
+    builder.addCase(updateSampleInCart, (state, action) => {
+      state.inCart = action.payload.inCart;
     });
   },
 });

--- a/src/main/webapp/resources/js/pages/cart/components/SampleRenderer.jsx
+++ b/src/main/webapp/resources/js/pages/cart/components/SampleRenderer.jsx
@@ -41,7 +41,7 @@ export class SampleRenderer extends React.Component {
             <SampleDetailViewer
               sampleId={sample.id}
               projectId={this.props.data.project.id}
-              refetch={this.props.refetch}
+              refetchCart={this.props.refetch}
             >
               <Button
                 className="t-sample-details-btn"

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/CartPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/CartPageIT.java
@@ -102,6 +102,35 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		driver().manage().window().maximize();
 		// Add some samples to the cart and test to see if they get displayed/
 		ProjectSamplesPage samplesPage = ProjectSamplesPage.goToPage(driver(), 1);
+
+		SampleDetailsViewer sampleDetailsViewer = SampleDetailsViewer.getSampleDetails(driver());
+
+		// Test that the add/remove buttons for the sample detail viewer are displayed correctly depending on if the sample is in the cart or not
+		samplesPage.clickSampleName("sample5fg44");
+		assertTrue(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
+				"The add cart to sample button should be displayed");
+		assertFalse(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
+				"The remove sample from cart button should not be displayed");
+
+		sampleDetailsViewer.clickAddSampleToCartButton();
+
+		assertFalse(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
+				"The add cart to sample button should not be displayed");
+		assertTrue(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
+				"The remove sample from cart button should be displayed");
+
+		sampleDetailsViewer.clickSampleDetailsViewerCloseButton();
+
+		samplesPage.clickSampleName("sample5fg44");
+
+		assertFalse(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
+				"The add cart to sample button should not be displayed");
+		assertTrue(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
+				"The remove sample from cart button should be displayed");
+
+		sampleDetailsViewer.clickRemoveSampleFromCartButton();
+		sampleDetailsViewer.clickSampleDetailsViewerCloseButton();
+
 		samplesPage.selectSampleByName("sample5fg44");
 		samplesPage.selectSampleByName("sample5fdgr");
 		samplesPage.selectSampleByName("sample554sg5");
@@ -121,7 +150,6 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		final String sampleName = "sample554sg5";
 		final String projectName = "project";
 		page.viewSampleDetailsFor(sampleName);
-		SampleDetailsViewer sampleDetailsViewer = SampleDetailsViewer.getSampleDetails(driver());
 
 		assertFalse(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
 				"The add cart to sample button should not be displayed");
@@ -184,7 +212,7 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		assertEquals(1, sampleDetailsViewer.numberOfSampleAnalysesVisible(),
 				"AUser should only see listing of 1 analysis ran with this sample");
 
-		sampleDetailsViewer.clickRemoveSampleFromCartButton();
+		sampleDetailsViewer.clickRemoveSampleFromCartButtonCartPage();
 
 		assertFalse(sampleDetailsViewer.sampleDetailsViewerVisible(), "The sample details viewer should not be displayed as the sample was removed from the cart");
 
@@ -202,6 +230,35 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		driver().manage().window().maximize();
 		// Add some samples to the cart and test to see if they get displayed/
 		ProjectSamplesPage samplesPage = ProjectSamplesPage.goToPage(driver(), 1);
+		SampleDetailsViewer sampleDetailsViewer = SampleDetailsViewer.getSampleDetails(driver());
+
+		// Test that the add/remove buttons for the sample detail viewer are displayed correctly depending on if the sample is in the cart or not
+		samplesPage.clickSampleName("sample5fg44");
+		assertTrue(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
+				"The add cart to sample button should be displayed");
+		assertFalse(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
+				"The remove sample from cart button should not be displayed");
+
+		sampleDetailsViewer.clickAddSampleToCartButton();
+
+		assertFalse(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
+				"The add cart to sample button should not be displayed");
+		assertTrue(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
+				"The remove sample from cart button should be displayed");
+
+		sampleDetailsViewer.clickSampleDetailsViewerCloseButton();
+
+		samplesPage.clickSampleName("sample5fg44");
+
+		assertFalse(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
+				"The add cart to sample button should not be displayed");
+		assertTrue(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
+				"The remove sample from cart button should be displayed");
+
+		sampleDetailsViewer.clickRemoveSampleFromCartButton();
+		sampleDetailsViewer.clickSampleDetailsViewerCloseButton();
+
+
 		samplesPage.selectSampleByName("sample5fg44");
 		samplesPage.selectSampleByName("sample5fdgr");
 		samplesPage.selectSampleByName("sample554sg5");
@@ -221,7 +278,7 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		final String sampleName = "sample554sg5";
 		final String projectName = "project";
 		page.viewSampleDetailsFor(sampleName);
-		SampleDetailsViewer sampleDetailsViewer = SampleDetailsViewer.getSampleDetails(driver());
+
 
 		assertFalse(sampleDetailsViewer.isAddSampleToCartButtonVisible(),
 				"The add cart to sample button should not be displayed");
@@ -360,7 +417,7 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		assertTrue(sampleDetailsViewer.isRemoveSampleFromCartButtonVisible(),
 				"The remove sample from cart button should be displayed");
 
-		sampleDetailsViewer.clickRemoveSampleFromCartButton();
+		sampleDetailsViewer.clickRemoveSampleFromCartButtonCartPage();
 
 		assertFalse(sampleDetailsViewer.sampleDetailsViewerVisible(), "The sample details viewer should not be displayed as the sample was removed from the cart");
 
@@ -419,7 +476,7 @@ public class CartPageIT extends AbstractIridaUIITChromeDriver {
 		SampleDetailsViewer viewer = SampleDetailsViewer.getSampleDetails(driver());
 		assertEquals(ASSOCIATED_PROJECT_NAME, viewer.getProjectName(), "Should have the correct project name");
 
-		viewer.clickRemoveSampleFromCartButton();
+		viewer.clickRemoveSampleFromCartButtonCartPage();
 
 		assertFalse(viewer.sampleDetailsViewerVisible(), "The sample details viewer should not be displayed as the sample was removed from the cart");
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/components/SampleDetailsViewer.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/components/SampleDetailsViewer.java
@@ -357,10 +357,23 @@ public class SampleDetailsViewer extends AbstractPage {
 		waitForTime(500);
 	}
 
-	public void clickRemoveSampleFromCartButton() {
+	// If removing the sample from the cart on the cart page it will close the sample detail viewer
+	public void clickRemoveSampleFromCartButtonCartPage() {
 		removeSampleFromCartBtn.click();
 		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(5));
 		wait.until(ExpectedConditions.invisibilityOf(modal));
+	}
+
+	public void clickRemoveSampleFromCartButton() {
+		removeSampleFromCartBtn.click();
+		waitForTime(500);
+	}
+
+	public void clickSampleDetailsViewerCloseButton() {
+		WebElement element = driver.findElement(By.className("ant-modal-close"));
+		element.click();
+		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10L));
+		wait.until(ExpectedConditions.invisibilityOfAllElements(driver.findElements(By.className("t-sample-details-modal"))));
 	}
 
 	public int numberOfSequencingObjectsSetAsDefault() {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
@@ -456,6 +456,11 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		checkbox.click();
 	}
 
+	public void clickSampleName(String sampleName) {
+		WebElement sampleNameLink = samplesTable.findElement(By.xpath("//td/button[span[text()='" + sampleName + "']]"));
+		sampleNameLink.click();
+	}
+
 	public Long getCoverageForSampleByName(String sampleName) {
 		WebElement coverageCell = samplesTable.findElement(
 				By.xpath("//td/button[span[text()='" + sampleName + "']]/../../td[contains(@class, 't-td-coverage')]"));


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed bug with sample details viewer which would still display a `Add to Cart` button to if the modal was closed and relaunched after the sample was added to the cart from the viewer.

Steps to reproduce before fix:

1) Add sample to project
2) Launch sample details viewer by clicking on the sample name in the project samples table
3) Click the `Add to Cart` button. Should now display the `Remove from Cart` button
4) Close the viewer
5) Relaunch the details viewer for the same sample
6) You should see a `Add to Cart` button

To test fix:

1) Add sample to project
2) Launch sample details viewer by clicking on the sample name in the project samples table
3) Click the `Add to Cart` button. Should now display the `Remove from Cart` button
4) Close the viewer
5) Relaunch the details viewer for the same sample
6) You should see a `Remove from Cart` button


## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
