### PR TITLE
Fixed sort on project members table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-# [23.10.1] = 2023/12/07
+# [23.10.1] - 2023/12/07
 * [UI]: Fixed issue where filter inputs required focus when they are opened on the project samples page. See [PR 1503](https://github.com/phac-nml/irida/pull/1503)
+* [UI]: Fixed bug preventing sorting and paging on the project members page. See [PR 1504](https://github.com/phac-nml/irida/pull/1504)
  
 ## [23.10] - 2023/10/15
 * [Developer]: Added functionality to delete sequence files from file system when a sequence run is removed. [See PR 1468](https://github.com/phac-nml/irida/pull/1468)

--- a/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectMembersService.java
+++ b/src/main/java/ca/corefacility/bioinformatics/irida/ria/web/services/UIProjectMembersService.java
@@ -55,6 +55,14 @@ public class UIProjectMembersService {
 	 */
 	public TableResponse<ProjectMemberTableModel> getProjectMembers(Long projectId, TableRequest tableRequest) {
 		Project project = projectService.read(projectId);
+
+		// Special case with the sort column on the name column.  Front end sends "name" which is a combination of first and last name.
+		// Needs to get the name from the User in the ProjectUserJoin, and sort by the first name since that is what is
+		// displayed in the table.
+		if (tableRequest.getSortColumn().equals("name")) {
+			tableRequest.setSortColumn("user.firstName");
+		}
+
 		Page<Join<Project, User>> usersForProject = userService.searchUsersForProject(project, tableRequest.getSearch(),
 				tableRequest.getCurrent(), tableRequest.getPageSize(), tableRequest.getSort());
 		List<ProjectMemberTableModel> members = usersForProject.get().map(join -> {

--- a/src/main/webapp/resources/js/components/ant.design/PagedTable/PagedTable.jsx
+++ b/src/main/webapp/resources/js/components/ant.design/PagedTable/PagedTable.jsx
@@ -36,6 +36,7 @@ export function PagedTable({ search = true, buttons, ...props }) {
         {search ? (
           <div>
             <Input
+              className="t-search"
               prefix={<IconSearch style={{ color: grey5 }} />}
               onChange={(e) => onSearch(e.target.value)}
             />

--- a/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
+++ b/src/main/webapp/resources/js/components/project-members/ProjectMembersTable.jsx
@@ -80,6 +80,7 @@ export function ProjectMembersTable({ projectId }) {
       },
       sorter: stringSorter("name"),
       defaultSortOrder: "ascend",
+      className: "t-user-name",
     },
     {
       title: i18n("ProjectMembersTable.projectRole"),

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/components/AntTable.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/components/AntTable.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -28,6 +29,15 @@ public class AntTable {
 
 	@FindBy(className = "ant-table-row")
 	List<WebElement> rows;
+
+	@FindBy(css = ".ant-pagination-next button")
+	WebElement nextButton;
+
+	@FindBy(css = ".ant-pagination-prev button")
+	WebElement prevButton;
+
+	@FindBy(css = ".t-search input")
+	WebElement searchInput;
 
 	public static AntTable getTable(WebDriver driver) {
 		return PageFactory.initElements(driver, AntTable.class);
@@ -89,4 +99,19 @@ public class AntTable {
 		}
 	}
 
+	public void goToNextPage() {
+		nextButton.click();
+	}
+
+	public void goToPrevPage() {
+		prevButton.click();
+	}
+
+	public void search(String text) {
+		if (!Strings.isNullOrEmpty(text)) {
+			searchInput.sendKeys(Keys.chord(Keys.CONTROL, "a"), text, Keys.ENTER);
+		} else {
+			searchInput.sendKeys(Keys.chord(Keys.CONTROL, "a"), Keys.BACK_SPACE, Keys.ENTER);
+		}
+	}
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectMembersPage.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/pages/ProjectMembersPage.java
@@ -81,6 +81,7 @@ public class ProjectMembersPage extends AbstractPage {
 
 	public void removeUser(int row) {
 		removeMember(row);
+		waitForTime(500);
 	}
 
 	public void removeManager(int row) {
@@ -110,9 +111,17 @@ public class ProjectMembersPage extends AbstractPage {
 	public boolean isNotificationDisplayed() {
 		WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 		wait.until(ExpectedConditions.visibilityOf(antNotification));
-		antNotificationClose.click();
-		wait.until(ExpectedConditions.invisibilityOf(antNotification));
 		return true;
+	}
+
+	public void goToNextTablePage() {
+		table.goToNextPage();
+		waitForTime(500);
+	}
+
+	public void goToPreviousTablePage() {
+		table.goToPrevPage();
+		waitForTime(500);
 	}
 
 	public void addUserToProject(String name, String role) {
@@ -139,6 +148,15 @@ public class ProjectMembersPage extends AbstractPage {
 		WebElement roleSelect = metadataRoleSelect.get(row);
 		roleSelect.click();
 		driver.findElement(By.className("t-" + role)).click();
+	}
+
+	public void sortByNameColumn() {
+		table.sortColumn("t-user-name");
+	}
+
+	public void searchByUsername(String username) {
+		table.search(username);
+		waitForTime(500);
 	}
 
 	public boolean userMetadataRoleSelectEnabled(int row) {

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectMembersPageIT.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/integration/projects/ProjectMembersPageIT.java
@@ -31,29 +31,42 @@ public class ProjectMembersPageIT extends AbstractIridaUIITChromeDriver {
 		LoginPage.loginAsManager(driver());
 		ProjectMembersPage page = ProjectMembersPage.goTo(driver());
 		assertEquals("Members", page.getPageHeaderTitle(), "Check for proper translation in title");
-		assertEquals(3, page.getNumberOfMembers(), "Should be 3 members in the project");
+		assertEquals(10, page.getNumberOfMembers(), "Should be 10 members in the project");
 		assertTrue(page.isAddMemberBtnVisible(), "Add Members button should be visible");
+
+		// Ensure that paging works.
+		page.goToNextTablePage();
+		assertEquals(1, page.getNumberOfMembers(), "Should be on page 1 of the table");
+
+		page.goToPreviousTablePage();
+		assertEquals(10, page.getNumberOfMembers(), "Should be on page 10 of the table");
 
 		// Test remove user from project
 		page.removeUser(1);
 		assertTrue(page.isNotificationDisplayed());
-		assertEquals(2, page.getNumberOfMembers(), "Should be 2 members in the project");
+		page.removeUser(3);
+		assertEquals(9, page.getNumberOfMembers(), "Should be 9 members in the project");
+
+		// Test sorting by name
+		page.sortByNameColumn();
+		assertEquals(9, page.getNumberOfMembers(), "Should be 9 members in the project");
 
 		// Should not be able to remove the manager so the remove button should be disabled
+		page.searchByUsername("Mr. Manager");
+		assertEquals(1, page.getNumberOfMembers(), "Should be 1 member after filtering");
+		// A manager has a metadata role of Level 4 and cannot be modified
+		assertFalse(page.userMetadataRoleSelectEnabled(0));
 		assertFalse(page.lastManagerRemoveButtonEnabled(0));
-		assertEquals(2, page.getNumberOfMembers(), "Should be 2 member in the project");
+		page.searchByUsername("");
+		assertEquals(9, page.getNumberOfMembers(), "Should be 9 members in the project");
 
 		// Test Add user to project
-		page.addUserToProject("test", ProjectRole.PROJECT_USER.toString());
-		page.isNotificationDisplayed();
-		assertEquals(3, page.getNumberOfMembers(), "Should be 3 members in the project");
+		page.addUserToProject("twelfth", ProjectRole.PROJECT_USER.toString());
+		assertEquals(10, page.getNumberOfMembers(), "Should be 10 members in the project");
 
 		// Try updating the users role to owner
 		page.updateUserRole(1, ProjectRole.PROJECT_OWNER.toString());
 		assertTrue(page.isNotificationDisplayed());
-
-		// A manager has a metadata role of Level 4 and cannot be modified
-		assertFalse(page.userMetadataRoleSelectEnabled(0));
 
 		// Change first manager back to a collaborator
 		page.updateUserRole(1, ProjectRole.PROJECT_USER.toString());

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
@@ -88,6 +88,13 @@ public class UIProjectMembersServiceTest {
 		assertNotNull(response.getDataSource());
 		List<ProjectMemberTableModel> members = response.getDataSource();
 		assertEquals(2, members.size(), "Should have 2 members");
+
+		// Test that the members are sorted by name
+		TableRequest sortRequest = new TableRequest(0, 10, "name", "asc", "");
+		when(userService.searchUsersForProject(PROJECT, sortRequest.getSearch(), sortRequest.getCurrent(),
+				sortRequest.getPageSize(), sortRequest.getSort())).thenReturn(getPagedUsersForProject());
+		// Make sure no errors are thrown
+		service.getProjectMembers(PROJECT_ID, sortRequest);
 	}
 
 	@Test

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
@@ -90,10 +90,9 @@ public class UIProjectMembersServiceTest {
 		assertEquals(2, members.size(), "Should have 2 members");
 
 		// Test that the members are sorted by name (special case since name is not a property of the ProjectUserJoin)
-		Sort sort = Sort.by("user.firstName").ascending();
-		TableRequest sortRequest = new TableRequest(0, 10, "name", "asc", "");
+		TableRequest sortRequest = new TableRequest(0, 10, "user.firstName", "asc", "");
 		when(userService.searchUsersForProject(PROJECT, sortRequest.getSearch(), sortRequest.getCurrent(),
-				sortRequest.getPageSize(), sort)).thenReturn(PAGE_USERS_FOR_PROJECT);
+				sortRequest.getPageSize(), sortRequest.getSort())).thenReturn(PAGE_USERS_FOR_PROJECT);
 		// Make sure no errors are thrown
 		service.getProjectMembers(PROJECT_ID, sortRequest);
 	}

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
@@ -67,12 +67,12 @@ public class UIProjectMembersServiceTest {
 		when(userService.read(USER_3.getId())).thenReturn(USER_3);
 
 		when(userService.searchUsersForProject(PROJECT, TABLE_REQUEST.getSearch(), TABLE_REQUEST.getCurrent(),
-				TABLE_REQUEST.getPageSize(), TABLE_REQUEST.getSort())).thenReturn(getPagedUsersForProject());
+				TABLE_REQUEST.getPageSize(), TABLE_REQUEST.getSort())).thenReturn(PAGE_USERS_FOR_PROJECT);
 
-		when(messageSource.getMessage("projectRole." + ProjectRole.PROJECT_OWNER.toString(), new Object[] {}, LOCALE))
-				.thenReturn("Manager");
-		when(messageSource.getMessage("projectRole." + ProjectRole.PROJECT_USER.toString(), new Object[] {}, LOCALE))
-				.thenReturn("Collaborator");
+		when(messageSource.getMessage("projectRole." + ProjectRole.PROJECT_OWNER, new Object[] {}, LOCALE)).thenReturn(
+				"Manager");
+		when(messageSource.getMessage("projectRole." + ProjectRole.PROJECT_USER, new Object[] {}, LOCALE)).thenReturn(
+				"Collaborator");
 
 		doThrow(ProjectWithoutOwnerException.class).when(projectService).removeUserFromProject(PROJECT, USER_3);
 		doThrow(ProjectWithoutOwnerException.class).when(projectService)
@@ -90,7 +90,10 @@ public class UIProjectMembersServiceTest {
 		assertEquals(2, members.size(), "Should have 2 members");
 
 		// Test that the members are sorted by name (special case since name is not a property of the ProjectUserJoin)
+		Sort sort = Sort.by("user.firstName").ascending();
 		TableRequest sortRequest = new TableRequest(0, 10, "name", "asc", "");
+		when(userService.searchUsersForProject(PROJECT, sortRequest.getSearch(), sortRequest.getCurrent(),
+				sortRequest.getPageSize(), sort)).thenReturn(PAGE_USERS_FOR_PROJECT);
 		// Make sure no errors are thrown
 		service.getProjectMembers(PROJECT_ID, sortRequest);
 	}
@@ -143,87 +146,85 @@ public class UIProjectMembersServiceTest {
 				ProjectMetadataRole.LEVEL_1);
 	}
 
-	private Page<Join<Project, User>> getPagedUsersForProject() {
-		return new Page<Join<Project, User>>() {
-			@Override
-			public int getTotalPages() {
-				return 0;
-			}
+	private final Page<Join<Project, User>> PAGE_USERS_FOR_PROJECT = new Page<Join<Project, User>>() {
+		@Override
+		public int getTotalPages() {
+			return 0;
+		}
 
-			@Override
-			public long getTotalElements() {
-				return 2;
-			}
+		@Override
+		public long getTotalElements() {
+			return 2;
+		}
 
-			@Override
-			public <U> Page<U> map(Function<? super Join<Project, User>, ? extends U> converter) {
-				return null;
-			}
+		@Override
+		public <U> Page<U> map(Function<? super Join<Project, User>, ? extends U> converter) {
+			return null;
+		}
 
-			@Override
-			public int getNumber() {
-				return 0;
-			}
+		@Override
+		public int getNumber() {
+			return 0;
+		}
 
-			@Override
-			public int getSize() {
-				return 0;
-			}
+		@Override
+		public int getSize() {
+			return 0;
+		}
 
-			@Override
-			public int getNumberOfElements() {
-				return 0;
-			}
+		@Override
+		public int getNumberOfElements() {
+			return 0;
+		}
 
-			@Override
-			public List<Join<Project, User>> getContent() {
-				return projectUserJoins;
-			}
+		@Override
+		public List<Join<Project, User>> getContent() {
+			return projectUserJoins;
+		}
 
-			@Override
-			public boolean hasContent() {
-				return false;
-			}
+		@Override
+		public boolean hasContent() {
+			return false;
+		}
 
-			@Override
-			public Sort getSort() {
-				return null;
-			}
+		@Override
+		public Sort getSort() {
+			return null;
+		}
 
-			@Override
-			public boolean isFirst() {
-				return false;
-			}
+		@Override
+		public boolean isFirst() {
+			return false;
+		}
 
-			@Override
-			public boolean isLast() {
-				return false;
-			}
+		@Override
+		public boolean isLast() {
+			return false;
+		}
 
-			@Override
-			public boolean hasNext() {
-				return false;
-			}
+		@Override
+		public boolean hasNext() {
+			return false;
+		}
 
-			@Override
-			public boolean hasPrevious() {
-				return false;
-			}
+		@Override
+		public boolean hasPrevious() {
+			return false;
+		}
 
-			@Override
-			public Pageable nextPageable() {
-				return null;
-			}
+		@Override
+		public Pageable nextPageable() {
+			return null;
+		}
 
-			@Override
-			public Pageable previousPageable() {
-				return null;
-			}
+		@Override
+		public Pageable previousPageable() {
+			return null;
+		}
 
-			@Override
-			public Iterator<Join<Project, User>> iterator() {
-				return projectUserJoins.iterator();
-			}
-		};
-	}
+		@Override
+		public Iterator<Join<Project, User>> iterator() {
+			return projectUserJoins.iterator();
+		}
+	};
 }

--- a/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
+++ b/src/test/java/ca/corefacility/bioinformatics/irida/ria/unit/web/services/UIProjectMembersServiceTest.java
@@ -89,10 +89,8 @@ public class UIProjectMembersServiceTest {
 		List<ProjectMemberTableModel> members = response.getDataSource();
 		assertEquals(2, members.size(), "Should have 2 members");
 
-		// Test that the members are sorted by name
+		// Test that the members are sorted by name (special case since name is not a property of the ProjectUserJoin)
 		TableRequest sortRequest = new TableRequest(0, 10, "name", "asc", "");
-		when(userService.searchUsersForProject(PROJECT, sortRequest.getSearch(), sortRequest.getCurrent(),
-				sortRequest.getPageSize(), sortRequest.getSort())).thenReturn(getPagedUsersForProject());
 		// Make sure no errors are thrown
 		service.getProjectMembers(PROJECT_ID, sortRequest);
 	}

--- a/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml
+++ b/src/test/resources/ca/corefacility/bioinformatics/irida/ria/web/ProjectsPageIT.xml
@@ -4,6 +4,14 @@
       <user id="2" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="test@me.com" firstName="test" lastName="User" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="testUser" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
       <user id="3" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="three@somewhere.com" firstName="third" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="thethird" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
       <user id="4" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="admin@somewhere.com" firstName="third" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="admin" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="5" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="five@somewhere.com" firstName="fifth" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="fifth" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="6" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="sixth@somewhere.com" firstName="sixth" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="sixth" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="7" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="seventh@somewhere.com" firstName="seventh" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="seventh" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="8" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="eighth@somewhere.com" firstName="eighth" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="eighth" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="9" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="ninth@somewhere.com" firstName="ninth" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="ninth" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="10" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="tenth@somewhere.com" firstName="tenth" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="tenth" enabled="true" system_role="ROLE_ADMIN" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="11" createdDate="2013-07-18 14:20:19.0" modifiedDate="2013-07-18 14:20:19.0" email="eleventh@somewhere.com" firstName="eleventh" lastName="guy" password="$2a$10$jFFix3ZyyoNy7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="eleventh" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
+      <user id="12" createdDate="2014-07-30 08:24:34" modifiedDate="2014-07-30 08:24:34" email="twelvth@somewhere.com" firstName="twelvth" lastName="guy" password="$2a$10$J7Z3Z3ZyY0Ny7HwavYjXauV0vByoPVbS1WnRpxPBCTKFXwEJeyXiK" phoneNumber="867-5309" username="twelfth" enabled="true" system_role="ROLE_USER" credentialsNonExpired="true" user_type="TYPE_LOCAL" />
 
       <user_group id="1" name="group 1" created_date="2013-07-12 14:20:19.0" />
       <user_group_member id="1" created_date="2013-07-12 14:20:19.0" role="GROUP_MEMBER" group_id="1" user_id="2" />
@@ -18,17 +26,26 @@
       <project id="8" organism="E. coli K-12" createdDate="2013-07-18 14:21:19.0" name="project IJKL" modifiedDate="2013-07-18 14:17:19.0" />
       <project id="9" organism="E. coli NEW" createdDate="2013-07-18 14:21:19.0" name="project MNOP" modifiedDate="2013-07-18 14:17:19.0" />
 
-      <project_user id="1" project_id="1" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="2" project_id="2" user_id="1" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />
       <project_user id="3" project_id="3" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="4" project_id="4" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
-      <project_user id="6" project_id="1" user_id="2" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />
       <project_user id="7" project_id="2" user_id="2" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="8" project_id="6" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="9" project_id="7" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="10" project_id="8" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
-      <project_user id="11" project_id="1" user_id="4" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
       <project_user id="12" project_id="9" user_id="2" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+
+      <project_user id="1" project_id="1" user_id="1" projectRole="PROJECT_OWNER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="5" project_id="1" user_id="2" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="6" project_id="1" user_id="3" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_1" />
+      <project_user id="11" project_id="1" user_id="4" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="13" project_id="1" user_id="5" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="14" project_id="1" user_id="6" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="15" project_id="1" user_id="7" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="16" project_id="1" user_id="8" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="17" project_id="1" user_id="9" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="18" project_id="1" user_id="10" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
+      <project_user id="19" project_id="1" user_id="11" projectRole="PROJECT_USER" createdDate="2013-07-18 14:20:19.0" metadataRole="LEVEL_4" />
 
       <project_subscription id="1" project_id="1" user_id="1" created_date="2013-07-18 14:20:19.0" email_subscription="false" />
       <project_subscription id="2" project_id="2" user_id="1" created_date="2013-07-18 14:20:19.0" email_subscription="true" />


### PR DESCRIPTION
## Description of changes

Fixed issue sorting by name on the project members table.  

When the method was called in the service it the sortColumn was set as `name` as that's what we have in the front end (combines the first and last name) which was retrieved on getting the members for the page originally. When we either sorted on the name column or switch pages it called the method with the sort params for the column as we set the sorter for it on the column in the front end code. When it went to do the order by on the query it was trying to get the name from the projectuserjoin which doesn't have a name column, neither does the User model, hence why if the column is name we sort on the first name for the user.

## Related issue

Link to the GitHub issue this pull request addresses using the `#issuenum` format. If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist

Things for the developer to confirm they've done before the PR should be accepted:

*   [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.
*   [ ] Tests added (or description of how to test) for any new features.
*   [ ] User documentation updated for UI or technical changes.