### PR TITLE
Fix: Analysis Text Output Preview

### DIFF
--- a/src/main/webapp/resources/js/pages/analysis/components/AnalysisTextPreview.jsx
+++ b/src/main/webapp/resources/js/pages/analysis/components/AnalysisTextPreview.jsx
@@ -32,6 +32,7 @@ export default function AnalysisTextPreview({ output }) {
   const [savedText, setSavedText] = useState("");
   const chunkSize = 8192;
   const [loading, setLoading] = useState(false);
+  const [fileSizePreview,setFileSizePreview] = useState("");
 
   /*
    * Get n bytes of text file output data on load and set
@@ -48,9 +49,7 @@ export default function AnalysisTextPreview({ output }) {
       setSavedText(data.text);
       setFilePointer(data.filePointer);
       setFileRows(data.text);
-      document.getElementById(
-        `${output.filename}-preview-status`
-      ).innerText = fileSizeLoaded(data.filePointer, output.fileSizeBytes);
+      setFileSizePreview(fileSizeLoaded(data.filePointer, output.fileSizeBytes))
       setLoading(false);
     });
   }, []);
@@ -81,9 +80,7 @@ export default function AnalysisTextPreview({ output }) {
           setSavedText(savedText + data.text);
           setFilePointer(data.filePointer);
           setFileRows(savedText + data.text);
-          document.getElementById(
-            `${output.filename}-preview-status`
-          ).innerText = fileSizeLoaded(data.filePointer, output.fileSizeBytes);
+          setFileSizePreview(fileSizeLoaded(data.filePointer, output.fileSizeBytes));
         }
         setLoading(false);
       });
@@ -108,7 +105,7 @@ export default function AnalysisTextPreview({ output }) {
           </TextOutputWrapper>
           <div>
             <Space direction={"horizontal"}>
-              <span id={`${output.filename}-preview-status`}></span>
+              <span id={`${output.filename}-preview-status`}>{fileSizePreview}</span>
               <span id={`${output.filename}-loading`}>
                 {loading ? (
                   <ContentLoading


### PR DESCRIPTION
## Description of changes
What did you change in this pull request?  Provide a description of files changed, user interactions changed, etc.  Include how to test your changes.

This PR fixes a bug with analysis text preview not being able to set the loaded file size using `document.getElementId` due to changes with react useeffect hook in react 18. Updated to set a state variable instead and that is used by the UI to display the loaded file size.

Before fix:

![image](https://github.com/user-attachments/assets/e52fe9a0-dc88-465a-9704-bc3df73ad145)

![image](https://github.com/user-attachments/assets/998ffb0f-e852-4e1a-93eb-4500380d33e2)


After fix:

![image](https://github.com/user-attachments/assets/6383e0af-42ae-4c07-b04f-ab52edf1c092)

![image](https://github.com/user-attachments/assets/e41e0767-340b-4e95-818e-ec4e5fe3730c)


## Related issue
Link to the GitHub issue this pull request addresses using the `#issuenum` format.  If it completes an issue, use `Fixes #issuenum` to automatically close the issue.

## Checklist
Things for the developer to confirm they've done before the PR should be accepted:

~* [ ] CHANGELOG.md (and UPGRADING.md if necessary) updated with information for new change.~
~* [ ] Tests added (or description of how to test) for any new features.~
~* [ ] User documentation updated for UI or technical changes.~
