### PR TITLE
Fixed broken links in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## [Unreleased]
 * [UI/Developer]: Updated `react-router` to the version 6.4.3. See[PR 1405](https://github.com/phac-nml/irida/pull/1405)
-* [Developer] Updated developer setup documentation, ignore java_pid*.hprof files, and added quality of life file `gradle.properties`
+* [Developer] Updated developer setup documentation, ignore java_pid\*.hprof files, and added quality of life file `gradle.properties`. See [PR 1415](https://github.com/phac-nml/irida/pull/1415).
+* [Documentation]: Updated broken links in developer documentation. See [PR 1416](https://github.com/phac-nml/irida/pull/1416).
 
 ## [22.09.4] - 2022/11/14
 * [REST]: Fixed issue with project/samples api response missing samples when a sample has a default sequencing object. See [PR 1413](https://github.com/phac-nml/irida/pull/1413)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## [Unreleased]
 * [UI/Developer]: Updated `react-router` to the version 6.4.3. See[PR 1405](https://github.com/phac-nml/irida/pull/1405)
 * [Developer] Updated developer setup documentation, ignore java_pid\*.hprof files, and added quality of life file `gradle.properties`. See [PR 1415](https://github.com/phac-nml/irida/pull/1415).
-* [Documentation]: Updated broken links in developer documentation. See [PR 1416](https://github.com/phac-nml/irida/pull/1416).
+* [Documentation]: Updated broken links in developer documentation. See [PR 1418](https://github.com/phac-nml/irida/pull/1418).
 
 ## [22.09.4] - 2022/11/14
 * [REST]: Fixed issue with project/samples api response missing samples when a sample has a default sequencing object. See [PR 1413](https://github.com/phac-nml/irida/pull/1413)

--- a/doc/developer/getting-started/index.md
+++ b/doc/developer/getting-started/index.md
@@ -66,7 +66,7 @@ Liquibase is used to manage IRIDA's relational database change management.  Any 
 
 Documentation: [https://docs.galaxyproject.org/en/master/index.html](https://docs.galaxyproject.org/en/master/index.html)
 
-Galaxy is used as IRIDA's analysis workflow engine.  Analysis pipelines must be developed as Galaxy pipelines to integrate with IRIDA's workflow system.  See the [Galaxy Setup](/administrator/galaxy/) documentation for Galaxy installation and the [Tool Development](/developer/tools/) documentation for building tools for IRDIA.
+Galaxy is used as IRIDA's analysis workflow engine.  Analysis pipelines must be developed as Galaxy pipelines to integrate with IRIDA's workflow system.  See the [Galaxy Setup](../../administrator/galaxy/) documentation for Galaxy installation and the [Tool Development](../../developer/tools/) documentation for building tools for IRDIA.
 
 #### Other important libraries
 {:.no_toc}
@@ -266,7 +266,7 @@ IRIDA documentation can be found in the <https://github.com/phac-nml/irida-docs>
 ##### Testing IRIDA documentation locally
 To view the documentation locally or make changes, you can checkout the above GitHub project and make changes.  To run the server locally you can run Jekyll to generate the pages.
 
-First `cd` into the `docs/` directory and run the following command:
+First `cd` into the `doc/` directory and run the following command:
 
 ```bash
 bundle exec jekyll serve


### PR DESCRIPTION
## Description of changes
Fixed some broken links in the developer documentation. Also fixed up some info in the CHANGELOG.

### Test

To test, you can build the docs as follows:

```bash
cd doc
bundle exec jekyll serve --host 0.0.0.0 --port 3000
```

Now you should be able to go to http://localhost:3000/irida-documentation and view the documentation.

You can remove the `--host 0.0.0.0 --port 3000` and it defaults to http://localhost:4000/irida-documentation

## Related issue
None.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* ~[ ] User documentation updated for UI or technical changes.~
