### PR TITLE
hotfix/sync old irida

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [UI]: Fixed bug that caused all metadata fields to be removed when single field was removed from a template. See [PR 1482](https://github.com/phac-nml/irida/pull/1482)
 * [Developer]: Fixed bug which allowed duplicated entries in the user_group_project table which prevented the user group from being removed. Fixed bug which was preventing analyses with `html` file outputs from completing. See [PR 1483](https://github.com/phac-nml/irida/pull/1483)
 * [Developer]: Fixed flaky PipelinesPhylogenomicsPageIT test. See [PR 1482](https://github.com/phac-nml/irida/pull/1482)
-* [REST]: Fixed issues with syncing between newer IRIDA (>=20.09) and older IRIDA (<20.09) by disabling requests for `application/xml` for some of the REST requests and only requesting data as `application/json`.
+* [REST]: Fixed issues with syncing between newer IRIDA (>22.09) and older IRIDA (<=20.09) by disabling requests for `application/xml` for some of the REST requests and only requesting data as `application/json`.
 
 
 ## [23.01.1] - 2023/03/21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [UI]: Fixed bug that caused all metadata fields to be removed when single field was removed from a template. See [PR 1482](https://github.com/phac-nml/irida/pull/1482)
 * [Developer]: Fixed bug which allowed duplicated entries in the user_group_project table which prevented the user group from being removed. Fixed bug which was preventing analyses with `html` file outputs from completing. See [PR 1483](https://github.com/phac-nml/irida/pull/1483)
 * [Developer]: Fixed flaky PipelinesPhylogenomicsPageIT test. See [PR 1482](https://github.com/phac-nml/irida/pull/1482)
+* [REST]: Fixed issues with syncing between newer IRIDA (>=20.09) and older IRIDA (<20.09) by disabling requests for `application/xml` for some of the REST requests and only requesting data as `application/json`.
 
 
 ## [23.01.1] - 2023/03/21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [UI]: Fixed bug that caused all metadata fields to be removed when single field was removed from a template. See [PR 1482](https://github.com/phac-nml/irida/pull/1482)
 * [Developer]: Fixed bug which allowed duplicated entries in the user_group_project table which prevented the user group from being removed. Fixed bug which was preventing analyses with `html` file outputs from completing. See [PR 1483](https://github.com/phac-nml/irida/pull/1483)
 * [Developer]: Fixed flaky PipelinesPhylogenomicsPageIT test. See [PR 1482](https://github.com/phac-nml/irida/pull/1482)
-* [REST]: Fixed issues with syncing between newer IRIDA (>22.09) and older IRIDA (<=20.09) by disabling requests for `application/xml` for some of the REST requests and only requesting data as `application/json`.
+* [REST]: Fixed issues with syncing between newer IRIDA (>22.09) and older IRIDA (<=20.09) by disabling requests for `application/xml` for some of the REST requests and only requesting data as `application/json`. See [PR 1484](https://github.com/phac-nml/irida/pull/1484).
 
 
 ## [23.01.1] - 2023/03/21

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/ProjectRemoteRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/ProjectRemoteRepositoryImpl.java
@@ -1,5 +1,6 @@
 package ca.corefacility.bioinformatics.irida.repositories.remote.impl;
 
+import com.google.common.collect.ImmutableList;
 import ca.corefacility.bioinformatics.irida.exceptions.LinkNotFoundException;
 import ca.corefacility.bioinformatics.irida.model.RemoteAPI;
 import ca.corefacility.bioinformatics.irida.model.project.Project;
@@ -11,10 +12,12 @@ import ca.corefacility.bioinformatics.irida.service.RemoteAPITokenService;
 import ca.corefacility.bioinformatics.irida.service.user.UserService;
 import ca.corefacility.bioinformatics.irida.web.assembler.resource.ProjectHashResource;
 import ca.corefacility.bioinformatics.irida.web.controller.api.projects.RESTProjectsController;
+import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Link;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
@@ -64,8 +67,12 @@ public class ProjectRemoteRepositoryImpl extends RemoteRepositoryImpl<Project> i
 		OAuthTokenRestTemplate restTemplate = new OAuthTokenRestTemplate(tokenService, remoteAPI);
 		Link link = project.getLink(HASH_REL).map(i -> i).orElse(null);
 
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(ImmutableList.of(MediaType.APPLICATION_JSON));
+		HttpEntity<Object> request = new HttpEntity<Object>(headers);
+
 		ResponseEntity<ResourceWrapper<ProjectHashResource>> exchange = restTemplate.exchange(link.getHref(),
-				HttpMethod.GET, HttpEntity.EMPTY, projectHashReference);
+				HttpMethod.GET, request, projectHashReference);
 
 		Integer projectHash = exchange.getBody().getResource().getProjectHash();
 

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/RemoteRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/RemoteRepositoryImpl.java
@@ -2,10 +2,13 @@ package ca.corefacility.bioinformatics.irida.repositories.remote.impl;
 
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+import org.springframework.http.MediaType;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -95,7 +98,11 @@ public abstract class RemoteRepositoryImpl<Type extends IridaRepresentationModel
 	@Override
 	public boolean getServiceStatus(RemoteAPI remoteAPI) {
 		OAuthTokenRestTemplate restTemplate = new OAuthTokenRestTemplate(tokenService, remoteAPI);
-		ResponseEntity<String> forEntity = restTemplate.getForEntity(remoteAPI.getServiceURI(), String.class);
+		//ResponseEntity<String> forEntity = restTemplate.getForEntity(remoteAPI.getServiceURI(), String.class);
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(ImmutableList.of(MediaType.APPLICATION_JSON));
+		HttpEntity<Object> request = new HttpEntity<Object>(headers);
+		ResponseEntity<String> forEntity = restTemplate.exchange(remoteAPI.getServiceURI(), HttpMethod.GET, request, String.class);
 
 		return forEntity.getStatusCode() == HttpStatus.OK;
 	}

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/RemoteRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/RemoteRepositoryImpl.java
@@ -67,7 +67,12 @@ public abstract class RemoteRepositoryImpl<Type extends IridaRepresentationModel
 	@Override
 	public Type read(String uri, RemoteAPI remoteAPI) {
 		OAuthTokenRestTemplate restTemplate = new OAuthTokenRestTemplate(tokenService, remoteAPI);
-		ResponseEntity<ResourceWrapper<Type>> exchange = restTemplate.exchange(uri, HttpMethod.GET, HttpEntity.EMPTY,
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(ImmutableList.of(MediaType.APPLICATION_JSON));
+		HttpEntity<Object> request = new HttpEntity<Object>(headers);
+
+		ResponseEntity<ResourceWrapper<Type>> exchange = restTemplate.exchange(uri, HttpMethod.GET, request,
 				objectTypeReference);
 
 		Type resource = exchange.getBody().getResource();
@@ -82,8 +87,13 @@ public abstract class RemoteRepositoryImpl<Type extends IridaRepresentationModel
 	@Override
 	public List<Type> list(String uri, RemoteAPI remoteAPI) {
 		OAuthTokenRestTemplate restTemplate = new OAuthTokenRestTemplate(tokenService, remoteAPI);
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(ImmutableList.of(MediaType.APPLICATION_JSON));
+		HttpEntity<Object> request = new HttpEntity<Object>(headers);
+
 		ResponseEntity<ListResourceWrapper<Type>> exchange = restTemplate.exchange(uri, HttpMethod.GET,
-				HttpEntity.EMPTY, listTypeReference);
+				request, listTypeReference);
 
 		List<Type> resources = exchange.getBody().getResource().getResources();
 		for (Type r : resources) {
@@ -98,10 +108,11 @@ public abstract class RemoteRepositoryImpl<Type extends IridaRepresentationModel
 	@Override
 	public boolean getServiceStatus(RemoteAPI remoteAPI) {
 		OAuthTokenRestTemplate restTemplate = new OAuthTokenRestTemplate(tokenService, remoteAPI);
-		//ResponseEntity<String> forEntity = restTemplate.getForEntity(remoteAPI.getServiceURI(), String.class);
+
 		HttpHeaders headers = new HttpHeaders();
 		headers.setAccept(ImmutableList.of(MediaType.APPLICATION_JSON));
 		HttpEntity<Object> request = new HttpEntity<Object>(headers);
+
 		ResponseEntity<String> forEntity = restTemplate.exchange(remoteAPI.getServiceURI(), HttpMethod.GET, request, String.class);
 
 		return forEntity.getStatusCode() == HttpStatus.OK;

--- a/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/SampleRemoteRepositoryImpl.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/repositories/remote/impl/SampleRemoteRepositoryImpl.java
@@ -3,12 +3,15 @@ package ca.corefacility.bioinformatics.irida.repositories.remote.impl;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.hateoas.Link;
 import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Repository;
@@ -74,9 +77,13 @@ public class SampleRemoteRepositoryImpl extends RemoteRepositoryImpl<Sample> imp
 		// get the metadata link
 		Link metadataLink = sample.getLink(METADATA_REL).map(i -> i).orElse(null);
 
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(ImmutableList.of(MediaType.APPLICATION_JSON));
+		HttpEntity<Object> request = new HttpEntity<Object>(headers);
+
 		// request metadata response
 		ResponseEntity<ResourceWrapper<SampleMetadataWrapper>> exchange = restTemplate.exchange(metadataLink.getHref(),
-				HttpMethod.GET, HttpEntity.EMPTY, metadataTypeReference);
+				HttpMethod.GET, request, metadataTypeReference);
 
 		// pull metadata response from request
 		Map<String, MetadataEntry> resource = exchange.getBody().getResource().getMetadata();


### PR DESCRIPTION
## Description of changes

Fixes issue with syncing with old IRIDA (specifically with 20.01). Specifically, this explicitly changes the request headers for the API to respond with JSON. Previously, in some instances, we were defaulting to requesting XML, which is not supported by the older IRIDA instances. This would have first occurred in https://github.com/phac-nml/irida/commit/b334e59169f926e8fa9e41754806c0dbdc8f4a55 where we disabled XML support in the REST API.

This should be merged into `main` after the branch `fix-remove-template-field`.

This can be tested by setting up two instances of IRIDA (one 20.01 and another this version) and attempting to sync from newer IRIDA to 20.01. Without this fix, it will fail. With this fix it will succeed.

## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [x] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
* [x] Tests added (or description of how to test) for any new features.
* ~[ ] User documentation updated for UI or technical changes.~
