### PR TITLE
test: Fix flaky PipelinesPhylogenomicsPageIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [Developer]: Added script to do initial cleanup of sequence files from file system. [See PR 1469](https://github.com/phac-nml/irida/pull/1469)
 * [UI]: Add identifier to project drop-down on project synchronization page. See [PR 1474](https://github.com/phac-nml/irida/pull/1474)
 * [Developer]: Added functionality to delete sequence files from file storage when removed from sample. [See PR 1476](https://github.com/phac-nml/irida/pull/1476)
+* [Developer]: Fixed flaky text in `PipelinesPhylogenomicsPageIT#testPageSetup` test. See [PR 1490](https://github.com/phac-nml/irida/pull/1492)
 
 ## [23.01.3] - 2023/05/09
 * [Developer]: Fixed issue with metadata uploader removing existing data. See [PR 1489](https://github.com/phac-nml/irida/pull/1489)

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/pipelines/LaunchPipelinePage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/pipelines/LaunchPipelinePage.java
@@ -188,7 +188,8 @@ public class LaunchPipelinePage extends AbstractPage {
 	}
 
 	public void saveModifiedTemplateAs(String name) {
-		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20L));
+		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(2L));
+		WebElement alertBox = driver.findElement(By.className("t-modified-alert"));
 
 		// Scroll to the modified alert
 		WebElement modifiedSaveAsButton = driver.findElement(By.className("t-modified-saveas"));
@@ -201,7 +202,7 @@ public class LaunchPipelinePage extends AbstractPage {
 				ExpectedConditions.visibilityOfElementLocated(By.className("t-save-params-form")));
 		modifiedNameInput.sendKeys(name);
 		saveTemplatePopover.findElement(By.tagName("button")).click();
-		wait.until(ExpectedConditions.invisibilityOf(modifiedAlert.get(0)));
+		wait.until(ExpectedConditions.invisibilityOf(alertBox));
 	}
 
 	public String getSelectedParametersTemplateName() {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/pipelines/LaunchPipelinePage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/pipelines/LaunchPipelinePage.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -187,12 +188,14 @@ public class LaunchPipelinePage extends AbstractPage {
 	}
 
 	public void saveModifiedTemplateAs(String name) {
-		driver.manage().window().maximize();
-		// Fixes issue where save button scrolled off page.
-		driver.findElement(By.tagName("body")).sendKeys(Keys.HOME);
 		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20L));
 
+		// Scroll to the modified alert
 		WebElement modifiedSaveAsButton = driver.findElement(By.className("t-modified-saveas"));
+		Actions actions = new Actions(driver);
+		actions.moveToElement(modifiedSaveAsButton);
+		actions.perform();
+
 		modifiedSaveAsButton.click();
 		WebElement saveTemplatePopover = wait.until(
 				ExpectedConditions.visibilityOfElementLocated(By.className("t-save-params-form")));


### PR DESCRIPTION
## Description of changes
Fixed a flaky part of the PipelinesPhylogenomicsPageIT#testPageSetup for saving modified pipeline parameters.
 * Removed maximizing page size
 * Added scrolling to the modified alert save button
 * Cleaned up check to see if the modified alert is removed from the page.

## Related issue
N/A

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

* [X] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.

