### PR TITLE
HOTFIX: display synchronize new remote project url errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 # Changelog
 
+## [22.09.5] - Unreleased
+* [Developer/UI]: Updated synchronize new remote project page to display http errors when setting the url manually and an error is encountered. See [PR 1433](https://github.com/phac-nml/irida/pull/1431)
+
 ## [22.09.4] - 2022/11/14
 * [REST]: Fixed issue with project/samples api response missing samples when a sample has a default sequencing object. See [PR 1413](https://github.com/phac-nml/irida/pull/1413)
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/IridaOAuthException.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/exceptions/IridaOAuthException.java
@@ -1,5 +1,7 @@
 package ca.corefacility.bioinformatics.irida.exceptions;
 
+import org.springframework.http.HttpStatus;
+
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPIToken;
 
@@ -14,6 +16,7 @@ public class IridaOAuthException extends RuntimeException {
 
 	private static final long serialVersionUID = 5281201199554307578L;
 	private RemoteAPI remoteAPI;
+	private HttpStatus httpStatusCode;
 
 	/**
 	 * Create a new IridaOAuthException with the given message and service
@@ -27,6 +30,13 @@ public class IridaOAuthException extends RuntimeException {
 	public IridaOAuthException(String message, RemoteAPI remoteAPI) {
 		super(message);
 		this.remoteAPI = remoteAPI;
+	}
+
+	public IridaOAuthException(String message, HttpStatus httpStatusCode, RemoteAPI remoteAPI) {
+		super(message);
+		this.httpStatusCode = httpStatusCode;
+		this.remoteAPI = remoteAPI;
+
 	}
 
 	/**
@@ -62,5 +72,13 @@ public class IridaOAuthException extends RuntimeException {
 	 */
 	public void setRemoteAPI(RemoteAPI remoteAPI) {
 		this.remoteAPI = remoteAPI;
+	}
+
+	public HttpStatus getHttpStatusCode() {
+		return httpStatusCode;
+	}
+
+	public void setHttpStatusCode(HttpStatus httpStatusCode) {
+		this.httpStatusCode = httpStatusCode;
 	}
 }

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/resttemplate/IridaOAuthErrorHandler.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/resttemplate/IridaOAuthErrorHandler.java
@@ -31,10 +31,10 @@ public class IridaOAuthErrorHandler extends DefaultResponseErrorHandler {
 		switch (statusCode) {
 		case UNAUTHORIZED:
 			logger.trace("Throwing new IridaOAuthException (Unauthorized) for this error");
-			throw new IridaOAuthException("User is unauthorized for this service", statusCode, remoteAPI);
+			throw new IridaOAuthException("User is unauthorized for this resource", statusCode, remoteAPI);
 		case FORBIDDEN:
 			logger.trace("Throwing new IridaOAuthException (Forbidden) for this error");
-			throw new IridaOAuthException("User is forbidden from accessing this service", statusCode, remoteAPI);
+			throw new IridaOAuthException("User is forbidden from accessing this resource", statusCode, remoteAPI);
 		case NOT_FOUND:
 			logger.trace("Throwing new IridaOAuthException for this error");
 			throw new IridaOAuthException("Resource not found", statusCode, remoteAPI);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/resttemplate/IridaOAuthErrorHandler.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/resttemplate/IridaOAuthErrorHandler.java
@@ -31,7 +31,7 @@ public class IridaOAuthErrorHandler extends DefaultResponseErrorHandler {
 		switch (statusCode) {
 		case UNAUTHORIZED:
 			logger.trace("Throwing new IridaOAuthException (Unauthorized) for this error");
-			throw new IridaOAuthException("User is unauthorized for this resource", statusCode, remoteAPI);
+			throw new IridaOAuthException("User is unauthorized for this service", statusCode, remoteAPI);
 		case FORBIDDEN:
 			logger.trace("Throwing new IridaOAuthException (Forbidden) for this error");
 			throw new IridaOAuthException("User is forbidden from accessing this resource", statusCode, remoteAPI);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/resttemplate/IridaOAuthErrorHandler.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/resttemplate/IridaOAuthErrorHandler.java
@@ -30,11 +30,14 @@ public class IridaOAuthErrorHandler extends DefaultResponseErrorHandler {
 		logger.trace("Checking error type " + statusCode.toString());
 		switch (statusCode) {
 		case UNAUTHORIZED:
-			logger.trace("Throwing new IridaOAuthException for this error");
-			throw new IridaOAuthException("User is unauthorized for this service", remoteAPI);
+			logger.trace("Throwing new IridaOAuthException (Unauthorized) for this error");
+			throw new IridaOAuthException("User is unauthorized for this service", statusCode, remoteAPI);
 		case FORBIDDEN:
+			logger.trace("Throwing new IridaOAuthException (Forbidden) for this error");
+			throw new IridaOAuthException("User is forbidden from accessing this service", statusCode, remoteAPI);
+		case NOT_FOUND:
 			logger.trace("Throwing new IridaOAuthException for this error");
-			throw new IridaOAuthException("User is unauthorized for this service", remoteAPI);
+			throw new IridaOAuthException("Resource not found", statusCode, remoteAPI);
 		default:
 			logger.trace("Passing error to superclass");
 			super.handleError(response);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/ajax/RemoteAPIAjaxController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/ajax/RemoteAPIAjaxController.java
@@ -148,13 +148,11 @@ public class RemoteAPIAjaxController extends BaseController {
      * @return status of created the new remote project
      */
     @PostMapping("/project")
-    public ResponseEntity<AjaxResponse> createSynchronizedProject(@RequestBody CreateRemoteProjectRequest request) {
+    public ResponseEntity<AjaxResponse> createSynchronizedProject(@RequestBody CreateRemoteProjectRequest request, Locale locale) {
         try {
-            return ResponseEntity.ok(service.createSynchronizedProject(request));
+            return ResponseEntity.ok(new AjaxCreateItemSuccessResponse(service.createSynchronizedProject(request, locale)));
         } catch (IridaOAuthException e) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new AjaxErrorResponse(e.getMessage()));
-        } catch (EntityNotFoundException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new AjaxErrorResponse(e.getMessage()));
+            return ResponseEntity.status(e.getHttpStatusCode()).body(new AjaxErrorResponse(e.getMessage()));
         }
     }
 

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -3024,6 +3024,6 @@ AnalysisState.ERROR=Error
 #=========================================================================================#
 InputWithOptions.required={0} is required to run this pipeline. Please select one of the options.
 
-IridaOAuthErrorHandler.unauthorized=User is unauthorized for this resource
+IridaOAuthErrorHandler.unauthorized=User is unauthorized for this service
 IridaOAuthErrorHandler.forbidden=Access denied. User is forbidden from accessing this resource
 IridaOAuthErrorHandler.notFound=Resource not found. A resource with the given identifier could not be found

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -3024,6 +3024,6 @@ AnalysisState.ERROR=Error
 #=========================================================================================#
 InputWithOptions.required={0} is required to run this pipeline. Please select one of the options.
 
-IridaOAuthErrorHandler.unauthorized=User is unauthorized for this service
-IridaOAuthErrorHandler.forbidden=Access denied. User is forbidden from accessing this service
+IridaOAuthErrorHandler.unauthorized=User is unauthorized for this resource
+IridaOAuthErrorHandler.forbidden=Access denied. User is forbidden from accessing this resource
 IridaOAuthErrorHandler.notFound=Resource not found. A resource with the given identifier could not be found

--- a/src/main/resources/i18n/messages.properties
+++ b/src/main/resources/i18n/messages.properties
@@ -3023,3 +3023,7 @@ AnalysisState.ERROR=Error
 # InputWithOptions                                                                        #
 #=========================================================================================#
 InputWithOptions.required={0} is required to run this pipeline. Please select one of the options.
+
+IridaOAuthErrorHandler.unauthorized=User is unauthorized for this service
+IridaOAuthErrorHandler.forbidden=Access denied. User is forbidden from accessing this service
+IridaOAuthErrorHandler.notFound=Resource not found. A resource with the given identifier could not be found

--- a/src/main/webapp/resources/js/apis/remote-api/remote-api.js
+++ b/src/main/webapp/resources/js/apis/remote-api/remote-api.js
@@ -59,5 +59,8 @@ export function getProjectsForAPI({ id }) {
 export function createSynchronizedProject({ url, frequency }) {
   return axios
     .post(`${BASE_URL}/project`, { url, frequency })
-    .then(({ data }) => data);
+    .then(({ data }) => data)
+    .catch((error) => {
+      return Promise.reject(error.response.data.error);
+    });
 }

--- a/src/main/webapp/resources/js/components/remote-api/CreateRemoteProjectSyncForm.jsx
+++ b/src/main/webapp/resources/js/components/remote-api/CreateRemoteProjectSyncForm.jsx
@@ -125,6 +125,7 @@ export function CreateRemoteProjectSyncForm() {
                   <span>
                     {i18n("NewProjectSync.remoteUrl")}
                     <Checkbox
+                      className="t-remote-project-url-checkbox"
                       onChange={(e) => {
                         setManual(e.target.checked);
                         setNewRemoteProjectUrlError(null);

--- a/src/main/webapp/resources/js/components/remote-api/CreateRemoteProjectSyncForm.jsx
+++ b/src/main/webapp/resources/js/components/remote-api/CreateRemoteProjectSyncForm.jsx
@@ -18,6 +18,8 @@ import { SyncFrequencySelect } from "./SyncFrequencySelect";
 export function CreateRemoteProjectSyncForm() {
   const [apis, setApis] = useState([]);
   const [selectedApi, setSelectedApi] = useState();
+  const [newRemoteProjectUrlError, setNewRemoteProjectUrlError] =
+    useState(null);
   const [projects, setProjects] = useState([]);
   const [connected, setConnected] = useState();
   const [manual, setManual] = useState(false);
@@ -53,12 +55,15 @@ export function CreateRemoteProjectSyncForm() {
 
   const createRemote = () => {
     form.validateFields().then(({ frequency, url }) => {
+      setNewRemoteProjectUrlError(null);
       createSynchronizedProject({
         url,
         frequency,
-      }).then(
-        ({ id }) => (window.location.href = setBaseUrl(`/projects/${id}`))
-      );
+      })
+        .then(
+          ({ id }) => (window.location.href = setBaseUrl(`/projects/${id}`))
+        )
+        .catch((error) => setNewRemoteProjectUrlError(error));
     });
   };
 
@@ -106,6 +111,10 @@ export function CreateRemoteProjectSyncForm() {
                 />
               </Form.Item>
               <Form.Item
+                validateStatus={newRemoteProjectUrlError !== null && "error"}
+                help={
+                  newRemoteProjectUrlError !== null && newRemoteProjectUrlError
+                }
                 rules={[
                   {
                     required: true,
@@ -115,7 +124,12 @@ export function CreateRemoteProjectSyncForm() {
                 label={
                   <span>
                     {i18n("NewProjectSync.remoteUrl")}
-                    <Checkbox onChange={(e) => setManual(e.target.checked)}>
+                    <Checkbox
+                      onChange={(e) => {
+                        setManual(e.target.checked);
+                        setNewRemoteProjectUrlError(null);
+                      }}
+                    >
                       {i18n("NewProjectSync.remoteUrl.manual")}
                       <HelpPopover
                         content={<div>{i18n("NewProjectSync.url.help")}</div>}
@@ -125,7 +139,11 @@ export function CreateRemoteProjectSyncForm() {
                 }
                 name="url"
               >
-                <Input className="t-project-url" disabled={!manual} />
+                <Input
+                  className="t-project-url"
+                  disabled={!manual}
+                  onChange={() => setNewRemoteProjectUrlError(null)}
+                />
               </Form.Item>
               <SyncFrequencySelect />
             </>

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSyncPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSyncPage.java
@@ -1,6 +1,7 @@
 package ca.corefacility.bioinformatics.irida.ria.integration.pages.projects;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -75,6 +76,39 @@ public class ProjectSyncPage extends AbstractPage {
 		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 		wait.until(ExpectedConditions.elementToBeClickable(submitBtn));
 		submitBtn.click();
+		waitForTime(500);
+	}
+
+	public boolean isResourceNotFoundErrorMessageDisplayed() {
+		List<WebElement> elements = driver.findElements(By.className("ant-form-item-explain-error"));
+
+		if(elements.size() == 1) {
+			return elements.get(0).getText().contains("Resource not found");
+		}
+		return false;
+	}
+
+	public boolean isAccessDeniedErrorMessageDisplayed() {
+		List<WebElement> elements = driver.findElements(By.className("ant-form-item-explain-error"));
+
+		if(elements.size() == 1) {
+			return elements.get(0).getText().contains("Access denied");
+		}
+		return false;
+	}
+
+	public void clickSetUrlManuallyCheckbox() {
+		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+		WebElement element = driver.findElement(By.className("t-remote-project-url-checkbox"));
+		wait.until(ExpectedConditions.elementToBeClickable(element));
+		element.click();
+		waitForTime(500);
+	}
+
+	public void setRemoteProjectUrl(String projectUrl) {
+		WebElement element = driver.findElement(By.className("t-project-url"));
+		element.sendKeys(Keys.CONTROL + "a", Keys.DELETE);
+		element.sendKeys(projectUrl);
 		waitForTime(500);
 	}
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/remoteapi/RemoteAPIsPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/remoteapi/RemoteAPIsPage.java
@@ -18,7 +18,7 @@ import ca.corefacility.bioinformatics.irida.ria.integration.pages.AbstractPage;
 public class RemoteAPIsPage extends AbstractPage {
 	private static final String RELATIVE_URL = "remote_api";
 
-	@FindBy(css = ".t-remoteapi-table table")
+	@FindBy(className = "t-remoteapi-table")
 	private WebElement table;
 
 	@FindBy(className = "t-add-remote-api-btn")
@@ -120,7 +120,10 @@ public class RemoteAPIsPage extends AbstractPage {
 		for (WebElement row : rows) {
 			WebElement nameCell = row.findElement(By.className("t-api-name"));
 			if (nameCell != null && nameCell.getText().equals(clientName)) {
-				row.findElement(By.className("t-remote-status-connect")).click();
+				WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(2));
+				WebElement connectBtn = row.findElement(By.className("t-remote-status-connect"));
+				wait.until(ExpectedConditions.elementToBeClickable(connectBtn));
+				connectBtn.click();
 				waitForTime(400);
 				clickAuthorize();
 			}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSyncPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSyncPageIT.java
@@ -7,12 +7,12 @@ import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.admin.AdminClientsPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectDetailsPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectSyncPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.remoteapi.RemoteAPIsPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.utilities.RemoteApiUtilities;
 
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 @DatabaseSetup("/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml")
 public class ProjectSyncPageIT extends AbstractIridaUIITChromeDriver {
@@ -47,5 +47,68 @@ public class ProjectSyncPageIT extends AbstractIridaUIITChromeDriver {
 		ProjectDetailsPage projectDetailsPage = ProjectDetailsPage.initElements(driver());
 		String dataProjectName = projectDetailsPage.getProjectName();
 		assertEquals(dataProjectName, name, "Should be on the remote project page");
+	}
+
+	@Test
+	public void testSyncProjectNotExist() {
+		LoginPage.loginAsAdmin(driver());
+
+		//create the oauth client
+		String redirectLocation = RemoteApiUtilities.getRedirectLocation();
+		clientsPage = AdminClientsPage.goTo(driver());
+		clientsPage.createClientWithDetails(clientId, "authorization_code", redirectLocation, AdminClientsPage.READ_YES,
+				AdminClientsPage.WRITE_NO);
+		clientSecret = clientsPage.getClientSecret(clientId);
+		RemoteApiUtilities.addRemoteApi(driver(), clientId, clientSecret);
+		LoginPage.logout(driver());
+
+		LoginPage.loginAsManager(driver());
+
+		RemoteAPIsPage remoteAPIsPage = RemoteAPIsPage.goToUserPage(driver());
+		remoteAPIsPage.connectToRemoteAPI("new name");
+
+		page = ProjectSyncPage.goTo(driver());
+		page.selectApi(0);
+		final String name = "project";
+		page.selectProjectInListing(name);
+
+		page.clickSetUrlManuallyCheckbox();
+		String url = page.getProjectUrl() + "11";
+		page.setRemoteProjectUrl(url);
+		page.submitProject();
+
+		// The project does not exist so a resource not found error should be displayed
+		assertTrue(page.isResourceNotFoundErrorMessageDisplayed());
+	}
+
+	@Test
+	public void testSyncProjectAccessDenied() {
+		LoginPage.loginAsAdmin(driver());
+
+		//create the oauth client
+		String redirectLocation = RemoteApiUtilities.getRedirectLocation();
+		clientsPage = AdminClientsPage.goTo(driver());
+		clientsPage.createClientWithDetails(clientId, "authorization_code", redirectLocation, AdminClientsPage.READ_YES,
+				AdminClientsPage.WRITE_NO);
+		clientSecret = clientsPage.getClientSecret(clientId);
+		RemoteApiUtilities.addRemoteApi(driver(), clientId, clientSecret);
+		LoginPage.logout(driver());
+
+		LoginPage.loginAsManager(driver());
+
+		RemoteAPIsPage remoteAPIsPage = RemoteAPIsPage.goToUserPage(driver());
+		remoteAPIsPage.connectToRemoteAPI("new name");
+		page = ProjectSyncPage.goTo(driver());
+		page.selectApi(0);
+		final String name = "project";
+		page.selectProjectInListing(name);
+
+		page.clickSetUrlManuallyCheckbox();
+		String url = page.getProjectUrl().replaceFirst("[^/]*$", "9");
+		page.setRemoteProjectUrl(url);
+		page.submitProject();
+
+		// The project exists but the currently logged in user is not on the project, so an access denied error should be displayed
+		assertTrue(page.isAccessDeniedErrorMessageDisplayed());
 	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectsPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectsPageIT.java
@@ -28,7 +28,7 @@ public class ProjectsPageIT extends AbstractIridaUIITChromeDriver {
 		ProjectsPage page = ProjectsPage.goToProjectsPage(driver(), true);
 		checkTranslations(page, ImmutableList.of("projects"), "Projects\nCreate New Project");
 
-		assertEquals(8, page.getNumberOfProjects(), "Should be 8 projects");
+		assertEquals(9, page.getNumberOfProjects(), "Should be 9 projects");
 		List<String> projectNames = page.getProjectsSortListByColumnName();
 		assertFalse(Ordering.natural().isOrdered(projectNames),
 				"Projects name should not be sorted originally");
@@ -56,7 +56,7 @@ public class ProjectsPageIT extends AbstractIridaUIITChromeDriver {
 
 		page = ProjectsPage.goToProjectsPage(driver(), false);
 		checkTranslations(page, ImmutableList.of("projects"), "Projects\nCreate New Project");
-		assertEquals(2, page.getNumberOfProjects(), "Should be 2 projects on the page");
+		assertEquals(3, page.getNumberOfProjects(), "Should be 3 projects on the page");
 
 		assertTrue(page.createNewButtonVisible(), "There should be a Create New Project button visible");
 	}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIRemoteAPIServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIRemoteAPIServiceTest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.commons.lang3.time.DateUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.MessageSource;
 
 import ca.corefacility.bioinformatics.irida.exceptions.IridaOAuthException;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
@@ -31,6 +32,8 @@ public class UIRemoteAPIServiceTest {
 	private ProjectService projectService;
 	private UIRemoteAPIService service;
 
+	private MessageSource messageSource;
+
 	private final long REMOTE_ID_WITH_TOKEN = 1L;
 	private final String REMOTE_CLIENT_ID_WITH_TOKEN = "with_token";
 	private final long REMOTE_ID_WITH_EXPIRED_TOKEN = 2L;
@@ -46,7 +49,8 @@ public class UIRemoteAPIServiceTest {
 		this.tokenService = mock(RemoteAPITokenService.class);
 		this.projectRemoteService = mock(ProjectRemoteService.class);
 		this.projectService = mock(ProjectService.class);
-		this.service = new UIRemoteAPIService(remoteAPIService, tokenService, projectRemoteService, projectService);
+		this.messageSource = mock(MessageSource.class);
+		this.service = new UIRemoteAPIService(remoteAPIService, tokenService, projectRemoteService, projectService, messageSource);
 
 		// Valid token
 		RemoteAPI validAPI = createFakeRemoteAPI(REMOTE_CLIENT_ID_WITH_TOKEN);

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml
@@ -16,6 +16,7 @@
       <project id="6" organism="E. coli" createdDate="2013-07-18 14:21:19.0" name="project ABCD" modifiedDate="2013-07-18 14:17:19.0" />
       <project id="7" organism="E. coli O157:H7" createdDate="2013-07-18 14:21:19.0" name="project EFGH" modifiedDate="2013-07-18 14:17:19.0" />
       <project id="8" organism="E. coli K-12" createdDate="2013-07-18 14:21:19.0" name="project IJKL" modifiedDate="2013-07-18 14:17:19.0" />
+      <project id="9" organism="E. coli NEW" createdDate="2013-07-18 14:21:19.0" name="project MNOP" modifiedDate="2013-07-18 14:17:19.0" />
 
       <project_user id="1" project_id="1" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="2" project_id="2" user_id="1" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />
@@ -26,6 +27,7 @@
       <project_user id="8" project_id="6" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="9" project_id="7" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="10" project_id="8" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="11" project_id="9" user_id="2" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
 
       <project_subscription id="1" project_id="1" user_id="1" created_date="2013-07-18 14:20:19.0" email_subscription="false" />
       <project_subscription id="2" project_id="2" user_id="1" created_date="2013-07-18 14:20:19.0" email_subscription="true" />


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Updated to display error message if setting url manually for sync new remote project and the server returns an error (such as unauthorized, forbidden, not found, etc)

**To test:**

1) Create a project as user A and note the project ID (will use this is step 6)
2) Login as user B
3) From the `Projects` dropdown select `Synchronize Remote Project`
4) Select a project from the drop down
5) Click the checkbox for `Set URL Manually`
6) Enter in the url `http://IP_ADDRESS:PORT/api/projects/PROJECT_ID`
7) Click the `Create Synchronized Project` button
8) The URL input box should have an error underneath (access is denied)

![accessdenied](https://user-images.githubusercontent.com/25466211/207448032-4e1993af-60de-4f9f-a523-0ea9cc70dced.png)

To test not found error repeat everything and for PROJECT_ID in step 6 set the id to a project id that doesn't exist in the database. Click the `Create Synchronized Project` button and you should see a `Resource Not Found` error

![resourcenotfound](https://user-images.githubusercontent.com/25466211/207448067-5c6e10d6-1f5a-420a-9ce6-c134a2b9d62b.png)

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
