### PR TITLE
Fixed sample details viewer files display

### DIFF
--- a/src/main/webapp/resources/js/components/samples/components/SampleFiles.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/SampleFiles.tsx
@@ -130,7 +130,7 @@ export default function SampleFiles() {
           formData,
           config: seqFileUploadConfig,
         })
-          .then((response) => {
+          .then(() => {
             notification.success({
               message: i18n("SampleFiles.successfullyUploaded", "sequence"),
             });
@@ -187,7 +187,7 @@ export default function SampleFiles() {
           formData,
           config: assemblyUploadConfig,
         })
-          .then((response) => {
+          .then(() => {
             notification.success({
               message: i18n("SampleFiles.successfullyUploaded", "assembly"),
             });
@@ -244,7 +244,7 @@ export default function SampleFiles() {
           formData,
           config: fast5UploadConfig,
         })
-          .then((response) => {
+          .then(() => {
             notification.success({
               message: i18n("SampleFiles.successfullyUploaded", "fast5"),
             });

--- a/src/main/webapp/resources/js/components/samples/components/SampleFiles.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/SampleFiles.tsx
@@ -148,7 +148,7 @@ export default function SampleFiles() {
           });
       }
     },
-    [dispatch, sample.identifier, sequenceFiles]
+    [sequenceFiles, sample.identifier, refetchSampleFiles]
   );
 
   /*
@@ -205,7 +205,7 @@ export default function SampleFiles() {
           });
       }
     },
-    [dispatch, assemblyFiles, sample.identifier]
+    [assemblyFiles, sample.identifier, refetchSampleFiles]
   );
 
   /*
@@ -262,7 +262,7 @@ export default function SampleFiles() {
           });
       }
     },
-    [dispatch, fast5Files, sample.identifier]
+    [fast5Files, sample.identifier, refetchSampleFiles]
   );
 
   React.useEffect(() => {

--- a/src/main/webapp/resources/js/components/samples/components/SampleFiles.tsx
+++ b/src/main/webapp/resources/js/components/samples/components/SampleFiles.tsx
@@ -7,12 +7,7 @@ import { DragUpload } from "../../files/DragUpload";
 import { FileUploadProgress } from "./upload-progress/FileUploadProgress";
 import { SampleFileList } from "./SampleFileList";
 import { useAppDispatch, useAppSelector } from "../../../hooks/useState";
-import {
-  addToSequenceFiles,
-  addToAssemblyFiles,
-  addToFast5Files,
-  fetchFilesForSample,
-} from "../sampleFilesSlice";
+import { fetchFilesForSample } from "../sampleFilesSlice";
 
 import {
   FileUpload,
@@ -35,7 +30,11 @@ export default function SampleFiles() {
     (state) => state.sampleReducer
   );
 
-  const { data: files = {}, isLoading: loading } = useGetSampleFilesQryQuery({
+  const {
+    data: files = {},
+    isLoading: loading,
+    refetch: refetchSampleFiles,
+  } = useGetSampleFilesQryQuery({
     sampleId: sample.identifier,
     projectId,
   });
@@ -135,7 +134,7 @@ export default function SampleFiles() {
             notification.success({
               message: i18n("SampleFiles.successfullyUploaded", "sequence"),
             });
-            dispatch(addToSequenceFiles({ sequenceFiles: response }));
+            refetchSampleFiles();
             setSequenceFiles([]);
           })
           .catch((error) => {
@@ -192,7 +191,7 @@ export default function SampleFiles() {
             notification.success({
               message: i18n("SampleFiles.successfullyUploaded", "assembly"),
             });
-            dispatch(addToAssemblyFiles({ assemblies: response }));
+            refetchSampleFiles();
             setAssemblyFiles([]);
           })
           .catch((error) => {
@@ -249,7 +248,7 @@ export default function SampleFiles() {
             notification.success({
               message: i18n("SampleFiles.successfullyUploaded", "fast5"),
             });
-            dispatch(addToFast5Files({ fast5: response }));
+            refetchSampleFiles();
             setFast5Files([]);
           })
           .catch((error) => {

--- a/src/main/webapp/resources/js/components/samples/sampleFilesSlice.ts
+++ b/src/main/webapp/resources/js/components/samples/sampleFilesSlice.ts
@@ -19,36 +19,6 @@ export const updatedSequencingObjects = createAction(
 );
 
 /**
- * Action to add sequence files to sample
- */
-export const addToSequenceFiles = createAction(
-  `sampleFiles/addToSequenceFiles`,
-  ({ sequenceFiles }) => ({
-    payload: { sequenceFiles },
-  })
-);
-
-/**
- * Action to add assembly files to sample
- */
-export const addToAssemblyFiles = createAction(
-  `sampleFiles/addToAssemblyFiles`,
-  ({ assemblies }) => ({
-    payload: { assemblies },
-  })
-);
-
-/**
- * Action to add fast5 files to sample
- */
-export const addToFast5Files = createAction(
-  `sampleFiles/addToFast5Files`,
-  ({ fast5 }) => ({
-    payload: { fast5 },
-  })
-);
-
-/**
  * Action to add sequencingobject to concatenation selected list
  */
 export const addToConcatenateSelected = createAction(
@@ -122,47 +92,6 @@ const sampleFilesSlice = createSlice({
         state.files = fileTypesWithLength;
       }
       state.loading = false;
-    });
-
-    builder.addCase(addToSequenceFiles, (state, action) => {
-      const seqFiles = action.payload.sequenceFiles;
-
-      seqFiles.map((seqFile: SampleSequencingObject) => {
-        if (seqFile.secondFileSize !== null) {
-          if (!state.files["paired"]) {
-            state.files.paired = [];
-          }
-          state.files.paired = [...state.files.paired, seqFile];
-        } else {
-          if (!state.files["singles"]) {
-            state.files.singles = [];
-          }
-
-          state.files.singles = [...state.files.singles, seqFile];
-        }
-      });
-    });
-
-    builder.addCase(addToAssemblyFiles, (state, action) => {
-      const newAssemblies = action.payload.assemblies;
-
-      newAssemblies.map((newAssembly: SampleGenomeAssembly) => {
-        if (!state.files["assemblies"]) {
-          state.files.assemblies = [];
-        }
-        state.files.assemblies = [...state.files.assemblies, newAssembly];
-      });
-    });
-
-    builder.addCase(addToFast5Files, (state, action) => {
-      const newFast5s = action.payload.fast5;
-
-      newFast5s.map((newFast5: SampleSequencingObject) => {
-        if (!state.files["fast5"]) {
-          state.files.fast5 = [];
-        }
-        state.files.fast5 = [...state.files.fast5, newFast5];
-      });
     });
 
     builder.addCase(updatedSequencingObjects, (state, action) => {


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

Fixed sample details viewer files not displaying after uploading and closing/reopening the modal. Cleaned it up to refetch the sample files after uploading rather than storing the files in the state (can't use invalidatetags since the upload functions aren't a part of the createapi).

**To test broken functionality**
1) Checkout the `development` branch
2) Create a project and add a sample
3) Launch the sample details viewer by clicking on the sample name and then click the files tab
4) Upload some files to the sample
5) Close the sample details viewer and then relaunch and click the files tab
6) The files list should be empty even though we just uploaded files. Refresh the page and relaunch the sample details viewer. Now the files should display

**To test the fix**
1) Be on this branch  `fix-sample-details-files`
2) Create a project and add a sample
3) Launch the sample details viewer by clicking on the sample name and then click the files tab
4) Upload some files to the sample
5) Close the sample details viewer and then relaunch and click the files tab
6) The files should be displayed

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
* [x] Tests added (or description of how to test) for any new features.
~* [ ] User documentation updated for UI or technical changes.~
