### PR TITLE
fix unreachable chromedriver connections for tests

### DIFF
--- a/src/test/java/ca/corefacility/bioinformatics/irida/junit5/listeners/IntegrationUITestListener.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/junit5/listeners/IntegrationUITestListener.java
@@ -94,6 +94,7 @@ public class IntegrationUITestListener implements TestExecutionListener {
 		}
 
 		options.addArguments("--window-size=1920,1080");
+		options.addArguments("--remote-allow-origins=*");
 
 		// Set up default download directory
 		if (!DOWNLOAD_DIRECTORY.exists()) {


### PR DESCRIPTION
## Description of changes
Fixes a issue where running integration tests are unable to connect to generated websockets.
https://stackoverflow.com/questions/75680149/unable-to-establish-websocket-connection

Add the `--remote-allow-origins=*` arg to integration test chrome driver instances

This affects both local tests and tests run on github actions

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [ ] Tests added (or description of how to test) for any new features.
* [ ] User documentation updated for UI or technical changes.
