### PR TITLE
deprecated getSampleBySequencerId, added getSampleBySampleName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [Developer/UI]: Performance enhancements to the metadata uploader. See [PR 1445](https://github.com/phac-nml/irida/pull/1445).
 * [Developer/UI]: Fix for updating sample modified date when metadata is deleted. See [PR 1457](https://github.com/phac-nml/irida/pull/1457).
 * [Developer]: Added support for cloud based storage. Currently, Microsoft Azure Blob and Amazon AWS S3 are supported. [See PR 1194](https://github.com/phac-nml/irida/pull/1194)
+* [Developer]: Deprecated "/api/projects/{projectId}/samples/bySequencerId/{seqeuncerId}" in favour of "/api/projects/{projectId}/samples/bySampleName", which accepts a json property "sampleName"
 
 ## [22.09.7] - 2022/01/24
 * [UI]: Fixed bugs on NCBI Export page preventing the NCBI `submission.xml` file from being properly written. See [PR 1451](https://github.com/phac-nml/irida/pull/1451)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -263,7 +263,7 @@ public class RESTProjectSamplesController {
 	 * Get samples by a given string name
 	 *
 	 * @param projectId   the Project to get samples from
-	 * @param sampleNameMap consumes 'sampleName' property
+	 * @param sampleName  String containing sample name
 	 * @return The found sample
 	 */
 	@RequestMapping(

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -281,10 +281,10 @@ public class RESTProjectSamplesController {
 		String sampleName = sampleNameMap.get(sampleNameProperty);
 		Project p = projectService.read(projectId);
 
-		Sample sampleBySampleId = sampleService.getSampleBySampleName(p, sampleName);
+		Sample sampleBySampleName = sampleService.getSampleBySampleName(p, sampleName);
 
 		Link withSelfRel = linkTo(
-				methodOn(RESTProjectSamplesController.class).getSample(sampleBySampleId.getId())).withSelfRel();
+				methodOn(RESTProjectSamplesController.class).getSample(sampleBySampleName.getId())).withSelfRel();
 		String href = withSelfRel.getHref();
 
 		RedirectView redirectView = new RedirectView(href);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -266,9 +266,7 @@ public class RESTProjectSamplesController {
 	 * @param sampleName  String containing sample name
 	 * @return The found sample
 	 */
-	@RequestMapping(
-			value = "/api/projects/{projectId}/samples/bySampleName",
-			method = RequestMethod.GET)
+	@RequestMapping(value = "/api/projects/{projectId}/samples/bySampleName", method = RequestMethod.GET)
 	public ModelAndView getProjectSampleBySampleName(@PathVariable Long projectId, @RequestParam String sampleName) {
 		Project p = projectService.read(projectId);
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -268,18 +268,8 @@ public class RESTProjectSamplesController {
 	 */
 	@RequestMapping(
 			value = "/api/projects/{projectId}/samples/bySampleName",
-			method = RequestMethod.GET,
-			consumes = { MediaType.APPLICATION_JSON_VALUE })
-	public ModelAndView getProjectSampleBySampleName(
-			@PathVariable Long projectId,
-			@RequestBody Map<String, String> sampleNameMap) {
-		String sampleNameProperty = "sampleName";
-
-		if (!sampleNameMap.containsKey(sampleNameProperty)) {
-			throw new IllegalArgumentException("'sampleName' must be provided.");
-		}
-
-		String sampleName = sampleNameMap.get(sampleNameProperty);
+			method = RequestMethod.GET)
+	public ModelAndView getProjectSampleBySampleName(@PathVariable Long projectId, @RequestParam String sampleName) {
 		Project p = projectService.read(projectId);
 
 		Sample sampleBySampleName = sampleService.getSampleBySampleName(p, sampleName);

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -243,11 +243,45 @@ public class RESTProjectSamplesController {
 	 * @param seqeuncerId the string id of the sample
 	 * @return The found sample
 	 */
+	@Deprecated()
 	@RequestMapping(value = "/api/projects/{projectId}/samples/bySequencerId/{seqeuncerId}", method = RequestMethod.GET)
 	public ModelAndView getProjectSampleBySequencerId(@PathVariable Long projectId, @PathVariable String seqeuncerId) {
 		Project p = projectService.read(projectId);
 
 		Sample sampleBySampleId = sampleService.getSampleBySampleName(p, seqeuncerId);
+
+		Link withSelfRel = linkTo(
+				methodOn(RESTProjectSamplesController.class).getSample(sampleBySampleId.getId())).withSelfRel();
+		String href = withSelfRel.getHref();
+
+		RedirectView redirectView = new RedirectView(href);
+
+		return new ModelAndView(redirectView);
+	}
+
+	/**
+	 * Get samples by a given string name
+	 *
+	 * @param projectId   the Project to get samples from
+	 * @param sampleNameMap consumes 'sampleName' property
+	 * @return The found sample
+	 */
+	@RequestMapping(
+			value = "/api/projects/{projectId}/samples/bySampleName",
+			method = RequestMethod.GET,
+			consumes = { MediaType.APPLICATION_JSON_VALUE })
+	public ModelAndView getProjectSampleBySampleName(@PathVariable Long projectId,
+													 @RequestBody Map<String, String> sampleNameMap) {
+		String sampleNameProperty = "sampleName";
+
+		if (!sampleNameMap.containsKey(sampleNameProperty)) {
+			throw new IllegalArgumentException("'sampleName' must be provided.");
+		}
+
+		String sampleName = sampleNameMap.get(sampleNameProperty);
+		Project p = projectService.read(projectId);
+
+		Sample sampleBySampleId = sampleService.getSampleBySampleName(p, sampleName);
 
 		Link withSelfRel = linkTo(
 				methodOn(RESTProjectSamplesController.class).getSample(sampleBySampleId.getId())).withSelfRel();

--- a/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/web/controller/api/projects/RESTProjectSamplesController.java
@@ -270,8 +270,9 @@ public class RESTProjectSamplesController {
 			value = "/api/projects/{projectId}/samples/bySampleName",
 			method = RequestMethod.GET,
 			consumes = { MediaType.APPLICATION_JSON_VALUE })
-	public ModelAndView getProjectSampleBySampleName(@PathVariable Long projectId,
-													 @RequestBody Map<String, String> sampleNameMap) {
+	public ModelAndView getProjectSampleBySampleName(
+			@PathVariable Long projectId,
+			@RequestBody Map<String, String> sampleNameMap) {
 		String sampleNameProperty = "sampleName";
 
 		if (!sampleNameMap.containsKey(sampleNameProperty)) {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
@@ -1,11 +1,9 @@
 package ca.corefacility.bioinformatics.irida.web.controller.test.integration.project;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.*;
 
+import org.apache.commons.collections.map.SingletonMap;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -387,5 +385,32 @@ public class ProjectSamplesIT {
 				.body("resource.resources.sampleName", hasItems("sample1", "sample2"))
 				.when()
 				.get(projectSamplesUri);
+	}
+
+	@Test
+	public void testReadSampleByName() {
+		String rootUri = uriTemplateHandler.getRootUri() + "/api";
+		String projectUri = rootUri + "/projects/5";
+		String sampleByNameUri = projectUri + "/samples/bySampleName?sampleName=sample1";
+		String expectedSampleUri = rootUri + "/samples/1";
+
+		final Response r = asAdmin().expect()
+				.body("resource.links.rel", hasItems("self", "sample/sequenceFiles"))
+				.when()
+				.get(sampleByNameUri);
+		final String responseBody = r.getBody().asString();
+		final String selfUri = from(responseBody).get("resource.links.find{it.rel == 'self'}.href");
+		assertEquals(expectedSampleUri, selfUri);
+	}
+
+	@Test
+	public void testReadSampleByNameError() {
+		String projectUri = uriTemplateHandler.getRootUri() + "/api/projects/5";
+		String sampleByNameUri = projectUri + "/samples/bySampleName?sampleName=not_a_sample";
+
+		asAdmin().expect()
+				.statusCode(equalTo(404))
+				.when()
+				.get(sampleByNameUri);
 	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/integration/project/ProjectSamplesIT.java
@@ -3,7 +3,6 @@ package ca.corefacility.bioinformatics.irida.web.controller.test.integration.pro
 import java.util.*;
 import java.util.concurrent.*;
 
-import org.apache.commons.collections.map.SingletonMap;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/projects/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/projects/RESTProjectSamplesControllerTest.java
@@ -202,10 +202,8 @@ public class RESTProjectSamplesControllerTest {
 		when(sampleService.getSampleBySampleName(p, s.getSampleName())).thenReturn(s);
 
 		String sampleLocation = "http://localhost/api/samples/" + s.getId();
-		Map<String, String> sampleMap = new HashMap<String, String>() {};
-		sampleMap.put("sampleName", s.getSampleName());
 
-		ModelAndView responseObject = controller.getProjectSampleBySampleName(p.getId(), sampleMap);
+		ModelAndView responseObject = controller.getProjectSampleBySampleName(p.getId(), s.getSampleName());
 
 		verify(sampleService).getSampleBySampleName(p, s.getSampleName());
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/projects/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/projects/RESTProjectSamplesControllerTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.net.HttpHeaders;
-import org.springframework.ui.ModelMap;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 

--- a/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/projects/RESTProjectSamplesControllerTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/web/controller/test/unit/projects/RESTProjectSamplesControllerTest.java
@@ -34,6 +34,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.net.HttpHeaders;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.RedirectView;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -188,6 +191,27 @@ public class RESTProjectSamplesControllerTest {
 		assertNotNull(projectLink);
 		assertEquals(projectLocation, projectLink.getHref());
 
+	}
+
+	@Test
+	public void testGetProjectSampleByName() throws IOException {
+		Project p = TestDataFactory.constructProject();
+		Sample s = TestDataFactory.constructSample();
+
+		// mock out the service calls
+		when(projectService.read(p.getId())).thenReturn(p);
+		when(sampleService.getSampleBySampleName(p, s.getSampleName())).thenReturn(s);
+
+		String sampleLocation = "http://localhost/api/samples/" + s.getId();
+		Map<String, String> sampleMap = new HashMap<String, String>() {};
+		sampleMap.put("sampleName", s.getSampleName());
+
+		ModelAndView responseObject = controller.getProjectSampleBySampleName(p.getId(), sampleMap);
+
+		verify(sampleService).getSampleBySampleName(p, s.getSampleName());
+
+		RedirectView rv = (RedirectView) responseObject.getView();
+		assertEquals(sampleLocation, rv.getUrl());
 	}
 
 	@Test


### PR DESCRIPTION
## Description of changes
Added deprecated tag to getSampleBySequencerId
Added new api route getSampleBySampleName, which accepts a json dictionary with the property "sampleName"

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
