### PR TITLE
Removed jsonignore annotation to send file size in bytes to response

### DIFF
--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/assembly/GenomeAssembly.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/assembly/GenomeAssembly.java
@@ -88,7 +88,6 @@ public abstract class GenomeAssembly extends IridaRepresentationModel
 	 * @return file size
 	 * @throws IOException if the file cannot be read
 	 */
-	@JsonIgnore
 	public Long getFileSizeBytes() throws IOException {
 		return IridaFiles.getFileSizeBytes(getFile());
 	}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/sequenceFile/SequenceFile.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/sequenceFile/SequenceFile.java
@@ -317,7 +317,6 @@ public class SequenceFile extends IridaRepresentationModel
 	 *
 	 * @return if file exists or not
 	 */
-	@JsonIgnore
 	public Long getFileSizeBytes() {
 		return IridaFiles.getFileSizeBytes(getFile());
 	}


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Removed JsonIgnore annotations to add the file size in bytes to a response which includes sequence files and/or genome assemblies.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
