### PR TITLE
Fix remove sample error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [Developer]: Updated metadata uploader to use react-router-dom Outlet. [See PR 1464](https://github.com/phac-nml/irida/pull/1464)
 * [Developer]: Deprecated "/api/projects/{projectId}/samples/bySequencerId/{seqeuncerId}" in favour of "/api/projects/{projectId}/samples/bySampleName", which accepts a json property "sampleName"
 * [Developer]: Fixed bug in setting a `default_sequencing_object and default_genome_assembly to `NULL` for a sample when the default sequencing object or genome assembly were removed. [See PR 1466](https://github.com/phac-nml/irida/pull/1466)
-* [Developer]: Fixed bug preventing a `sample` with and analysis submission from being deleted. [See PR 1467](https://github.com/phac-nml/irida/pull/1467)
+* [Developer]: Fixed bug preventing a `sample` with an analysis submission from being deleted. [See PR 1467](https://github.com/phac-nml/irida/pull/1467)
 
 ## [22.09.7] - 2022/01/24
 * [UI]: Fixed bugs on NCBI Export page preventing the NCBI `submission.xml` file from being properly written. See [PR 1451](https://github.com/phac-nml/irida/pull/1451)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [Developer]: Updated metadata uploader to use react-router-dom Outlet. [See PR 1464](https://github.com/phac-nml/irida/pull/1464)
 * [Developer]: Deprecated "/api/projects/{projectId}/samples/bySequencerId/{seqeuncerId}" in favour of "/api/projects/{projectId}/samples/bySampleName", which accepts a json property "sampleName"
 * [Developer]: Fixed bug in setting a `default_sequencing_object and default_genome_assembly to `NULL` for a sample when the default sequencing object or genome assembly were removed. [See PR 1466](https://github.com/phac-nml/irida/pull/1466)
+* [Developer]: Fixed bug preventing a `sample` with and analysis submission from being deleted. [See PR 1467](https://github.com/phac-nml/irida/pull/1467)
 
 ## [22.09.7] - 2022/01/24
 * [UI]: Fixed bugs on NCBI Export page preventing the NCBI `submission.xml` file from being properly written. See [PR 1451](https://github.com/phac-nml/irida/pull/1451)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/model/sample/Sample.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/model/sample/Sample.java
@@ -142,11 +142,11 @@ public class Sample extends IridaRepresentationModel
 	@Longitude
 	private String longitude;
 
-	@OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@OneToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "default_sequencing_object")
 	private SequencingObject defaultSequencingObject;
 
-	@OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+	@OneToOne(fetch = FetchType.EAGER)
 	@JoinColumn(name = "default_genome_assembly")
 	private GenomeAssembly defaultGenomeAssembly;
 

--- a/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
@@ -86,7 +86,12 @@ export default function RemoveModal({
         )}
         {error && (
           <Col span={24}>
-            <Alert type="error" showIcon message={i18n("RemoveModal.error")} />
+            <Alert
+              type="error"
+              className="t-remove-error"
+              showIcon
+              message={i18n("RemoveModal.error")}
+            />
           </Col>
         )}
       </Row>

--- a/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
@@ -1,5 +1,14 @@
-import React from "react";
-import { Alert, Col, Divider, List, Modal, Row, Typography } from "antd";
+import React, { useEffect } from "react";
+import {
+  Alert,
+  Col,
+  Divider,
+  List,
+  Modal,
+  notification,
+  Row,
+  Typography,
+} from "antd";
 import { useRemoveMutation } from "../../../../apis/projects/samples";
 import LockedSamplesList from "./LockedSamplesList";
 import AssociatedSamplesList from "./AssociatedSamplesList";
@@ -22,16 +31,17 @@ export default function RemoveModal({
   onComplete,
   onCancel,
 }) {
-  const [removeSamples, { isLoading, error }] = useRemoveMutation();
+  const [removeSamples, { isLoading, error, isSuccess }] = useRemoveMutation();
 
   const onOk = async () => {
-    try {
-      await removeSamples(samples.valid.map((sample) => sample.id));
-      onComplete();
-    } catch (e) {
-      // Do nothing, handled by mutation
-    }
+    await removeSamples(samples.valid.map((sample) => sample.id));
   };
+
+  useEffect(() => {
+    if (isSuccess) {
+      onComplete();
+    }
+  }, [onComplete, isSuccess]);
 
   return (
     <Modal
@@ -75,7 +85,9 @@ export default function RemoveModal({
           </Col>
         )}
         {error && (
-          <Alert type="error" showIcon message={i18n("RemoveModal.error")} />
+          <Col span={24}>
+            <Alert type="error" showIcon message={i18n("RemoveModal.error")} />
+          </Col>
         )}
       </Row>
     </Modal>

--- a/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { Alert, Col, Divider, List, Modal, Typography } from "antd";
+import { Alert, Col, Divider, List, Modal, Row, Typography } from "antd";
 import { useRemoveMutation } from "../../../../apis/projects/samples";
 import AssociatedSamplesList from "./AssociatedSamplesList";
 

--- a/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/RemoveModal.jsx
@@ -1,16 +1,6 @@
 import React, { useEffect } from "react";
-import {
-  Alert,
-  Col,
-  Divider,
-  List,
-  Modal,
-  notification,
-  Row,
-  Typography,
-} from "antd";
+import { Alert, Col, Divider, List, Modal, Typography } from "antd";
 import { useRemoveMutation } from "../../../../apis/projects/samples";
-import LockedSamplesList from "./LockedSamplesList";
 import AssociatedSamplesList from "./AssociatedSamplesList";
 
 /**

--- a/src/main/webapp/resources/js/pages/projects/samples/components/SamplesMenu.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/SamplesMenu.jsx
@@ -292,13 +292,14 @@ export default function SamplesMenu() {
     <>
       <Row justify="space-between">
         <Space>
-          {details.canManage && (
-            <Dropdown overlay={toolsMenu}>
-              <Button className="t-sample-tools">
-                {i18n("SamplesMenu.label")} <IconDropDown />
-              </Button>
-            </Dropdown>
-          )}
+          {details.canManage ||
+            (details.canManageRemote && (
+              <Dropdown overlay={toolsMenu}>
+                <Button className="t-sample-tools">
+                  {i18n("SamplesMenu.label")} <IconDropDown />
+                </Button>
+              </Dropdown>
+            ))}
           <Dropdown overlay={exportMenu}>
             <Button className="t-export">
               {i18n("SampleMenu.export")} <IconDropDown />

--- a/src/main/webapp/resources/js/pages/projects/samples/components/SamplesMenu.jsx
+++ b/src/main/webapp/resources/js/pages/projects/samples/components/SamplesMenu.jsx
@@ -292,14 +292,13 @@ export default function SamplesMenu() {
     <>
       <Row justify="space-between">
         <Space>
-          {details.canManage ||
-            (details.canManageRemote && (
-              <Dropdown overlay={toolsMenu}>
-                <Button className="t-sample-tools">
-                  {i18n("SamplesMenu.label")} <IconDropDown />
-                </Button>
-              </Dropdown>
-            ))}
+          {details.canManage && (
+            <Dropdown overlay={toolsMenu}>
+              <Button className="t-sample-tools">
+                {i18n("SamplesMenu.label")} <IconDropDown />
+              </Button>
+            </Dropdown>
+          )}
           <Dropdown overlay={exportMenu}>
             <Button className="t-export">
               {i18n("SampleMenu.export")} <IconDropDown />

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectMembersPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectMembersPage.java
@@ -96,6 +96,17 @@ public class ProjectMembersPage extends AbstractPage {
 		wait.until(ExpectedConditions.visibilityOf(antNotification));
 	}
 
+	public void removeManagerByName(String name) {
+		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(4));
+		WebElement button = wait.until(ExpectedConditions.visibilityOfElementLocated(
+				By.xpath("//table/tbody/tr/td/a[contains(text(), '" + name + "')]/../../td/button")));
+		button.click();
+		wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("t-remove-popover")));
+		wait.until(ExpectedConditions.elementToBeClickable(By.className("t-remove-confirm")));
+		driver.findElement(By.className("t-remove-confirm")).click();
+		wait.until(ExpectedConditions.visibilityOf(antNotification));
+	}
+
 	public boolean isNotificationDisplayed() {
 		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 		wait.until(ExpectedConditions.visibilityOf(antNotification));

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
@@ -550,7 +550,10 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		removeBtn.click();
 		wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.className("t-remove-modal")));
 		removeModal.findElement(By.xpath("//button[@type='button' and span='Remove Samples']")).click();
-		wait.until(ExpectedConditions.textMatches(By.className("t-summary"), Pattern.compile("^Selected: 0")));
+	}
+
+	public boolean isRemoveErrorDisplayed() {
+		return driver.findElements(By.className("t-remove-error")).size() > 0;
 	}
 
 	public void shareSamples() {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/projects/ProjectSamplesPage.java
@@ -550,6 +550,9 @@ public class ProjectSamplesPage extends ProjectPageBase {
 		removeBtn.click();
 		wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.className("t-remove-modal")));
 		removeModal.findElement(By.xpath("//button[@type='button' and span='Remove Samples']")).click();
+		// Modal might or might not close depending the outcome of the remove, so we need to wait a moment to
+		// see what happens.
+		waitForTime(400);
 	}
 
 	public boolean isRemoveErrorDisplayed() {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -447,16 +447,6 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 	}
 
 	@Test
-	void testSharingWithLockedSamplesAsManager() {
-		LoginPage.loginAsManager(driver());
-		ProjectSamplesPage page = ProjectSamplesPage.goToPage(driver(), 1L);
-		page.selectSampleByName(LOCKED_SAMPLE_NAME);
-		page.openToolsDropDown();
-		page.shareSamples();
-		assertTrue(page.isMessageDisplayed("All samples are locked and cannot be shared."));
-	}
-
-	@Test
 	void testFailedRemoveRemovingPrivileges() {
 		LoginPage.loginAsManager(driver());
 		LoginPage.loginAsAdmin(driver2());

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -154,19 +154,6 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 	}
 
 	@Test
-	public void testRemoteProjectSamplesManagerSetup() {
-		LoginPage.loginAsManager(driver());
-
-		ProjectSamplesPage page = ProjectSamplesPage.goToPage(driver(), 7L);
-
-		page.selectSampleByName("sample23p7");
-		page.selectSampleByName("sample24p7");
-
-		page.openToolsDropDown();
-		assertFalse(page.isMergeBtnVisible(), "Merge button should not be displayed");
-	}
-
-	@Test
 	public void testRemoveSamplesFromProject() {
 		LoginPage.loginAsManager(driver());
 		ProjectSamplesPage page = ProjectSamplesPage.goToPage(driver(), 1L);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -154,6 +154,19 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 	}
 
 	@Test
+	public void testRemoteProjectSamplesManagerSetup() {
+		LoginPage.loginAsManager(driver());
+
+		ProjectSamplesPage page = ProjectSamplesPage.goToPage(driver(), 7L);
+
+		page.selectSampleByName("sample23p7");
+		page.selectSampleByName("sample24p7");
+
+		page.openToolsDropDown();
+		assertFalse(page.isMergeBtnVisible(), "Merge button should not be displayed");
+	}
+
+	@Test
 	public void testRemoveSamplesFromProject() {
 		LoginPage.loginAsManager(driver());
 		ProjectSamplesPage page = ProjectSamplesPage.goToPage(driver(), 1L);

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectSamplesPageIT.java
@@ -9,6 +9,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 
 import ca.corefacility.bioinformatics.irida.ria.integration.AbstractIridaUIITChromeDriver;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.LoginPage;
+import ca.corefacility.bioinformatics.irida.ria.integration.pages.ProjectMembersPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ProjectSamplesPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.ShareSamplesPage;
 import ca.corefacility.bioinformatics.irida.ria.integration.pages.projects.TableSummary;
@@ -176,6 +177,7 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 
 		// Remove process
 		page.removeSamples();
+		assertFalse(page.isRemoveErrorDisplayed(), "Should not be an error message");
 		TableSummary updatedSummary = page.getTableSummary();
 		assertEquals(summary.getTotal() - 2, updatedSummary.getTotal(), "Should be 2 less samples after removal");
 	}
@@ -452,6 +454,25 @@ public class ProjectSamplesPageIT extends AbstractIridaUIITChromeDriver {
 		page.openToolsDropDown();
 		page.shareSamples();
 		assertTrue(page.isMessageDisplayed("All samples are locked and cannot be shared."));
+	}
+
+	@Test
+	void testFailedRemoveRemovingPrivileges() {
+		LoginPage.loginAsManager(driver());
+		LoginPage.loginAsAdmin(driver2());
+
+		ProjectSamplesPage page = ProjectSamplesPage.goToPage(driver(), 1L);
+
+		page.selectSampleByName(FIRST_SAMPLE_NAME);
+		page.selectSampleByName(SECOND_SAMPLE_NAME);
+
+		//admin removes manager from project
+		ProjectMembersPage projectMembersPage = ProjectMembersPage.goTo(driver2());
+		projectMembersPage.removeManagerByName("Mr. Manager");
+
+		// Remove process
+		page.removeSamples();
+		assertTrue(page.isRemoveErrorDisplayed(), "There should be an error message");
 	}
 }
 

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesPage.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesPage.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dataset>
-    <user id="1" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="manager@nowhere.com" firstName="Mr." lastName="Manager" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="mrtest" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" />
+    <user id="1" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="manager@nowhere.com" firstName="Mr." lastName="Manager" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="mrtest" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" />
     <user id="2" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="test@me.com" firstName="test" lastName="User" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="testUser" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" />
     <user id="3" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="project1Manager@test.com" firstName="project1Manager" lastName="Manager" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="project1Manager" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" />
-    <user id="4" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="admin@nowhere.com" firstName="Mr." lastName="Manager" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="admin" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" />
+    <user id="4" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="admin@nowhere.com" firstName="Admin" lastName="Admin" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="admin" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" />
 
     <client_details id="1" clientId="testClient" clientSecret="testClientSecret" token_validity="100000" createdDate="2013-07-18 14:20:19.0" />
     <client_details_grant_types client_details_id="1" grant_value="authorization_code" />

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesPage.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/projects/ProjectSamplesPage.xml
@@ -26,7 +26,7 @@
     <related_project id="1" subject_id="1" relatedProject_id="6" createdDate="2013-07-18 14:20:19.0" />
 
     <project_user id="1" project_id="1" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
-    <project_user id="2" project_id="2" user_id="1" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />
+    <project_user id="2" project_id="2" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />
     <project_user id="3" project_id="3" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
     <project_user id="4" project_id="4" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
     <project_user id="6" project_id="1" user_id="2" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />


### PR DESCRIPTION
## Description of changes

Fixed bug with cascading deletes failing when attempting to remove a sample that had an analysis run on it.  Removing `cascade = CascadeType.ALL` allowed the cascade to work properly.  Also needed to update how the UI handled and error if a sample could not be removed.

**To Test:**

1.  Login as a user (fbristow works)
2.  Create a new project
3.  Create a sample in that project
4.  Add multiple files to the new sample
5.  Run the assembly and annotation pipeline (just needs to start not actually run)
6.  Go back to the project and remove the sample you created.

**To Test Error Notification:**

1.  Login as a user (fbristow works)
2.  Create a new project
3.  Create a sample in that project
4.  Add multiple files to the new sample
5.  Run the assembly and annotation pipeline (just needs to start not actually run)
6.  Go back to the project created.
7.  _**In a different bowser (or incognito mode), log in as admin and revoke the user (fbristow if that is the one you used) from the project.**_
8.  Try removing the sample in the original browser, since the user no longer has permissions on the project they will not be allowed to remove the sample.

## Related issue

Link to the GitHub issue this pull request addresses using the `#issuenum` format. If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist

Things for the developer to confirm they've done before the PR should be accepted:

*   [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
*   [x] Tests added (or description of how to test) for any new features.
*   [ ] ~User documentation updated for UI or technical changes.~