### PR TITLE
Hotfix/irida newer galaxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [UI]: Fixed bug preventing the removal of locked samples within a project. See [PR 1396](https://github.com/phac-nml/irida/pull/1396)
 * [Developer/UI]: Fixed bug preventing managers from sharing project samples. See [PR 1398](https://github.com/phac-nml/irida/pull/1398)
 * [UI]: Fixed bug where a sample added to the cart from the sample detail viewer still had a `Add to Cart` button if the viewer was closed and relaunched. See [PR 1397](https://github.com/phac-nml/irida/pull/1397)
-* [Galaxy]: Fixed missing "deferred" state found in the Galaxy API but not in the IRIDA API for getting status of Galaxy histories. See [PR X]().
+* [Galaxy]: Fixed missing "deferred" state found in the Galaxy API but not in the IRIDA API for getting status of Galaxy histories. See [PR 1402](https://github.com/phac-nml/irida/pull/1402).
 
 ## [22.09.1] - 2022/10/21
 * [UI]: Fixed when sharing or exporting sample on the project sample page, and other minor bugs. See [PR 1382](https://github.com/phac-nml/irida/pull/1382)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UI]: Fixed bug preventing the removal of locked samples within a project. See [PR 1396](https://github.com/phac-nml/irida/pull/1396)
 * [Developer/UI]: Fixed bug preventing managers from sharing project samples. See [PR 1398](https://github.com/phac-nml/irida/pull/1398)
 * [UI]: Fixed bug where a sample added to the cart from the sample detail viewer still had a `Add to Cart` button if the viewer was closed and relaunched. See [PR 1397](https://github.com/phac-nml/irida/pull/1397)
+* [Galaxy]: Fixed missing "deferred" state found in the Galaxy API but not in the IRIDA API for getting status of Galaxy histories. See [PR X]().
 
 ## [22.09.1] - 2022/10/21
 * [UI]: Fixed when sharing or exporting sample on the project sample page, and other minor bugs. See [PR 1382](https://github.com/phac-nml/irida/pull/1382)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/execution/galaxy/GalaxyWorkflowState.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/workflow/execution/galaxy/GalaxyWorkflowState.java
@@ -8,8 +8,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Defines the state of a workflow.
  * Based off of states defined within Galaxy.
- * @see <a href="https://bitbucket.org/galaxy/galaxy-dist/src/097bbb3b7d3246faaa5188a1fc2a79b01630025c/lib/galaxy/model/__init__.py#cl-1316">Galaxy Dataset Model</a>
- * @see <a href="https://bitbucket.org/galaxy/galaxy-dist/src/097bbb3b7d3246faaa5188a1fc2a79b01630025c/lib/galaxy/web/base/controller.py#cl-429">Galaxy API</a>
+ * @see <a href="https://github.com/galaxyproject/galaxy/blob/21375c6b821b85863a6c95f4ed1ebd6a217495f1/lib/galaxy/model/__init__.py#L3410-L3427">Galaxy Dataset Model</a>
+ * @see <a href="https://github.com/galaxyproject/galaxy/blob/21375c6b821b85863a6c95f4ed1ebd6a217495f1/lib/galaxy/webapps/galaxy/api/histories.py#L181-L192">Galaxy API show_history</a>
  * @see <a href="https://github.com/jmchilton/blend4j/blob/c5e3f157d402950a843d4e395e1daf889945d587/src/main/java/com/github/jmchilton/blend4j/galaxy/beans/HistoryDetails.java">HistoryDetails in blend4j</a>
  *
  */
@@ -30,6 +30,7 @@ public enum GalaxyWorkflowState {
 	PAUSED("paused"),
 	SETTING_METADATA("setting_metadata"),
 	FAILED_METADATA("failed_metadata"),
+	DEFERRED("deferred"),
 	RESUBMITTED("resubmitted");
 	
 	private static Map<String, GalaxyWorkflowState> stateMap = new HashMap<>();


### PR DESCRIPTION
## Description of changes

Added a "deferred" state in the allowable states from the Galaxy API for datasets in a Galaxy history. This fixes an issue with communication between IRIDA and newer versions of Galaxy.

If you wished to directly test, you would have to first install a new version of Galaxy (I used 22.05) and configure to run data analysis pipelines for IRIDA. Then try to run a pipeline. Prior to this fix, running pipelines will not work but after this fix they do work.

## Related issue
Fixes #1401 

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* ~[ ] User documentation updated for UI or technical changes.~
